### PR TITLE
Workflow de-dup (last 2) + game-uplift scouting plan

### DIFF
--- a/.github/workflows/auto-update-data.yml
+++ b/.github/workflows/auto-update-data.yml
@@ -87,33 +87,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `🤖 Auto-Update Failed - ${new Date().toISOString().split('T')[0]}`;
-            const body = `
-            ## Automated Data Update Failure
-
-            **Workflow:** Auto-Update Data
-            **Run ID:** ${{ github.run_id }}
-            **Trigger:** ${{ github.event_name }}
-            **Timestamp:** ${new Date().toUTCString()}
-
-            ### Status
-            - Version Update: ${{ steps.update-version.outcome }}
-            - Stats Update: ${{ steps.update-stats.outcome }}
-
-            ### Next Steps
-            1. Review workflow logs: [Link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Check if GitHub API rate limits are exceeded
-            3. Verify scripts are functioning correctly
-            4. Consider manual run: \`npm run sync:all\`
-
-            **Priority:** Medium - Automated process
-            This issue was automatically created by the auto-update workflow.
-            `;
-
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: body,
-              labels: ['automation', 'monitoring', 'auto-created']
+            // De-duplicated alert: one rolling issue (fixed title, no date), comment on repeats.
+            const title = '🤖 Auto-Update Data failing';
+            const label = 'auto-created';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const body = [
+              '## Auto-Update Data failure',
+              '',
+              `Version update: ${{ steps.update-version.outcome }} | Stats update: ${{ steps.update-stats.outcome }}`,
+              `Run: ${runUrl}`,
+              '',
+              '_Single rolling issue -- reused, not duplicated, per run._'
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 20,
             });
+            const found = existing.data.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: found.number,
+                body: `Still failing as of ${new Date().toUTCString()}.\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['automation', 'monitoring', label],
+              });
+            }

--- a/.github/workflows/sync-leaderboards.yml
+++ b/.github/workflows/sync-leaderboards.yml
@@ -125,39 +125,34 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = `🔄 Leaderboard Sync Failed - ${new Date().toISOString().split('T')[0]}`;
-            const body = `
-            ## Leaderboard Sync Failure
-
-            **Workflow Run:** ${{ github.run_id }}
-            **Timestamp:** ${new Date().toUTCString()}
-
-            ### Status
-            - Integration Check: ${{ steps.check-integration.outcome }}
-            - Sync All: ${{ steps.sync-all.outcome }}
-            - Sync Weekly: ${{ steps.sync-weekly.outcome }}
-            - Data Verification: ${{ steps.verify.outcome }}
-
-            ### Likely Causes
-            - Game repository not accessible
-            - Data format changes
-            - File permission issues
-            - Network connectivity problems
-
-            ### Required Actions
-            1. Review workflow logs: [Link](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Check game integration: \`npm run game:status\`
-            3. Verify game repository is accessible
-            4. Manual sync if needed: \`npm run game:sync-all\`
-
-            **Priority:** Medium - Leaderboard data may be stale
-            This issue was automatically created by the sync workflow.
-            `;
-
-            github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: body,
-              labels: ['automation', 'leaderboard', 'sync-failure', 'auto-created']
+            // De-duplicated alert: one rolling issue (fixed title, no date), comment on repeats.
+            const title = '🔄 Leaderboard sync failing';
+            const label = 'sync-failure';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const body = [
+              '## Leaderboard sync failure',
+              '',
+              `all: ${{ steps.sync-all.outcome }} | weekly: ${{ steps.sync-weekly.outcome }} | verify: ${{ steps.verify.outcome }}`,
+              `Run: ${runUrl}`,
+              '',
+              'Likely: game repo inaccessible, data-format change, or the game->website uplift (see the uplift tracking issue).',
+              '',
+              '_Single rolling issue -- reused, not duplicated, per run._'
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 20,
             });
