### PR TITLE
Data-contract validation system: enforced seams, integrity checks, de-duped alerts

### DIFF
--- a/.github/workflows/data-contract-validation.yml
+++ b/.github/workflows/data-contract-validation.yml
@@ -1,0 +1,105 @@
+name: Data Contract Validation
+
+# Validates the data seams (events + leaderboard) against schemas/ and runs
+# semantic integrity/drift checks (scripts/validate_data.py). FAIL-severity breaks
+# CI and opens ONE de-duplicated alert issue; WARN-severity is surfaced on the
+# /monitoring/ dashboard only (no alert -- conserve attention).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'public/data/events.json'
+      - 'public/leaderboard/data/**'
+      - 'schemas/**'
+      - 'scripts/validate_data.py'
+  pull_request:
+    paths:
+      - 'public/data/events.json'
+      - 'public/leaderboard/data/**'
+      - 'schemas/**'
+      - 'scripts/validate_data.py'
+  schedule:
+    - cron: '0 6 * * *'   # daily 06:00 UTC -- catches drift even with no commits
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  validate:
+    name: Validate data contracts
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.run.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install validation deps
+        run: pip install --quiet jsonschema==4.26.0
+      - name: Run validation
+        id: run
+        run: |
+          set +e
+          python scripts/validate_data.py
+          code=$?
+          echo "status=$([ $code -eq 0 ] && echo pass || echo fail)" >> "$GITHUB_OUTPUT"
+          exit $code
+
+      # Keep the dashboard's health snapshot fresh (schedule/main only).
+      - name: Commit integration-health.json
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'push')
+        run: |
+          if ! git diff --quiet public/data/integration-health.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add public/data/integration-health.json
+            git commit -m "chore: refresh integration-health.json [skip ci]"
+            git push
+          fi
+
+  alert:
+    name: Alert on failure (de-duplicated)
+    needs: validate
+    if: failure() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update the single data-contract issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🔴 Data contract validation failing';
+            const label = 'data-contract';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'Automated data-contract validation reported a **FAIL**.',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'This means a data seam broke its schema, contains encoding corruption, or is self-contradictory.',
+              'Reproduce locally: `python scripts/validate_data.py`.',
+              '',
+              '_This is a single rolling issue -- it is reused, not duplicated, per run._'
+            ].join('\n');
+
+            // Find an existing open issue (reuse, never spam N issues).
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 10,
+            });
+            const found = existing.data.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: found.number,
+                body: `Still failing as of ${new Date().toUTCString()}.\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: [label, 'automation', 'priority:high'],
+              });
+            }

--- a/.github/workflows/health-checks.yml
+++ b/.github/workflows/health-checks.yml
@@ -97,38 +97,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `🚨 Health Check Failed - ${new Date().toISOString().split('T')[0]}`;
-            const body = `
-            ## Health Check Failure Report
-            
-            **Workflow:** ${{ github.workflow }}
-            **Run ID:** ${{ github.run_id }}
-            **Commit:** ${{ github.sha }}
-            **Branch:** ${{ github.ref_name }}
-            **Triggered by:** ${{ github.event_name }}
-            
-            ### Failed Steps
-            One or more health checks have failed. Please check the workflow logs for details.
-            
-            ### Next Steps
-            1. Review the workflow logs: [Link to run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Check which scripts are failing
-            3. Verify data integrity
-            4. Test deployment process manually if needed
-            
-            ### Auto-generated Alert
-            This issue was automatically created by the health check workflow.
-            
-            **Priority:** High - Deployment process integrity compromised
-            `;
-            
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: body,
-              labels: ['bug', 'deployment', 'automated-alert', 'high-priority']
+            // De-duplicated alert: reuse ONE rolling issue (fixed title, no date),
+            // comment on repeats. A 6-hourly job must never spawn N duplicate issues.
+            const title = '🚨 Health checks failing';
+            const label = 'automated-alert';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const body = [
+              '## Health check failure',
+              '',
+              'One or more health checks failed. Review the run logs and verify data/deploy integrity.',
+              '',
+              `Run: ${runUrl}`,
+              `Commit: ${{ github.sha }} on ${{ github.ref_name }}`,
+              '',
+              '_Single rolling issue -- reused, not duplicated, per run._'
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 20,
             });
+            const found = existing.data.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: found.number,
+                body: `Still failing as of ${new Date().toUTCString()}.\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['bug', 'deployment', label, 'high-priority'],
+              });
+            }
             
   deployment-simulation:
     runs-on: ubuntu-latest

