### PR TITLE
Release-readiness: version display auto-updates sitewide

### DIFF
--- a/docs/RELEASE_RUNTHROUGH.md
+++ b/docs/RELEASE_RUNTHROUGH.md
@@ -1,0 +1,35 @@
+# Release run-through checklist
+
+Use this when the `pdoom1` game ships a new release, to confirm the website reflects it correctly. The site reads the game's **latest GitHub release** — it does not need a website deploy to pick up a new game version, but a few things are worth verifying by eye.
+
+## How version info flows
+- `scripts/update-version-info.py` (run every 6h by `.github/workflows/auto-update-data.yml`) fetches the game repo's `releases/latest` and writes `public/data/version.json`. It also syncs the release block into `public/data/status.json` (guarded against API-failure fallback).
+- Client-side, pages fetch `public/data/version.json` and update their version display:
+  - Homepage nav badge + footer + hero download buttons → inline scripts in `public/index.html`.
+  - Homepage hero **stats** (doom %, frontier labs, strategic possibilities) → `loadGameStats()` in `public/index.html`.
+  - The 7 pages using the injected nav (about, blog, cats, game-changelog, game-stats, issues, leaderboard) → `updateNavVersion()` in `public/assets/js/navigation.js`.
+
+## When a new release lands — verify
+
+1. **Release is actually tagged/published.** The site follows *published releases*, not commits. If the game team merged the "massive update" but hasn't cut a release, the site correctly still shows the previous release. Cut the release first.
+
+2. **Download links resolve.** Buttons point at `github.com/PipFoweraker/pdoom1/releases/latest/download/<asset>`:
+   - `PDoom-Windows.zip`
+   - `PDoom.app.zip`
+   - `PDoom.x86_64`
+   ⚠️ If the new release renames these assets, the `latest/download/...` links will 404. Either keep the asset filenames stable, or update the three hrefs in `public/index.html` (ids `download-windows` / `download-macos` / `download-linux`).
+
+3. **Let the auto-updater run (or trigger it).** Either wait for the 6-hourly `auto-update-data.yml`, or run it manually (`workflow_dispatch`) / locally: `python scripts/update-version-info.py`. Confirm `public/data/version.json` shows the new `latest_release.version`.
+
+4. **Spot-check version display** on a few pages (hard-refresh to bypass cache):
+   - Homepage: nav badge, footer, and the three hero stat numbers populate (not `--`).
+   - One injected-nav page (e.g. `/leaderboard/`): nav badge shows the new version, not the hardcoded fallback.
+
+5. **Changelog / release notes.** Check `public/game-changelog/` and `CHANGELOG.md` reflect the new release (these may be Airtable-synced or manual — confirm the source).
+
+6. **CHANGELOG version-gate CI.** `version-check.yml` fails PRs with `feat:`/`fix:` commits that don't bump the CHANGELOG — expect it to be relevant for the website's own changes, not the game release.
+
+## Known follow-ups (not blockers)
+- Blog/changelog content is **Airtable-sourced** (`sync_airtable.py`); refresh at source, not by editing `public/data/*.json`.
+- The website's own version scheme is muddled (`status.json` website `0.2.1` vs `CHANGELOG.md` `1.2.0`) — pick a canonical scheme when convenient.
+- `public/includes/navigation.html` is an unused legacy include; the live nav is `public/assets/js/navigation.js`.

--- a/public/assets/js/navigation.js
+++ b/public/assets/js/navigation.js
@@ -11,8 +11,8 @@
 			<div class="logo-container">
 				<a href="/" class="logo" aria-label="p(Doom)1 home">p(Doom)1</a>
 				<span class="version-badge" id="versionBadge">
-					<span class="version-number" id="versionNumber">v0.10.2</span>
-					<span id="versionDate">2025-11-08</span>
+					<span class="version-number" id="versionNumber">v0.11.0</span>
+					<span id="versionDate">2025-12-07</span>
 				</span>
 			</div>
 			<ul class="nav-links" role="menubar">
@@ -123,10 +123,38 @@
 		});
 	}
 
+	// Update the nav version badge from the canonical version.json so every page
+	// using this injected nav reflects the current game release (instead of the
+	// hardcoded fallback above). Silently no-ops if the badge or file is absent.
+	async function updateNavVersion() {
+		const numberEl = document.getElementById('versionNumber');
+		const dateEl = document.getElementById('versionDate');
+		if (!numberEl && !dateEl) return;
+		try {
+			const response = await fetch('/data/version.json', { cache: 'no-store' });
+			if (!response.ok) return;
+			const data = await response.json();
+			const release = data.latest_release || {};
+			if (numberEl && release.version) {
+				numberEl.textContent = release.version;
+			}
+			if (dateEl && release.published_at) {
+				dateEl.textContent = release.published_at.split('T')[0];
+			}
+		} catch (e) {
+			// Keep the hardcoded fallback on any failure.
+		}
+	}
+
+	function init() {
+		initNavigation();
+		updateNavVersion();
+	}
+
 	// Run when DOM is ready
 	if (document.readyState === 'loading') {
-		document.addEventListener('DOMContentLoaded', initNavigation);
+		document.addEventListener('DOMContentLoaded', init);
 	} else {
-		initNavigation();
+		init();
 	}
 })();

--- a/public/includes/navigation.html
+++ b/public/includes/navigation.html
@@ -3,8 +3,8 @@
 	<div class="logo-container">
 		<a href="/" class="logo" aria-label="p(Doom)1 home">p(Doom)1</a>
 		<span class="version-badge" id="versionBadge">
-			<span class="version-number" id="versionNumber">v0.10.2</span>
-			<span id="versionDate">2025-11-08</span>
+			<span class="version-number" id="versionNumber">v0.11.0</span>
+			<span id="versionDate">2025-12-07</span>
 		</span>
 	</div>
 	<ul class="nav-links" role="menubar">

--- a/public/index.html
+++ b/public/index.html
@@ -1480,8 +1480,8 @@ python main.py</pre>
 		});
 		
 		// GitHub Issues section removed - now on dedicated /issues/ page
-		// Load and update version information
-		async function loadVersionInfo() {
+		// Load and update homepage game stats + download button labels
+		async function loadGameStats() {
 			try {
 				const response = await fetch('/data/version.json', { cache: 'no-store' });
 				const versionData = await response.json();
@@ -1510,7 +1510,7 @@ python main.py</pre>
 					}
 				});
 				
-				.log('Version info updated:', versionData.latest_release.version);
+				console.log('Version info updated:', versionData.latest_release.version);
 			} catch (error) {
 				console.warn('Could not load version info:', error);
 			}
@@ -1518,7 +1518,7 @@ python main.py</pre>
 		
 		// Load version info when page loads
 		document.addEventListener('DOMContentLoaded', () => {
-			loadVersionInfo();
+			loadGameStats();
 			setupDownloadTracking();
 		});
 


### PR DESCRIPTION
Re-open of #122 (auto-closed when its base branch `accuracy-trust-pass` was deleted on #121 merge). Same commit, approved. See #122 for full description.

- navigation.js: adds updateNavVersion() so the 7 injected-nav pages reflect the current release (were stuck at v0.10.2).
- index.html: fixes a syntax error that killed the first inline script block (hero stats showed '--', download analytics never ran); ends the loadVersionInfo name collision.
- docs/RELEASE_RUNTHROUGH.md: release verification checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)