+            const found = existing.data.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: found.number,
+                body: `Still failing as of ${new Date().toUTCString()}.\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['automation', 'leaderboard', label],
+              });
+            }

--- a/docs/GAME_UPLIFT_PLAN.md
+++ b/docs/GAME_UPLIFT_PLAN.md
@@ -1,0 +1,89 @@
+# Game → website score uplift: scouting findings + plan
+
+Scouted `pdoom1` @ `origin/main` (abbe277, 2026-07-16) in a read-only worktree, 2026-07-16.
+
+## Finding: there is no working uplift today
+
+The game→website score path is **broken**, not merely stale:
+
+- **Godot leaderboard is local-only.** `godot/scripts/leaderboard.gd` ("Local leaderboard
+  system... JSON-based storage, ported from pygame") writes to
+  `user://leaderboards/leaderboard_<seed>__<version>.json` on the *player's* machine.
+  It contains **no HTTP / upload / API / website code** whatsoever.
+- **The Python export is orphaned.** `scripts/export_leaderboards.py` (the old
+  `--copy-to-website` uplift) imports `scripts.lib.scores.enhanced_leaderboard` and
+  `scripts.lib.services.version` — **neither module exists** anymore (deleted in the
+  Godot migration). It would crash on run. `tools/web_export/api_format.py` has the same
+  dead `scripts.lib.services.version` import.
+- **Consequence:** the website's leaderboard files (`seed_leaderboard_*.json`,
+  `weekly/current.json`) are **frozen legacy data from the v0.4.1 Python era** — which is
+  exactly why `validate_data.py` flags `game_version=v0.4.1` vs deployed `v0.11.0`, and why
+  the weekly league has 0 participants.
+
+Version-of-truth is also fragmented: `version.txt` = `0.11.0` (real), but the export path
+hardcodes `Bootstrap_v0.4.1` (`api_format.py` x5) and `website-version-api.py` hardcodes
+`0.6.0`. Three numbers, none reading `version.txt`.
+
+## Good news
+
+The **contract is already right**: the website's `schemas/leaderboard-seed.schema.json`
+matches the fields the (old) export produced and that Godot stores locally
+(`score, player_name, date, level_reached, game_mode, duration_seconds, entry_uuid,
+final_*`). So whatever we build to move data, the shape is already specified and validated.
+
+## The decision that gates everything
+
+**Are player scores meant to reach the website automatically, or is the leaderboard
+curated by you?** The game is a downloadable Godot app on players' machines, and the site
+is static (DreamHost) — so "real player leaderboards" needs an ingestion backend that
+accepts writes. Three architectures:
+
+### Option A — In-game HTTP submission (the "real" multiplayer leaderboard)
+Godot POSTs each game-over score to a website ingestion endpoint.
+- **Needs:** (1) an ingestion API that can *write* (netlify function + a datastore, or the
+  existing `scripts/api-server.py` promoted to a real host; the static site can't take
+  writes directly); (2) Godot `HTTPRequest` on game-over; (3) the score-submission contract
+  (already have it: the `entry` schema); (4) anti-cheat (server-side seed/score sanity,
+  rate-limit, since a downloadable client is trivially spoofable).
+- **Where the work lives:** ingestion API + validation → **website/pdoom-data** (safe, we
+  control). HTTP submit + read `version.txt` → **game** (handoff).
+- **Effort:** high. This is the actual weekly-league feature.
+
+### Option B — Curated / batch export (rebuild the bridge for Godot)  ← recommended first step
+A small script reads Godot's leaderboard JSON (from a dev/known `user://` export, or a
+committed fixtures dir) and writes conformant `seed_leaderboard_*.json` into the website,
+stamped from `version.txt`. This is the old Python export, **rebuilt Godot-aware and
+version-correct**, runnable manually or in game-CI on release.
+- **Where:** a new `scripts/export_leaderboards.py` in the **game** (reads Godot output +
+  `version.txt`), validated against the copied schema before it writes (see
+  `schemas/README.md`). Website side unchanged (it already consumes + validates).
+- **Effort:** low–medium. Unblocks the drift immediately, no backend.
+
+### Option C — Do nothing yet, but stop lying
+Mark the current website leaderboard as **legacy/seed data** (a banner + a `"legacy": true`
+flag) so `v0.4.1` isn't presented as live, and let `validate_data.py` keep the drift
+visible. Zero code in the game.
+- **Effort:** trivial. Buys honesty until A or B is chosen.
+
+## Recommendation
+
+1. **Now (website, safe):** Option C — stop presenting stale data as live; the validator
+   already surfaces the drift. (~30 min, this repo.)
+2. **Next (game handoff):** Option B — rebuild `export_leaderboards.py` Godot-aware +
+   `version.txt`-stamped, validating against the contract before writing. Refreshes real
+   seed leaderboards with correct versions. This is the "give the push-out mechanism love"
+   you predicted — except it needs a *rebuild*, not a tweak, because the migration deleted it.
+3. **Later (project):** Option A — the real ingestion API + in-game submission, when the
+   weekly league is meant to have live players. Design the datastore first (netlify+KV/DB,
+   or promote `api-server.py`).
+
+The version-of-truth fix (everything reads `version.txt`; delete the hardcoded
+`Bootstrap_v0.4.1` / `0.6.0`) is a prerequisite for B and A and is a clean, isolated
+game-side change — good first handoff task.
+
+## Immediate handoff tasks for the game repo (when your build is pushed)
+- [ ] Make the score export read `version.txt` for `game_version`; delete hardcoded
+      `Bootstrap_v0.4.1` (api_format.py) and `0.6.0` (website-version-api.py).
+- [ ] Decide A vs B for how Godot scores leave the machine.
+- [ ] If B: rebuild `export_leaderboards.py` against Godot's `user://leaderboards/*.json`,
+      validate against `schemas/leaderboard-seed.schema.json` before writing.