--- a/docs/DATA_SPLIT.md
+++ b/docs/DATA_SPLIT.md
@@ -1,0 +1,35 @@
+# Event data: pure history vs game adaptation — ownership decision
+
+`pdoom-data/DATA_ARCHITECTURE.md` proposes splitting event data into **pure history**
+(pdoom-data, scholarly facts) and **game adaptations** (game fields: `impacts`, `rarity`,
+`pdoom_impact`). This note records the *operative* decision for the website so the two
+don't drift with ambiguous ownership (the classic solo-dev trap).
+
+## Current reality (2026-07-16)
+- `public/data/events.json` (1,194 events) **carries game fields** (`impacts`, `rarity`,
+  `pdoom_impact`) — i.e. it is the *game-adapted* copy, not pure history.
+- It is **generated** from pdoom-data via `scripts/sync/sync-events.py`.
+- Data-quality signal from `validate_data.py`: **1,174 / 1,194** events are
+  `technical_research_breakthrough` and **1,076** are `rarity: rare` — the bulk
+  alignmentforum import defaulted these. The game-adaptation layer is barely differentiated.
+
+## Decision
+**pdoom-data = source of truth for historical facts. The website consumes a game-adapted
+projection. The website never hand-edits `events.json`** (edits belong upstream + re-sync).
+
+Ownership of each field is now explicit and enforced:
+- **History fields** (owned by pdoom-data): `id`, `title`, `year`, `category`,
+  `description`, `sources`, `tags`, reactions.
+- **Game-adaptation fields** (owned by the game/adapter): `impacts`, `rarity`,
+  `pdoom_impact`. Marked as such in `schemas/events.schema.json`.
+
+The website's job is to **validate** the projection it receives (`scripts/validate_data.py`
++ `schemas/events.schema.json`) and display it — not to author it.
+
+## Open items (not blocking)
+1. The game-adaptation layer is undifferentiated (see the 1,174/1,076 skew). If rarity/
+   category are meant to affect gameplay, they need real per-event values — currently they
+   look like import defaults. Decide in the game repo.
+2. If pdoom-data ever strips game fields to become "pure" (its stated plan), the adapter
+   that re-adds them must live in ONE place (game repo's `historical_adapter.py`), and the
+   website schema's "game-adaptation" fields become required-from-adapter, not from source.

--- a/docs/WORKFLOW_ATTENTION_AUDIT.md
+++ b/docs/WORKFLOW_ATTENTION_AUDIT.md
@@ -1,0 +1,48 @@
+# Workflow attention-cost audit (2026-07-16)
+
+Solo-dev principle: **automation should conserve attention** — silent when fine, ONE
+actionable alert when real. More automation is not better; *trustworthy* automation is.
+Two antipatterns to hunt: (a) creating issues on success, (b) creating a *new* issue
+every failing run (no de-dup).
+
+## Findings
+
+| Workflow | Schedule | Issue-on-success? | Failure de-dup? | Verdict |
+|---|---|---|---|---|
+| `weekly-league-rollover.yml` | (removed) | **YES (35 spam issues)** | n/a | ✅ Fixed 2026-07-14 (deleted; now logs to /monitoring/, `weekly-league-reset.yml` alerts only on failure) |
+| `health-checks.yml` | every 6h | no | **NO → date-in-title, 4 dupes/day** | ✅ Fixed 2026-07-16 (de-dup pattern retrofitted) |
+| `auto-update-data.yml` | every 6h | no | **NO** | ⚠️ TODO: retrofit de-dup (highest remaining dupe risk) |
+| `sync-leaderboards.yml` | daily | no | **NO** | ⚠️ TODO: retrofit de-dup |
+| `extract-analytics.yml` | monthly | no | **NO** | low risk (monthly), retrofit when convenient |
+| `data-contract-validation.yml` | daily | no | **YES** | ✅ New; reference implementation |
+
+**Good news:** no workflow still creates success issues (the rollover spam was the only
+one, already removed). **Remaining risk:** duplicate *failure* issues from the 6-hourly
+jobs that lack de-dup.
+
+## The de-dup pattern (copy this into the remaining `if: failure()` blocks)
+
+Fixed title (no date), search open issues by label, comment if found else create:
+
+```js
+const title = '🚨 <fixed title, no date>';
+const label = 'automated-alert';
+const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+const existing = await github.rest.issues.listForRepo({
+  owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: label, per_page: 20 });
+const found = existing.data.find(i => i.title === title);
+if (found) {
+  await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo,
+    issue_number: found.number, body: `Still failing ${new Date().toUTCString()}. ${runUrl}` });
+} else {
+  await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo,
+    title, body: `Failing. Run: ${runUrl}`, labels: ['automated-alert', 'priority:high'] });
+}
+```
+
+Reference implementations: `health-checks.yml` and `data-contract-validation.yml`.
+
+## Next
+- Retrofit de-dup into `auto-update-data.yml` and `sync-leaderboards.yml` (same pattern).
+- Consider a shared composite action (`.github/actions/rolling-alert`) so de-dup is DRY
+  rather than copy-pasted — do this once a 3rd workflow needs it.

--- a/public/data/integration-health.json
+++ b/public/data/integration-health.json
@@ -1,0 +1,61 @@
+{
+  "generated": "2026-07-16T02:47:00.068824+00:00",
+  "overall_status": "WARN",
+  "summary": {
+    "fail": 0,
+    "warn": 2,
+    "ok": 8
+  },
+  "checks": [
+    {
+      "name": "schema:events",
+      "status": "OK",
+      "detail": "valid"
+    },
+    {
+      "name": "schema:league_weekly",
+      "status": "OK",
+      "detail": "valid"
+    },
+    {
+      "name": "schema:league_seed",
+      "status": "OK",
+      "detail": "valid"
+    },
+    {
+      "name": "encoding:events",
+      "status": "OK",
+      "detail": "no mojibake"
+    },
+    {
+      "name": "encoding:league_weekly",
+      "status": "OK",
+      "detail": "no mojibake"
+    },
+    {
+      "name": "league:freshness",
+      "status": "OK",
+      "detail": "generated 3.1 days ago"
+    },
+    {
+      "name": "league:current_week",
+      "status": "WARN",
+      "detail": "week 2026_W28 is marked is_current but ended 3.1 days ago -- rollover cadence off"
+    },
+    {
+      "name": "league:version_drift",
+      "status": "WARN",
+      "detail": "leaderboard game_version=v0.4.1 but deployed game=v0.11.0 -- export stamping stale version"
+    },
+    {
+      "name": "league:integrity",
+      "status": "OK",
+      "detail": "0 entries, 0 unique players consistent"
+    },
+    {
+      "name": "seed_leaderboards:parse",
+      "status": "OK",
+      "detail": "15 files parse OK"
+    }
+  ]
+}

--- a/public/monitoring/index.html
+++ b/public/monitoring/index.html
@@ -309,6 +309,19 @@
             </div>
         </div>
 
+        <!-- Integration Health Section (data contracts + cross-repo drift) -->
+        <div class="recent-checks" style="margin-top: 3rem;">
+            <h2>🔗 Integration Health</h2>
+            <p style="color: var(--text-muted); margin-bottom: 1rem;">
+                Data-seam contracts (events + leaderboard) and cross-repo drift.
+                <strong>FAIL</strong> = broken, alerts; <strong>WARN</strong> = drift worth a glance, no alert.
+                Source: <code>scripts/validate_data.py</code> &rarr; <code>/data/integration-health.json</code>.
+            </p>
+            <div id="integration-health">
+                Loading integration health...
+            </div>
+        </div>
+
         <!-- Automation Status Section -->
         <div class="recent-checks" style="margin-top: 3rem;">
             <h2>🤖 Automation Status</h2>
@@ -653,6 +666,34 @@
             alert('Manual trigger feature requires GitHub Actions workflow_dispatch.\n\nTo manually rollover:\n1. Run: npm run league:archive\n2. Run: npm run league:new-week\n\nOr visit GitHub Actions and run "Weekly League Rollover" workflow.');
         }
         
