### PR TITLE
Launch-harden download + bug-report flows

### DIFF
--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -429,25 +429,39 @@
 					return;
 				}
 				
-				// Production API submission
-				button.textContent = 'Submitting...';
-				const base = (window.__PDOOM_CONFIG__ && window.__PDOOM_CONFIG__.apiBase) || '';
-				const url = (base ? base.replace(/\/$/, '') : '') + '/api/report-bug';
-				const res = await fetch(url, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(bugData)
-				});
-				if (!res.ok) throw new Error('Failed to submit');
-				button.textContent = '[OK] Report Submitted!';
-				button.style.background = 'var(--success-color)';
-				setTimeout(() => {
-					button.textContent = originalText;
+				// Bug reports -> pdoom1 GitHub issues (backend decision). Try a configured
+				// server-side endpoint (config.bugApi) first; else / on failure open a
+				// pre-filled GitHub issue the reporter confirms. Never lose a report.
+				const cfg = window.__PDOOM_CONFIG__ || {};
+				const bugApi = (cfg.bugApi || '').replace(/\/$/, '');
+				const ghUrl = 'https://github.com/PipFoweraker/pdoom1/issues/new?title='
+					+ encodeURIComponent(bugData.title || 'Bug report')
+					+ '&body=' + encodeURIComponent(
+						(bugData.description || '') +
+						'\n\n---\nType: ' + (bugData.type || 'bug') +
+						(bugData.email ? '\nReporter: ' + bugData.email : '') +
+						'\n_(filed via the website bug form)_');
+				let submitted = false;
+				if (bugApi) {
+					button.textContent = 'Submitting...';
+					try {
+						const res = await fetch(bugApi, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(bugData) });
+						submitted = res.ok;
+					} catch (_) { submitted = false; }
+				}
+				if (submitted) {
+					button.textContent = '[OK] Report Submitted!';
+					button.style.background = 'var(--success-color)';
+					setTimeout(() => { button.textContent = originalText; button.style.background = ''; e.target.reset(); button.disabled = false; }, 3000);
+				} else {
+					window.open(ghUrl, '_blank', 'noopener');
+					button.textContent = 'Continue on GitHub \u2192';
 					button.style.background = '';
-					e.target.reset();
-					button.disabled = false;
-				}, 3000);
-				
+					let fb = document.getElementById('bug-fallback');
+					if (!fb) { fb = document.createElement('p'); fb.id = 'bug-fallback'; fb.style.cssText = 'margin-top:0.8rem; font-size:0.9rem; color: var(--text-secondary);'; button.insertAdjacentElement('afterend', fb); }
+					fb.innerHTML = 'Your report opens as a pre-filled <a href="' + ghUrl + '" target="_blank" rel="noopener" style="color: var(--accent-primary); font-weight:bold;">GitHub issue &rarr;</a> &mdash; click "Submit new issue" there to finish. (A free GitHub account is needed.)';
+					setTimeout(() => { button.textContent = originalText; button.disabled = false; }, 4000);
+				}
 			} catch (err) {
 				button.textContent = '[ERROR] Submit Failed';
 				button.style.background = 'var(--accent-danger)';

--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,7 @@
 {
   "apiBase": "https://api.pdoom1.com",
   "scoreApi": "",
+  "bugApi": "",
   "contactEmail": "team@pdoom1.com",
   "steamStoreUrl": "",
   "githubReleasesUrl": "https://github.com/PipFoweraker/pdoom1/releases",

--- a/public/index.html
+++ b/public/index.html
@@ -882,13 +882,15 @@ t	.hero {
 
 			<!-- Download Options - Platform-Specific CTAs -->
 			<div class="download-ctas" style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.4rem;">
-				<a id="download-windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom-Windows.zip" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<!-- hrefs default to the release PAGE (never 404s on any asset naming);
+				     resolveDownloads() upgrades them to direct per-platform asset URLs. -->
+				<a id="download-windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Windows
 				</a>
-				<a id="download-macos" href="https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom.app.zip" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<a id="download-macos" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for macOS
 				</a>
-				<a id="download-linux" href="https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom.x86_64" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<a id="download-linux" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Linux
 				</a>
 			</div>
@@ -1560,10 +1562,35 @@ t	.hero {
 		}
 		
 		// Load version info when page loads
+		// Upgrade the platform download buttons from the safe release-page baseline to
+		// direct per-platform asset URLs, resolved from the latest release. Robust to any
+		// asset naming; on rate-limit/offline it silently keeps the working release-page href.
+		async function resolveDownloads() {
+			const platforms = {
+				'download-windows': /win/i,
+				'download-macos': /mac|osx|darwin|\.app|\.dmg/i,
+				'download-linux': /linux|x86_64|\.appimage/i
+			};
+			const isBuild = /\.(zip|dmg|appimage|x86_64|exe|tar\.gz)$/i;
+			try {
+				const res = await fetch('https://api.github.com/repos/PipFoweraker/pdoom1/releases/latest',
+					{ headers: { 'Accept': 'application/vnd.github+json' } });
+				if (!res.ok) return; // rate-limited/offline -> keep release-page baseline
+				const assets = (await res.json()).assets || [];
+				for (const [id, rx] of Object.entries(platforms)) {
+					const el = document.getElementById(id);
+					if (!el) continue;
+					const asset = assets.find(a => rx.test(a.name) && isBuild.test(a.name));
+					if (asset) el.href = asset.browser_download_url;
+				}
+			} catch (_) { /* keep baseline */ }
+		}
+
 		document.addEventListener('DOMContentLoaded', () => {
 			loadGameStats();
 				populateStatusCards();
 			setupDownloadTracking();
+			resolveDownloads();
 		});
 
 		// Track download button clicks with Plausible Analytics


### PR DESCRIPTION
Verified the two flows you're about to open to humans (download the game, submit a bug report) — **both were broken**.

## Download (homepage)
- **Linux button 404'd** — the release has no `PDoom.x86_64` (it's `PDoom-Linux-v0.11.0.zip`). Hardcoded asset names are also fragile across builds.
- Now: all three buttons default to the **release page** (never 404s on any naming), and `resolveDownloads()` upgrades them to **direct per-platform asset URLs** from the latest release. Silently keeps the release-page href on GitHub-API rate-limit/offline. Verified matching against the real v0.11.0 assets.

## Bug report
- The form POSTed to `api.pdoom1.com` (**down** → silent failure).
- Per the pdoom1 backend decision (**use pdoom1 GitHub issues**): route to a **pre-filled GitHub issue** the reporter confirms under their own account — tokenless, works on the static site today, correct repo. A `config.bugApi` hook lets us flip to a server-side endpoint later with no code change; the existing catch stays as a safety net.

Both syntax-checked. No `pdoom1` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)