--- a/docs/WORKFLOW_ATTENTION_AUDIT.md
+++ b/docs/WORKFLOW_ATTENTION_AUDIT.md
@@ -11,8 +11,8 @@ every failing run (no de-dup).
 |---|---|---|---|---|
 | `weekly-league-rollover.yml` | (removed) | **YES (35 spam issues)** | n/a | ✅ Fixed 2026-07-14 (deleted; now logs to /monitoring/, `weekly-league-reset.yml` alerts only on failure) |
 | `health-checks.yml` | every 6h | no | **NO → date-in-title, 4 dupes/day** | ✅ Fixed 2026-07-16 (de-dup pattern retrofitted) |
-| `auto-update-data.yml` | every 6h | no | **NO** | ⚠️ TODO: retrofit de-dup (highest remaining dupe risk) |
-| `sync-leaderboards.yml` | daily | no | **NO** | ⚠️ TODO: retrofit de-dup |
+| `auto-update-data.yml` | every 6h | no | **NO** | ✅ Fixed 2026-07-16 (de-dup retrofitted) |
+| `sync-leaderboards.yml` | daily | no | **NO** | ✅ Fixed 2026-07-16 (de-dup retrofitted) |
 | `extract-analytics.yml` | monthly | no | **NO** | low risk (monthly), retrofit when convenient |
 | `data-contract-validation.yml` | daily | no | **YES** | ✅ New; reference implementation |
 
@@ -43,6 +43,6 @@ if (found) {
 Reference implementations: `health-checks.yml` and `data-contract-validation.yml`.
 
 ## Next
-- Retrofit de-dup into `auto-update-data.yml` and `sync-leaderboards.yml` (same pattern).
-- Consider a shared composite action (`.github/actions/rolling-alert`) so de-dup is DRY
-  rather than copy-pasted — do this once a 3rd workflow needs it.
+- `extract-analytics.yml` (monthly, low risk) is the only remaining non-deduped alert.
+- Now that 3 workflows share the pattern, consider a shared composite action
+  (`.github/actions/rolling-alert`) so de-dup is DRY rather than copy-pasted.


### PR DESCRIPTION
## De-dup (attention-cost)
Retrofits the rolling-issue de-dup pattern into `auto-update-data.yml` (6-hourly) and `sync-leaderboards.yml` (daily) — they were minting date-titled duplicate issues per failing run. Only `extract-analytics.yml` (monthly, low risk) remains non-deduped. Audit doc updated.

## Game-uplift scouting plan (`docs/GAME_UPLIFT_PLAN.md`)
Scouted `pdoom1@origin/main` in a read-only worktree. **Finding: the game→website score uplift is broken, not stale.**
- Godot `leaderboard.gd` is local-only (writes `user://leaderboards/`, no HTTP/API).
- The Python export (`export_leaderboards.py`) is orphaned — dead imports to modules deleted in the Godot migration; would crash.
- So the website leaderboard is **frozen v0.4.1 legacy data** → the version-drift the new validator flagged.
- The contract already matches the data shape (good).

Plan: **(C)** stop presenting stale data as live (website, ~30min), **(B)** rebuild the export Godot-aware + `version.txt`-stamped (game handoff), **(A)** real ingestion API + in-game submission later (project). Version-of-truth fix (kill hardcoded `Bootstrap_v0.4.1`/`0.6.0`, read `version.txt`) is the clean first game-side task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)