+        async function updateIntegrationHealth() {
+            const container = document.getElementById('integration-health');
+            try {
+                const res = await fetch('/data/integration-health.json', { cache: 'no-store' });
+                if (!res.ok) throw new Error(res.status);
+                const h = await res.json();
+                const color = s => s === 'FAIL' ? '#ff4444' : (s === 'WARN' ? '#ffb000' : '#00ff41');
+                const badge = s => `<span style="color:${color(s)};font-weight:bold;">${s}</span>`;
+                const rows = (h.checks || []).map(c => `
+                    <div style="display:flex;gap:0.75rem;padding:0.35rem 0;border-bottom:1px solid var(--border-color);flex-wrap:wrap;">
+                        <span style="min-width:52px;">${badge(c.status)}</span>
+                        <span style="min-width:190px;color:var(--text-primary);">${c.name}</span>
+                        <span style="color:var(--text-muted);flex:1;">${c.detail || ''}</span>
+                    </div>`).join('');
+                const s = h.summary || {};
+                container.innerHTML = `
+                    <div style="margin-bottom:0.75rem;">
+                        Overall: ${badge(h.overall_status)} &nbsp;
+                        <span style="color:var(--text-muted);">
+                            ${s.fail||0} fail &middot; ${s.warn||0} warn &middot; ${s.ok||0} ok
+                            &nbsp;|&nbsp; checked ${h.generated ? new Date(h.generated).toLocaleString() : 'n/a'}
+                        </span>
+                    </div>${rows}`;
+            } catch (e) {
+                container.innerHTML = '<span style="color:var(--text-muted);">integration-health.json not available yet (populated by the Data Contract Validation workflow).</span>';
+            }
+        }
+
         async function refreshData() {
             if (refreshing) return;
             
@@ -669,7 +710,8 @@
                     updateGitHubStatus(),
                     updateRecentChecks(),
                     updateAutomationStatus(),
-                    updateLeagueStatus()
+                    updateLeagueStatus(),
+                    updateIntegrationHealth()
                 ]);
 
                 document.getElementById('last-updated').textContent = `Last updated: ${new Date().toLocaleString()}`;

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,12 @@ PyJWT==2.10.1           # JSON Web Tokens (security update 2025-11-10)
 python-dotenv==1.0.0   # Load .env files
 
 # ============================================================================
