### PR TITLE
Fix site-wide dark-theme regressions: white cards + blue event-page accents

### DIFF
--- a/public/analytics-config.json
+++ b/public/analytics-config.json
@@ -2,7 +2,7 @@
   "provider": "plausible",
   "enabled": true,
   "dataDomain": "pdoom1.com",
-  "scriptUrl": "https://plausible.io/js/script.js",
+  "scriptUrl": "https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js",
   "privacyFeatures": {
     "noCookies": true,
     "noPersonalData": true,

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -1,7 +1,11 @@
 :root {
-  --accent-primary: #0066cc;
-  --text-secondary: #666666;
-  --text-muted: #999999;
+  /* Dark-theme fallbacks. This file loads LAST, so these OVERRIDE each page's
+     own :root -- they must match the terminal palette, not fight it. Previously
+     these were light-theme values (#0066cc blue, #666/#999 greys), which turned
+     every page WITHOUT a runtime token loader (i.e. all ~2200 event pages) blue. */
+  --accent-primary: #00ff41;
+  --text-secondary: #cccccc;
+  --text-muted: #aaaaaa;
 }
 
 .summary-toggle {
@@ -35,10 +39,12 @@
 }
 
 .card {
-  background: #fff;
+  /* No background/shadow here on purpose: each page's own dark .card governs.
+     This file previously forced `background:#fff`, which whited-out the feature
+     cards (and any .card) on the dark terminal theme. Loaded last, it won the
+     cascade over the inline dark rule. See public/index.html About > Features. */
   padding: 1rem;
   border-radius: 6px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .status {


### PR DESCRIPTION
`site.css` is a leftover light-theme fragment loaded **last** on ~2,203 pages, so it won the cascade over each page's dark theme.

## Fixes
- **White feature cards** (homepage About > Features): `site.css` `.card { background:#fff }` overrode the inline dark `.card`. Removed — this was the white-card bug flagged from the screenshot dump.
- **Blue accents on ~2,200 event pages**: `site.css` `:root` set `--accent-primary` to blue `#0066cc`. The homepage masks this via `loadTokens()` at runtime, but event pages have no token loader, so they rendered blue instead of green. Corrected the fallbacks to the dark palette.
- **analytics-config.json**: reconciled `scriptUrl` to the real self-hosted `analytics.pdoom1.com` (was stale `plausible.io`). Note: this file is unused documentation; the live script tag was already correct. Ingestion verified (`POST /api/event` → 202).

Pure CSS/config; no page markup changed. Verifiable via the deploy preview (check a `/events/*` page for green accents and homepage Features cards for dark backgrounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)