### PR TITLE
Align website to the frozen v1 score contract (pdoom1 PR #679)

### DIFF
--- a/.github/workflows/sync-leaderboards.yml
+++ b/.github/workflows/sync-leaderboards.yml
@@ -60,12 +60,13 @@ jobs:
           echo "status=success" >> $GITHUB_OUTPUT
         continue-on-error: true
 
-      - name: Export leaderboard data
+      - name: Publish leaderboard snapshot (validated, honest)
         id: export
         if: github.event.inputs.sync_type == 'full'
         run: |
-          echo "Running full leaderboard export..."
-          python scripts/export-leaderboard-bridge.py --refresh
+          echo "Publishing leaderboard.json via the real pipeline..."
+          pip install --quiet jsonschema==4.26.0 || true
+          python scripts/ingest_scores.py
           echo "status=success" >> $GITHUB_OUTPUT
         continue-on-error: true
 

--- a/docs/GAME_UPLIFT_PLAN.md
+++ b/docs/GAME_UPLIFT_PLAN.md
@@ -1,5 +1,23 @@
 # Game → website score uplift: scouting findings + plan
 
+> **SETTLED (2026-07-17) by pdoom1 PR #679** — `docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md`.
+> The fragmentation this doc flagged is resolved: **one PHP score API behind a frozen v1 HTTP
+> contract; no parallel score paths.** What that means for *this* repo:
+> - **We are a READ-ONLY consumer.** Read scores via the API's `GET` (CORS-enabled) or the
+>   `board_<seed>__<version>.json` files. **Do not stand up a second score store** — our
+>   `ingest_scores.py` is a read *cache/snapshot* publisher, not authoritative.
+> - **The contract is frozen** and mirrored in `schemas/leaderboard-seed.schema.json` (`$defs.entry`)
+>   + `schemas/leaderboard-api.schema.json` (GET/board/POST shapes). Entry = `score, doom_integral,
+>   player_name, date, level_reached, game_mode, duration_seconds, entry_uuid, baseline_*`. Sort:
+>   score DESC, doom_integral DESC (ADR-0002). `final_*` are legacy-only.
+> - **Deploy collision RESOLVED:** the API lives on a separate subdomain (`api.pdoom1.com`), not under
+>   the static site's `rsync --delete` root (`pdoom1.com` → `$DH_PATH`) — different dirs, no clobber.
+>   Read path is config-driven via `config.json.scoreApi` (empty until the host is finalized).
+> - **Open (for Pip + agents):** final host/subdomain; whether we read `board_*.json` off-disk
+>   (needs co-location) or via `GET` (CORS, host-agnostic — the likely default for a static site).
+>
+> The historical scouting below stands as the record of *why* the uplift was broken.
+
 Scouted `pdoom1` @ `origin/main` (abbe277, 2026-07-16) in a read-only worktree, 2026-07-16.
 
 ## Finding: there is no working uplift today

--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,6 @@
 {
   "apiBase": "https://api.pdoom1.com",
+  "scoreApi": "",
   "contactEmail": "team@pdoom1.com",
   "steamStoreUrl": "",
   "githubReleasesUrl": "https://github.com/PipFoweraker/pdoom1/releases",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -8,12 +8,19 @@ field rename turns CI red instead of silently shipping a `NaN` / broken page to 
 | Schema | Seam | Producer | Consumer |
 |---|---|---|---|
 | `events.schema.json` | historical events | pdoom-data → `sync-events.py` | website event pages/timeline |
-| `leaderboard-seed.schema.json` | per-seed scores (`entry` = the score-submission contract) | game leaderboard export | website leaderboard |
-| `leaderboard-weekly.schema.json` | weekly league `current.json` | game export + `weekly-league-reset.yml` | website league page |
+| `leaderboard-seed.schema.json` | score `entry` (**FROZEN v1**) + legacy per-seed file | PHP score API (pdoom1) | website (read-only) |
+| `leaderboard-api.schema.json` | the score API read surfaces: `GET` response, on-disk `board_*.json`, `POST` ack | PHP score API | website (read-only) |
+| `leaderboard-weekly.schema.json` | weekly league `current.json` | weekly-league-reset.yml | website league page |
 
-The website validates the projection it *receives* via `scripts/validate_data.py`
-(schema + semantic checks: encoding, freshness, version drift, referential integrity).
-That's the defensive half — the consumer guarding the boundary it controls.
+**Score contract is SETTLED + FROZEN (pdoom1 PR #679, `docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md`):**
+one PHP score API, one frozen v1 HTTP contract, no parallel score paths. The website is a
+**read-only consumer** — it reads via the API `GET` (CORS) or the `board_<seed>__<version>.json`
+files; it never writes scores. `leaderboard-seed.schema.json#/$defs/entry` mirrors the frozen entry
+exactly; `leaderboard-api.schema.json` mirrors the GET/board/POST shapes. Changes are versioned
+(`/v2/...`), never silent.
+
+The website validates what it *receives* via `scripts/validate_data.py` (schema + semantic checks:
+encoding, freshness, version drift, referential integrity) — the consumer guarding its boundary.
 
 ## Game-side (producer) validation — drop-in for the `pdoom1` repo
 

--- a/schemas/leaderboard-api.schema.json
+++ b/schemas/leaderboard-api.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://pdoom1.com/schemas/leaderboard-api.schema.json",
+  "title": "p(Doom)1 score API -- frozen v1 read surfaces",
+  "description": "The two read surfaces of the frozen v1 score contract (pdoom1 PR #679, docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md). Base: https://<host>/score_api.php (host TBD -- api.pdoom1.com subdomain now). The website is a READ-ONLY consumer; it never writes scores.",
+  "$defs": {
+    "get_response": {
+      "description": "GET ?seed=<s>&version=<v>&limit=<n> -> this. entries sorted score DESC, doom_integral DESC.",
+      "type": "object",
+      "required": ["ok", "seed", "version", "entries"],
+      "additionalProperties": true,
+      "properties": {
+        "ok": { "type": "boolean" },
+        "seed": { "type": "string" },
+        "version": { "type": "string" },
+        "entries": {
+          "type": "array",
+          "items": { "$ref": "leaderboard-seed.schema.json#/$defs/entry" }
+        }
+      }
+    },
+    "board_file": {
+      "description": "On-disk board_<seed>__<version>.json is a bare JSON ARRAY of entries (score DESC, doom_integral DESC), readable directly if co-located.",
+      "type": "array",
+      "items": { "$ref": "leaderboard-seed.schema.json#/$defs/entry" }
+    },
+    "post_ack": {
+      "description": "POST (X-PDoom-Token header) -> this. Idempotent on entry_uuid. (Website never POSTs; documented for completeness.)",
+      "type": "object",
+      "required": ["ok"],
+      "additionalProperties": true,
+      "properties": {
+        "ok": { "type": "boolean" },
+        "added": { "type": "boolean" },
+        "rank": { "type": "integer" },
+        "duplicate": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/leaderboard-seed.schema.json
+++ b/schemas/leaderboard-seed.schema.json
@@ -28,22 +28,26 @@
   "$defs": {
     "entry": {
       "type": "object",
-      "description": "One score submission. THE game->website contract: the game produces these, the website displays them unchanged.",
-      "required": ["score", "player_name", "date"],
+      "description": "One score entry. FROZEN v1 contract -- pdoom1 docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md (PR #679). The game POSTs these to the PHP score API; the website reads them unchanged. Changes are versioned (/v2/...), never silent. Whitelisted fields only (the API drops the rest).",
+      "required": ["score", "player_name"],
       "additionalProperties": true,
       "properties": {
-        "score": { "type": "number" },
+        "score": { "type": "number", "description": "turns survived; PRIMARY sort DESC (ADR-0002)" },
+        "doom_integral": { "type": "number", "description": "integral of p(doom) over the run; TIEBREAK sort DESC (ADR-0002)" },
         "player_name": { "type": "string", "minLength": 1, "maxLength": 64 },
         "date": { "type": "string" },
         "level_reached": { "type": "integer", "minimum": 0 },
         "game_mode": { "type": "string" },
         "duration_seconds": { "type": "number", "minimum": 0 },
-        "entry_uuid": { "type": "string" },
-        "final_doom": { "type": "number" },
-        "final_money": { "type": "number" },
-        "final_staff": { "type": "number" },
-        "final_reputation": { "type": "number" },
-        "final_compute": { "type": "number" }
+        "entry_uuid": { "type": "string", "description": "idempotency key for POST de-dup" },
+        "baseline_score": { "type": "number" },
+        "baseline_doom_integral": { "type": "number" },
+
+        "final_doom": { "type": "number", "description": "LEGACY (pre-ADR-0002 snapshot); absent in v1 data" },
+        "final_money": { "type": "number", "description": "LEGACY" },
+        "final_staff": { "type": "number", "description": "LEGACY" },
+        "final_reputation": { "type": "number", "description": "LEGACY" },
+        "final_compute": { "type": "number", "description": "LEGACY" }
       }
     }
   }

--- a/scripts/export-leaderboard-bridge.py
+++ b/scripts/export-leaderboard-bridge.py
@@ -1,262 +1,36 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
-Leaderboard Export Bridge for p(Doom)1 Website Integration
+DEPRECATED -- do not use. Kept as a no-op stub for CLI back-compat only.
 
-This script bridges the gap between the game's leaderboard system and the website
-by creating a compatible export format until the main repository implements
-the web export functionality.
+This used to FABRICATE synthetic leaderboard data (15 fake entries stamped v0.4.1)
+"until game export is implemented". That's the source of the stale fake data the site
+was showing. It is superseded by:
 
-Usage:
-    python scripts/export-leaderboard-bridge.py
-    python scripts/export-leaderboard-bridge.py --seed specific-seed
-    python scripts/export-leaderboard-bridge.py --all-seeds
+  - scripts/ingest_scores.py   -- validates + publishes leaderboard.json (honest states)
+  - the frozen v1 score contract (pdoom1 PR #679): the game POSTs to the PHP score API;
+    the website is a READ-ONLY consumer (GET the API or read board_*.json). No fake data,
+    no second score store.
+
+This stub accepts the old flags and exits 0 so any lingering caller doesn't break, but
+it NEVER writes data. Delete once no workflow/test references it.
 """
 
-import json
 import argparse
 import sys
-from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Dict, List, Any, Optional
-import random
-
-
-class LeaderboardBridge:
-    """Bridge between game leaderboard format and website display format."""
-    
-    def __init__(self):
-        self.website_data_dir = Path(__file__).parent.parent / "public" / "leaderboard" / "data"
-        self.output_file = self.website_data_dir / "leaderboard.json"
-        
-    def create_realistic_leaderboard_data(self, seed: str = "demo-seed-v0.4.1", num_entries: int = 15) -> Dict[str, Any]:
-        """
-        Create realistic leaderboard data that matches the actual game format.
-        
-        This simulates what the game's export function should produce.
-        """
-        
-        # Lab names from the actual game (from pdoom1 repository)
-        lab_names = [
-            "Anthropic Safety Labs", "OpenAI Research", "DeepMind Safety", 
-            "MIRI Research", "Berkeley CHAI", "Future of Humanity Institute",
-            "Machine Intelligence Research", "AI Safety Research Group",
-            "Alignment Research Center", "Center for AI Safety",
-            "Existential Risk Research", "Technical AI Safety",
-            "Cooperative AI Foundation", "AI Governance Institute",
-            "Long-Term Future Fund"
-        ]
-        
-        entries = []
-        base_date = datetime.now() - timedelta(days=random.randint(1, 7))
-        
-        for i in range(num_entries):
-            # Create realistic score distribution (higher scores less common)
-            if i == 0:
-                score = random.randint(80, 95)  # Top score
-            elif i < 3:
-                score = random.randint(70, 85)  # Top 3
-            elif i < 8:
-                score = random.randint(50, 75)  # Middle tier
-            else:
-                score = random.randint(25, 55)  # Lower tier
-            
-            # Realistic game session data
-            duration_minutes = random.uniform(15, 120)  # 15 minutes to 2 hours
-            
-            # Economic metrics based on score performance
-            performance_factor = score / 100.0
-            final_money = int(performance_factor * random.uniform(500000, 3000000))
-            final_staff = int(performance_factor * random.randint(10, 60))
-            final_doom = round(random.uniform(10, 60) * (1.5 - performance_factor), 1)
-            final_reputation = round(performance_factor * random.uniform(60, 95), 1)
-            final_compute = int(performance_factor * random.randint(50000, 200000))
-            
-            entry = {
-                "score": score,
-                "player_name": lab_names[i % len(lab_names)],
-                "date": (base_date - timedelta(hours=random.randint(0, 168))).isoformat() + "Z",
-                "level_reached": score,  # Same as score in current game
-                "game_mode": "Bootstrap_v0.4.1",
-                "duration_seconds": round(duration_minutes * 60, 1),
-                "entry_uuid": f"uuid-{i+1:03d}",
-                "final_doom": final_doom,
-                "final_money": final_money,
-                "final_staff": final_staff,
-                "final_reputation": final_reputation,
-                "final_compute": final_compute,
-                "research_papers_published": random.randint(0, min(12, score // 10)),
-                "technical_debt_accumulated": random.randint(0, max(5, 100 - score))
-            }
-            entries.append(entry)
-        
-        # Sort by score (highest first)
-        entries.sort(key=lambda x: x["score"], reverse=True)
-        
-        return {
-            "meta": {
-                "generated": datetime.now().isoformat() + "Z",
-                "game_version": "v0.4.1",
-                "total_seeds": 1,
-                "total_players": len(set(entry["player_name"] for entry in entries)),
-                "export_source": "leaderboard-bridge",
-                "note": "Generated by website bridge until game export is implemented"
-            },
-            "seed": seed,
-            "economic_model": "Bootstrap_v0.4.1",
-            "entries": entries
-        }
-    
-    def export_leaderboard(self, seed: Optional[str] = None, refresh: bool = True) -> Path:
-        """
-        Export leaderboard data for website consumption.
-        
-        Args:
-            seed: Specific seed to export (None for default demo seed)
-            refresh: Whether to generate fresh data
-            
-        Returns:
-            Path to the exported file
-        """
-        if not refresh and self.output_file.exists():
-            print(f"DATA: Using existing leaderboard data: {self.output_file}")
-            return self.output_file
-        
-        # Ensure output directory exists
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Generate or load leaderboard data
-        seed = seed or "demo-competitive-seed"
-        leaderboard_data = self.create_realistic_leaderboard_data(seed)
-        
-        # Write to output file
-        with open(self.output_file, 'w', encoding='utf-8') as f:
-            json.dump(leaderboard_data, f, indent=2, ensure_ascii=False)
-        
-        print(f"SUCCESS: Exported leaderboard data to: {self.output_file}")
-        print(f"SEED: Seed: {seed}")
-        print(f"ENTRIES: Entries: {len(leaderboard_data['entries'])}")
-        print(f"TOP: Top Score: {leaderboard_data['entries'][0]['score']} turns")
-        print(f"LEADER: Leader: {leaderboard_data['entries'][0]['player_name']}")
-        
-        return self.output_file
-    
-    def validate_export(self) -> bool:
-        """Validate that the exported data matches website expectations."""
-        if not self.output_file.exists():
-            print("ERROR: No leaderboard data found to validate")
-            return False
-        
-        try:
-            with open(self.output_file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            
-            # Check required structure
-            required_fields = ["meta", "seed", "economic_model", "entries"]
-            for field in required_fields:
-                if field not in data:
-                    print(f"❌ Missing required field: {field}")
-                    return False
-            
-            # Check entries structure
-            if not data["entries"]:
-                print("❌ No entries found in leaderboard")
-                return False
-            
-            entry = data["entries"][0]
-            required_entry_fields = [
-                "score", "player_name", "date", "level_reached", 
-                "game_mode", "duration_seconds", "entry_uuid"
-            ]
-            
-            for field in required_entry_fields:
-                if field not in entry:
-                    print(f"❌ Missing required entry field: {field}")
-                    return False
-            
-            print("SUCCESS: Leaderboard data structure validation passed")
-            print(f"COMPATIBLE: Format compatible with game v{data['meta'].get('game_version', 'unknown')}")
-            return True
-            
-        except Exception as e:
-            print(f"ERROR: Validation failed: {e}")
-            return False
-    
-    def get_bridge_status(self) -> Dict[str, Any]:
-        """Get current status of the leaderboard bridge."""
-        status = {
-            "bridge_active": True,
-            "output_file": str(self.output_file),
-            "file_exists": self.output_file.exists(),
-            "last_modified": None,
-            "entries_count": 0,
-            "seed": None,
-            "ready_for_integration": False
-        }
-        
-        if self.output_file.exists():
-            try:
-                stat = self.output_file.stat()
-                status["last_modified"] = datetime.fromtimestamp(stat.st_mtime).isoformat()
-                
-                with open(self.output_file, 'r') as f:
-                    data = json.load(f)
-                    
-                status["entries_count"] = len(data.get("entries", []))
-                status["seed"] = data.get("seed")
-                status["ready_for_integration"] = True
-                
-            except Exception as e:
-                status["error"] = str(e)
-        
-        return status
 
 
 def main():
-    """CLI interface for the leaderboard bridge."""
-    parser = argparse.ArgumentParser(description="p(Doom)1 Leaderboard Export Bridge")
-    parser.add_argument("--seed", type=str, help="Specific seed to export")
-    parser.add_argument("--refresh", action="store_true", 
-                       help="Force refresh of leaderboard data")
-    parser.add_argument("--validate", action="store_true",
-                       help="Validate existing leaderboard data")
-    parser.add_argument("--status", action="store_true",
-                       help="Show bridge status")
-    
-    args = parser.parse_args()
-    
-    bridge = LeaderboardBridge()
-    
-    if args.status:
-        status = bridge.get_bridge_status()
-        print("🌉 Leaderboard Bridge Status:")
-        print(f"   📄 Output file: {status['output_file']}")
-        print(f"   📊 Entries: {status['entries_count']}")
-        print(f"   🎲 Seed: {status['seed']}")
-        print(f"   ⏰ Last updated: {status.get('last_modified', 'Never')}")
-        print(f"   ✅ Ready: {status['ready_for_integration']}")
-        return
-    
-    if args.validate:
-        success = bridge.validate_export()
-        sys.exit(0 if success else 1)
-    
-    # Export leaderboard data
-    try:
-        output_file = bridge.export_leaderboard(seed=args.seed, refresh=args.refresh)
-        
-        # Automatically validate after export
-        if bridge.validate_export():
-            print("\n🎯 Next steps:")
-            print("   1. View leaderboard: http://localhost:5173/leaderboard/")
-            print("   2. Test integration: npm run test:health")
-            print("   3. Deploy changes when ready")
-        else:
-            print("\n❌ Export completed but validation failed")
-            sys.exit(1)
-            
-    except Exception as e:
-        print(f"❌ Export failed: {e}")
-        sys.exit(1)
+    ap = argparse.ArgumentParser(description="DEPRECATED -- superseded by ingest_scores.py")
+    ap.add_argument("--seed", type=str)
+    ap.add_argument("--refresh", action="store_true")
+    ap.add_argument("--validate", action="store_true")
+    ap.add_argument("--status", action="store_true")
+    ap.add_argument("--all-seeds", action="store_true")
+    ap.parse_args()
+    print("export-leaderboard-bridge.py is DEPRECATED and no longer generates data.")
+    print("Use scripts/ingest_scores.py (real, validated) instead. See docs/GAME_UPLIFT_PLAN.md.")
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/scripts/ingest_scores.py
+++ b/scripts/ingest_scores.py
@@ -17,8 +17,11 @@ seed_leaderboard_*.json -- validated against schemas/leaderboard-seed.schema.jso
   4. sets an honest `data_status`: "live" | "pre-launch" | "legacy",
   5. recomputes weekly/current.json statistics for internal consistency.
 
-Whatever eventually delivers real entries -- an ingestion API (Option A) or a rebuilt
-Godot export (Option B) -- drops conforming seed files here and this publishes them.
+Per the FROZEN v1 contract (pdoom1 PR #679), scores live in the PHP score API and the
+website is a READ-ONLY consumer -- so this is a read *cache/snapshot* publisher, never an
+authoritative store. It aggregates conforming seed/board files (later: pulled from the
+API's GET) into a static snapshot for the fast static site. Entries are sorted per
+ADR-0002 (score DESC, doom_integral DESC).
 
 Test/dev seeds (test*, party*, demo*, final-verification*, natural-game-over*) are
 EXCLUDED by default so fixtures are never shown as real scores. --include-tests overrides.
@@ -131,7 +134,9 @@ def main():
         if valid_here:
             seeds_used.append(d.get("seed") or Path(f).stem)
 
-    merged = sorted(entries.values(), key=lambda e: e.get("score", 0), reverse=True)
+    # ADR-0002 order (frozen v1 contract): score (turns) DESC, then doom_integral DESC.
+    merged = sorted(entries.values(),
+                    key=lambda e: (e.get("score", 0), e.get("doom_integral", 0)), reverse=True)
 
     # Honest status: nothing published -> pre-launch; published via --include-legacy -> legacy.
     if not merged:


### PR DESCRIPTION
Mirrors the score architecture the game side settled in **pdoom1 PR #679** (`docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md`): one PHP score API, one **frozen v1 HTTP contract**, no parallel score paths, website = **read-only consumer**.

## Changes
- **`schemas/leaderboard-seed.schema.json`** — `entry` def now mirrors the frozen v1 fields (`score, doom_integral, player_name, date, level_reached, game_mode, duration_seconds, entry_uuid, baseline_*`). `final_*` kept **legacy-optional** so old data still validates (backward-compatible — `validate_data.py` stays green).
- **`schemas/leaderboard-api.schema.json`** (new) — the API read surfaces: `GET` `{ok,seed,version,entries}`, on-disk `board_*.json` (bare array), `POST` ack.
- **`ingest_scores.py`** — ADR-0002 sort (score DESC, `doom_integral` DESC); reframed as a read **cache/snapshot** publisher, never an authoritative store.
- **`config.json`** — `scoreApi` key (empty; host TBD → read path is config-driven).
- **`export-leaderboard-bridge.py`** — retired to a no-op deprecation stub (it was the synthetic **v0.4.1 fake-data generator** — the source of the stale fake data); `sync-leaderboards.yml` full-sync now runs `ingest_scores.py`.
- Docs (`GAME_UPLIFT_PLAN.md`, `schemas/README.md`) record the settle. **Deploy collision RESOLVED** — the API is on a separate `api.pdoom1.com` subdomain, not under the static site's `rsync --delete` root.

## Not touched
No `pdoom1` changes. Read-path wiring (pages → live GET) waits on the final host/subdomain. Leaderboard page display kept as-is per the pending design-coherence pass.

Verified: schemas valid, `validate_data.py` green, `test_ingest_scores.py` passes with the new fields+sort, deprecated bridge is a safe no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)