+# Data contract validation (scripts/validate_data.py, CI)
+# ============================================================================
+jsonschema==4.26.0     # JSON Schema validation of data seams (schemas/*.schema.json)
+Pillow>=10.0.0         # Image optimization (optimize-screenshots.py, blog assets)
+
+# ============================================================================
 # Optional Dependencies (Future Features)
 # ============================================================================
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,49 @@
+# p(Doom)1 data contracts
+
+These JSON Schemas are the **enforced contracts** for the data that flows between the
+game, pdoom-data, and the website. They are the single source of truth for the *shape* of
+each seam — both the producer and the consumer validate against the same file, so a
+field rename turns CI red instead of silently shipping a `NaN` / broken page to production.
+
+| Schema | Seam | Producer | Consumer |
+|---|---|---|---|
+| `events.schema.json` | historical events | pdoom-data → `sync-events.py` | website event pages/timeline |
+| `leaderboard-seed.schema.json` | per-seed scores (`entry` = the score-submission contract) | game leaderboard export | website leaderboard |
+| `leaderboard-weekly.schema.json` | weekly league `current.json` | game export + `weekly-league-reset.yml` | website league page |
+
+The website validates the projection it *receives* via `scripts/validate_data.py`
+(schema + semantic checks: encoding, freshness, version drift, referential integrity).
+That's the defensive half — the consumer guarding the boundary it controls.
+
+## Game-side (producer) validation — drop-in for the `pdoom1` repo
+
+Validate your leaderboard export **before** you push it, so bad data never leaves the game.
+Copy `leaderboard-seed.schema.json` + `leaderboard-weekly.schema.json` into the game repo
+(e.g. `contracts/`) and add a CI step:
+
+```yaml
+# .github/workflows/validate-export.yml (game repo)
+- name: Validate leaderboard export against contract
+  run: |
+    pip install --quiet jsonschema==4.26.0
+    python - <<'PY'
+    import json, sys, glob
+    from jsonschema import Draft7Validator
+    seed = json.load(open('contracts/leaderboard-seed.schema.json'))
+    v = Draft7Validator(seed)
+    bad = 0
+    for f in glob.glob('exports/seed_leaderboard_*.json'):
+        errs = sorted(v.iter_errors(json.load(open(f))), key=lambda e: list(e.path))
+        for e in errs:
+            print(f"{f}: {'/'.join(map(str,e.path)) or '(root)'}: {e.message}"); bad += 1
+    sys.exit(1 if bad else 0)
+    PY
+```
+
+Keeping the schema files identical across repos is the whole point. When you change the
+contract, change it in one place and copy it out — or, better, publish `schemas/` as the
+canonical copy and have the game repo fetch it in CI.
+
+## Versioning
+Treat a schema change as a breaking API change: bump intentionally, update both sides in
+the same PR, and let the failing validation on the other side tell you what you forgot.

--- a/schemas/events.schema.json
+++ b/schemas/events.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pdoom1.com/schemas/events.schema.json",
+  "title": "p(Doom)1 events map",
+  "description": "Contract for public/data/events.json. Object keyed by event id. SOURCE OF TRUTH: pdoom-data (generated via scripts/sync/sync-events.py). Consumed by the website (event pages/timeline) and the game. Any producer that changes these shapes must update this schema in the same change.",
+  "type": "object",
+  "minProperties": 1,
+  "additionalProperties": { "$ref": "#/$defs/event" },
+  "$defs": {
+    "event": {
+      "type": "object",
+      "required": ["id", "title", "year", "category", "description", "impacts", "sources", "tags", "rarity", "safety_researcher_reaction", "media_reaction"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "year": { "type": "integer", "minimum": 1950, "maximum": 2100 },
+        "category": {
+          "description": "Strict enum on purpose: adding a category is a deliberate contract change, not a silent one.",
+          "enum": ["funding_catastrophe", "organizational_crisis", "technical_research_breakthrough", "institutional_decay"]
+        },
+        "description": { "type": "string" },
+        "impacts": { "type": "array", "description": "Game-adaptation field (see DATA_SPLIT.md)." },
+        "sources": { "type": "array", "items": { "type": "string" } },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "rarity": {
+          "description": "Game-adaptation field. Strict enum.",
+          "enum": ["common", "rare", "legendary"]
+        },
+        "pdoom_impact": { "type": ["number", "null"], "description": "Game-adaptation field; usually null." },
+        "safety_researcher_reaction": { "type": "string" },
+        "media_reaction": { "type": "string" },
+        "source_id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/leaderboard-seed.schema.json
+++ b/schemas/leaderboard-seed.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pdoom1.com/schemas/leaderboard-seed.schema.json",
+  "title": "p(Doom)1 per-seed leaderboard",
+  "description": "Contract for public/leaderboard/data/seed_leaderboard_*.json. PRODUCER: game leaderboard export. CONSUMER: website leaderboard pages. The `entry` def is shared with the weekly schema -- it is the game->website score-submission contract.",
+  "type": "object",
+  "required": ["meta", "seed", "entries"],
+  "additionalProperties": true,
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["generated"],
+      "additionalProperties": true,
+      "properties": {
+        "generated": { "type": "string", "format": "date-time" },
+        "game_version": { "type": "string" },
+        "total_players": { "type": "integer", "minimum": 0 },
+        "export_source": { "type": "string" }
+      }
+    },
+    "seed": { "type": "string", "minLength": 1 },
+    "economic_model": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "description": "One score submission. THE game->website contract: the game produces these, the website displays them unchanged.",
+      "required": ["score", "player_name", "date"],
+      "additionalProperties": true,
+      "properties": {
+        "score": { "type": "number" },
+        "player_name": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "date": { "type": "string" },
+        "level_reached": { "type": "integer", "minimum": 0 },
+        "game_mode": { "type": "string" },
+        "duration_seconds": { "type": "number", "minimum": 0 },
+        "entry_uuid": { "type": "string" },
+        "final_doom": { "type": "number" },
+        "final_money": { "type": "number" },
+        "final_staff": { "type": "number" },
+        "final_reputation": { "type": "number" },
+        "final_compute": { "type": "number" }
+      }
+    }
+  }
+}

--- a/schemas/leaderboard-weekly.schema.json
+++ b/schemas/leaderboard-weekly.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pdoom1.com/schemas/leaderboard-weekly.schema.json",
+  "title": "p(Doom)1 weekly league (current.json)",
+  "description": "Contract for public/leaderboard/data/weekly/current.json. PRODUCER: the game's leaderboard export (scripts/export-leaderboard-bridge.py + weekly-league-reset workflow). CONSUMER: website leaderboard/league pages. This is the seam behind issue #126 (rollover false-positives) -- semantic freshness/version/integrity checks live in scripts/validate_data.py, not here.",
+  "type": "object",
+  "required": ["meta", "seed", "week_info", "entries", "statistics"],
+  "additionalProperties": true,
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["week_id", "generated", "competition_type"],
+      "additionalProperties": true,
+      "properties": {
+        "week_id": { "type": "string", "pattern": "^[0-9]{4}_W[0-9]{2}$" },
+        "season": { "type": "string" },
+        "generated": { "type": "string", "format": "date-time" },
+        "game_version": { "type": "string" },
+        "competition_type": { "type": "string" },
+        "total_participants": { "type": "integer", "minimum": 0 },
+        "total_submissions": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "seed": { "type": "string", "minLength": 1 },
+    "economic_model": { "type": "string" },
+    "week_info": {
+      "type": "object",
+      "required": ["week_id", "year", "week_number", "is_current"],
+      "additionalProperties": true,
+      "properties": {
+        "week_id": { "type": "string", "pattern": "^[0-9]{4}_W[0-9]{2}$" },
+        "year": { "type": "integer" },
+        "week_number": { "type": "integer", "minimum": 1, "maximum": 53 },
+        "is_current": { "type": "boolean" }
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "leaderboard-seed.schema.json#/$defs/entry" }
+    },
+    "statistics": {
+      "type": "object",
+      "required": ["highest_score", "unique_players"],
+      "additionalProperties": true,
+      "properties": {
+        "highest_score": { "type": "number" },
+        "average_score": { "type": "number" },
+        "total_games": { "type": "integer", "minimum": 0 },
+        "unique_players": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+validate_data.py -- contract + integrity validation for the p(Doom)1 data seams.
+
+Validates the data files the website consumes against the JSON Schemas in schemas/
+(the enforced contracts), then layers on semantic checks that schemas cannot express:
+encoding corruption, freshness, cross-repo version drift, and referential integrity.
+
+Severity model (the whole point -- conserve a solo dev's attention):
+  FAIL  = unambiguous bug. Breaks CI, warrants ONE actionable alert. (schema
+          violations, mojibake, self-contradictory data)
+  WARN  = drift/staleness worth a human glance, shown on the health dashboard but
+          NEVER alerted. (version lag, a 'current' week that has ended)
+  OK    = fine, stay silent.
+
+Emits public/data/integration-health.json for the /monitoring/ dashboard, and exits
+non-zero iff any FAIL -- so CI goes red on real breakage, quiet on drift.
+
+Run:  python scripts/validate_data.py            (full run, writes health json)
+      python scripts/validate_data.py --check    (exit-code only, no file write)
+"""
+
+import glob
+import io
+import json
+import re
+import sys
+from datetime import datetime, timezone, date
+from pathlib import Path
+
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC = ROOT / "public"
+SCHEMAS = ROOT / "schemas"
+
+FAIL, WARN, OK = "FAIL", "WARN", "OK"
+checks = []  # list of {name, status, detail}
+
+
+def add(name, status, detail=""):
+    checks.append({"name": name, "status": status, "detail": detail})
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+# ---- schema validation (jsonschema preferred; degrade gracefully) --------------
+def validate_schema(name, data_path, schema_name):
+    try:
+        import jsonschema
+        from jsonschema import Draft7Validator
+        from referencing import Registry, Resource
+    except Exception:
+        # Fallback: jsonschema present but no referencing (older), or absent.
+        try:
+            import jsonschema  # noqa
+        except Exception:
+            add(f"schema:{name}", WARN, "jsonschema not installed -- schema check skipped (pip install jsonschema)")
+            return
+    try:
+        data = load_json(data_path)
+    except FileNotFoundError:
+        add(f"schema:{name}", WARN, f"{data_path} not found -- skipped")
+        return
+    except Exception as e:
+        add(f"schema:{name}", FAIL, f"{data_path} is not valid JSON: {e}")
+        return
+
+    schema = load_json(SCHEMAS / schema_name)
+    try:
+        import jsonschema
+        # Resolve cross-file $refs (weekly -> seed) by loading all schemas into a store.
+        store = {}
+        for sf in SCHEMAS.glob("*.schema.json"):
+            s = load_json(sf)
+            store[sf.name] = s
+            if "$id" in s:
+                store[s["$id"]] = s
+        resolver = jsonschema.RefResolver(base_uri="", referrer=schema, store=store)
+        validator = jsonschema.Draft7Validator(schema, resolver=resolver)
+        errs = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+        if not errs:
+            add(f"schema:{name}", OK, "valid")
+        else:
+            e = errs[0]
+            loc = "/".join(str(p) for p in e.path) or "(root)"
+            add(f"schema:{name}", FAIL, f"{len(errs)} violation(s); first at {loc}: {e.message[:160]}")
+    except Exception as e:
+        add(f"schema:{name}", WARN, f"schema check errored: {e}")
+
+
+# ---- encoding corruption (the mojibake class) ----------------------------------
+MOJIBAKE = [chr(0x00E2) + chr(0x2020) + chr(0x2019),  # -> double-encoded
+            chr(0x00E2) + chr(0x20AC) + chr(0x2122),  # ' curly
+            chr(0x00E2) + chr(0x20AC) + chr(0x201D)]  # -- em dash
+
+
+def check_encoding(name, path):
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return
+    hits = {m: text.count(m) for m in MOJIBAKE if m in text}
+    if hits:
+        add(f"encoding:{name}", FAIL, f"mojibake found: {hits} (double-encoded chars in source)")
+    else:
+        add(f"encoding:{name}", OK, "no mojibake")
+
+
+# ---- leaderboard freshness / version / integrity -------------------------------
+def parse_dt(s):
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        # assume UTC for naive timestamps so arithmetic with now(utc) works
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def check_weekly_league():
+    path = PUBLIC / "leaderboard" / "data" / "weekly" / "current.json"
+    try:
+        d = load_json(path)
+    except FileNotFoundError:
+        add("league:present", FAIL, "weekly/current.json missing")
+        return
+    now = datetime.now(timezone.utc)
+
+    # freshness
+    gen = parse_dt((d.get("meta") or {}).get("generated"))
+    if gen:
+        age_days = (now - gen).total_seconds() / 86400
+        if age_days > 9:
+            add("league:freshness", FAIL, f"current.json is {age_days:.1f} days old -- weekly rollover likely stalled")
+        elif age_days > 7:
+            add("league:freshness", WARN, f"current.json is {age_days:.1f} days old (rollover due)")
+        else:
+            add("league:freshness", OK, f"generated {age_days:.1f} days ago")
+    else:
+        add("league:freshness", WARN, "no parseable meta.generated")
+
+    # current week actually current?
+    wi = d.get("week_info") or {}
+    end = None
+    for k in ("end_timestamp", "end_date"):
+        end = end or parse_dt(wi.get(k))
+    if wi.get("is_current") and end:
+        past = (now - end).total_seconds() / 86400
+        if past > 2:
+            add("league:current_week", WARN,
+                f"week {wi.get('week_id')} is marked is_current but ended {past:.1f} days ago -- rollover cadence off")
+        else:
+            add("league:current_week", OK, f"week {wi.get('week_id')} current")
+
+    # version drift vs deployed game version
+    try:
+        ver = load_json(PUBLIC / "data" / "version.json")
+        deployed = (ver.get("latest_release") or {}).get("version")
+        lb_ver = (d.get("meta") or {}).get("game_version")
+        if deployed and lb_ver and deployed != lb_ver:
+            add("league:version_drift", WARN,
+                f"leaderboard game_version={lb_ver} but deployed game={deployed} -- export stamping stale version")
+        elif deployed and lb_ver:
+            add("league:version_drift", OK, f"game_version {lb_ver} matches deployed")
+    except Exception:
+        pass
+
+    # referential integrity: stats vs entries
+    entries = d.get("entries") or []
+    stats = d.get("statistics") or {}
+    uniq = len({(e.get("player_name") or "").strip() for e in entries if e.get("player_name")})
+    if "unique_players" in stats and stats["unique_players"] != uniq:
+        add("league:integrity", FAIL,
+            f"statistics.unique_players={stats['unique_players']} but entries contain {uniq} unique players")
+    else:
+        add("league:integrity", OK, f"{len(entries)} entries, {uniq} unique players consistent")
+
+
+def check_seed_leaderboards():
+    files = sorted(glob.glob(str(PUBLIC / "leaderboard" / "data" / "seed_leaderboard_*.json")))
+    if not files:
+        add("seed_leaderboards:present", WARN, "no seed leaderboard files found")
+        return
+    bad = 0
+    for f in files:
+        try:
+            load_json(f)
+        except Exception:
+            bad += 1
+    add("seed_leaderboards:parse", FAIL if bad else OK,
+        f"{bad}/{len(files)} unparseable" if bad else f"{len(files)} files parse OK")
+
+
+# ---- main ----------------------------------------------------------------------
+def main():
+    check_only = "--check" in sys.argv
+
+    validate_schema("events", PUBLIC / "data" / "events.json", "events.schema.json")
+    validate_schema("league_weekly", PUBLIC / "leaderboard" / "data" / "weekly" / "current.json", "leaderboard-weekly.schema.json")
+    # validate one representative seed file against the seed schema
+    seeds = sorted(glob.glob(str(PUBLIC / "leaderboard" / "data" / "seed_leaderboard_*.json")))
+    if seeds:
+        validate_schema("league_seed", seeds[-1], "leaderboard-seed.schema.json")
+
+    check_encoding("events", PUBLIC / "data" / "events.json")
+    check_encoding("league_weekly", PUBLIC / "leaderboard" / "data" / "weekly" / "current.json")
+
+    check_weekly_league()
+    check_seed_leaderboards()
+
+    n_fail = sum(1 for c in checks if c["status"] == FAIL)
+    n_warn = sum(1 for c in checks if c["status"] == WARN)
+    overall = FAIL if n_fail else (WARN if n_warn else OK)
+
+    report = {
+        "generated": datetime.now(timezone.utc).isoformat(),
+        "overall_status": overall,
+        "summary": {"fail": n_fail, "warn": n_warn, "ok": sum(1 for c in checks if c["status"] == OK)},
+        "checks": checks,
+    }
+
+    # console
+    icon = {OK: "OK  ", WARN: "WARN", FAIL: "FAIL"}
+    print(f"Data contract & integrity validation -- overall: {overall}")
+    print("-" * 72)
+    for c in checks:
+        print(f"[{icon[c['status']]}] {c['name']}: {c['detail']}")
+    print("-" * 72)
+    print(f"{n_fail} fail, {n_warn} warn, {report['summary']['ok']} ok")
+
+    if not check_only:
+        out = PUBLIC / "data" / "integration-health.json"
+        out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"wrote {out.relative_to(ROOT)}")
+
+    sys.exit(1 if n_fail else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hardens the cross-repo integrations from *inferred* to *enforced*, so a broken data seam turns CI red instead of silently shipping NaN/mojibake/false-success to production. Consumer-side by design — the website validates the boundary it controls, regardless of producer state.

## What's in it
- **`schemas/`** — JSON Schema contracts for the three seams (events, per-seed leaderboard, weekly league). These files *are* the game-side handoff too (`schemas/README.md` has a drop-in producer CI snippet).
- **`scripts/validate_data.py`** — schema validation + semantic checks schemas can't express: encoding corruption, freshness, cross-repo version drift, referential integrity. **Severity split conserves attention:** `FAIL` breaks CI + alerts; `WARN` shows on the dashboard only.
- **`data-contract-validation.yml`** — runs on data/schema changes + daily; opens **one de-duplicated** alert issue on FAIL.
- **`health-checks.yml`** — retrofitted the same de-dup (it was creating dated duplicate issues ~4×/day).
- **`/monitoring/` Integration Health section** — the single pane of glass, reading `integration-health.json`.
- **docs** — workflow attention-cost audit + data-split ownership decision.

## It already earned its keep
On first run it surfaced two real drifts as `WARN`:
- leaderboard export stamps `game_version: v0.4.1` but deployed game is `v0.11.0`
- week `2026_W28` is marked `is_current` 3 days after it ended (rollover cadence off — the #126 concern, now observable)

Verified: schemas valid JSON, workflows valid YAML, validator runs (exit 0, 2 WARN), monitoring JS syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)