### PR TITLE
docs: game roadmap projection at /docs/roadmap.md (website work -> website-roadmap.md)

### DIFF
--- a/public/docs/roadmap.md
+++ b/public/docs/roadmap.md
@@ -1,29 +1,38 @@
 # Roadmap
 
-This roadmap is a living document. It summarizes major goals for the **website** and feeds the GitHub Issues backlog for execution. It is organized by status rather than version number to avoid confusion.
+Where P(Doom)1 is headed. This page is the player-facing projection of the
+game repo's [docs/ROADMAP.md](https://github.com/PipFoweraker/pdoom1/blob/main/docs/ROADMAP.md)
+(the source of truth); day-to-day execution lives on the
+[GitHub milestones](https://github.com/PipFoweraker/pdoom1/milestones).
+Website work has its own page: [Website roadmap](website-roadmap.md).
 
-> **Versioning note:** The *game* (`PipFoweraker/pdoom1`) is the source of truth for gameplay and releases — its current release is **v0.11.0**. This site tracks that release automatically via `public/data/version.json`. The milestones below describe *website* work and are independent of the game's version.
+## The release ladder
 
-## Shipped
-- **Weekly League system** — deterministic seeding, standings UI, archives, and automated weekly rollover.
-- **Auto-deployment & monitoring** — pushes to `main` deploy to production (DreamHost) via GitHub Actions; scheduled health checks and status data.
-- **Accessibility** — WCAG AA pass (ARIA, contrast, keyboard navigation).
-- **AI Safety resource integration** — auto-generated timeline/event pages sourced from the `pdoom-data` repository.
-- **Press kit** — factsheet, assets, and legal attribution page.
-- **Core SEO scaffolding** — `sitemap.xml`, `robots.txt`, OpenGraph tags.
+1. **Private alpha (v0.11) -- we are here.** Friends-and-family Windows build
+   with the full core loop, hiring pipeline, honest defeat screens, and the
+   world leaderboard.
+2. **Public alpha -- itch.io, free.** First-contact polish, onboarding, and
+   the share loop, then the doors open.
+3. **Beta -- Steam "coming soon" page.** Wishlists start compounding while
+   the mid and late game get built in.
+4. **1.0.**
 
-## In progress
-- **Game ↔ API score submission** — automatic score submission from the game client to the production API, and standing up that API/database ([#64](https://github.com/PipFoweraker/pdoom1-website/issues/64), [#65](https://github.com/PipFoweraker/pdoom1-website/issues/65), [#66](https://github.com/PipFoweraker/pdoom1-website/issues/66)). *API and database are coded but not yet deployed; the website still reads static JSON.*
-- **Community forum** — self-hosted forum ([#60](https://github.com/PipFoweraker/pdoom1-website/issues/60)) plus GitHub→forum posting ([#63](https://github.com/PipFoweraker/pdoom1-website/issues/63)). *Running, but forum links are hidden on the site until it has a proper HTTPS domain (`forum.pdoom1.com`).*
-- **Analytics extraction** — privacy-preserving server-log analytics pipeline ([#61](https://github.com/PipFoweraker/pdoom1-website/issues/61)).
+## Quarterly outlook
 
-## Planned
-- **Grant-readiness content** — donor landing ([#78](https://github.com/PipFoweraker/pdoom1-website/issues/78)), budget ([#84](https://github.com/PipFoweraker/pdoom1-website/issues/84)), team & hiring ([#83](https://github.com/PipFoweraker/pdoom1-website/issues/83)), public roadmap page ([#81](https://github.com/PipFoweraker/pdoom1-website/issues/81)), safety & responsibility statement ([#82](https://github.com/PipFoweraker/pdoom1-website/issues/82)), metrics ([#85](https://github.com/PipFoweraker/pdoom1-website/issues/85)), testimonials ([#86](https://github.com/PipFoweraker/pdoom1-website/issues/86)).
-- **Steam launch** — swap the "Coming to Steam" placeholders to the live store link and update OpenGraph/CTAs when the store page is live ([#17](https://github.com/PipFoweraker/pdoom1-website/issues/17)).
+| Quarter | Version | Theme |
+|---|---|---|
+| Q3 2026 | v0.12 | **First Contact** -- public itch alpha, onboarding and first-launch help, shareable runs ("beat my seed"), world leaderboard switched on |
+| Q4 2026 | v0.13 | **Rivals and News** -- rival labs become a visible strategic surface: intel panel, capability race, a News feed with detail you earn |
+| Q1 2027 | v0.14 | **The World Shoots Back** -- rivals fight back past a threshold; the Liability Ledger becomes fully player-facing; monthly world-updates begin flowing from real-world AI events |
+| Q2 2027 | v0.15 | **Beta / Steam Coming Soon** -- Steam page and wishlists, press kit, character creation, a full balance pass |
 
-## Later
-- Newsletter opt-in (double opt-in).
-- Localization scaffolding.
+v0.12 is committed; v0.13 is planned; the 2027 pins are honest intentions,
+sized to a solo developer working roughly one to two focused days per week --
+they exist to be steered, not to be marketing.
 
-## Notes
-- The source of truth for game code and the design system is the `PipFoweraker/pdoom1` repo. This site links there for downloads until the Steam launch.
+## Cadence
+
+Leagues and content updates run **monthly**: a curated world-update, balance
+adjustments, and a refreshed challenge board each month. Weekly output is
+limited to lightweight generated artifacts (challenge seeds). Runs are
+deterministic per seed, so every board compares fairly.

--- a/public/docs/website-roadmap.md
+++ b/public/docs/website-roadmap.md
@@ -1,0 +1,31 @@
+# Website roadmap
+
+This roadmap is a living document. It summarizes major goals for the **website** and feeds the GitHub Issues backlog for execution. It is organized by status rather than version number to avoid confusion.
+
+> **Versioning note:** The *game* (`PipFoweraker/pdoom1`) is the source of truth for gameplay and releases — its current release is **v0.11.0**. This site tracks that release automatically via `public/data/version.json`. The milestones below describe *website* work and are independent of the game's version.
+
+## Shipped
+- **Weekly League system** — deterministic seeding, standings UI, archives, and automated weekly rollover.
+- **Auto-deployment & monitoring** — pushes to `main` deploy to production (DreamHost) via GitHub Actions; scheduled health checks and status data.
+- **Accessibility** — WCAG AA pass (ARIA, contrast, keyboard navigation).
+- **AI Safety resource integration** — auto-generated timeline/event pages sourced from the `pdoom-data` repository.
+- **Press kit** — factsheet, assets, and legal attribution page.
+- **Core SEO scaffolding** — `sitemap.xml`, `robots.txt`, OpenGraph tags.
+
+## In progress
+- **Game ↔ API score submission** — automatic score submission from the game client to the production API, and standing up that API/database ([#64](https://github.com/PipFoweraker/pdoom1-website/issues/64), [#65](https://github.com/PipFoweraker/pdoom1-website/issues/65), [#66](https://github.com/PipFoweraker/pdoom1-website/issues/66)). *API and database are coded but not yet deployed; the website still reads static JSON.*
+- **Community forum** — self-hosted forum ([#60](https://github.com/PipFoweraker/pdoom1-website/issues/60)) plus GitHub→forum posting ([#63](https://github.com/PipFoweraker/pdoom1-website/issues/63)). *Running, but forum links are hidden on the site until it has a proper HTTPS domain (`forum.pdoom1.com`).*
+- **Analytics extraction** — privacy-preserving server-log analytics pipeline ([#61](https://github.com/PipFoweraker/pdoom1-website/issues/61)).
+
+## Planned
+- **Grant-readiness content** — donor landing ([#78](https://github.com/PipFoweraker/pdoom1-website/issues/78)), budget ([#84](https://github.com/PipFoweraker/pdoom1-website/issues/84)), team & hiring ([#83](https://github.com/PipFoweraker/pdoom1-website/issues/83)), public roadmap page ([#81](https://github.com/PipFoweraker/pdoom1-website/issues/81)), safety & responsibility statement ([#82](https://github.com/PipFoweraker/pdoom1-website/issues/82)), metrics ([#85](https://github.com/PipFoweraker/pdoom1-website/issues/85)), testimonials ([#86](https://github.com/PipFoweraker/pdoom1-website/issues/86)).
+- **Steam launch** — swap the "Coming to Steam" placeholders to the live store link and update OpenGraph/CTAs when the store page is live ([#17](https://github.com/PipFoweraker/pdoom1-website/issues/17)).
+
+## Later
+- Newsletter opt-in (double opt-in).
+- Localization scaffolding.
+
+## Notes
+- The source of truth for game code and the design system is the `PipFoweraker/pdoom1` repo. This site links there for downloads until the Steam launch.
+
+- Forward cadence note (2026-07-21): league/content operations move to a MONTHLY cycle; weekly output is limited to generated challenge seeds. See the game roadmap.


### PR DESCRIPTION
Counterpart to pdoom1 PR #736 (living roadmap SSOT).

- /docs/roadmap.md (nav-linked slug) now carries the player/funder-facing game roadmap: release ladder, quarterly outlook to v0.15, monthly cadence ruling. Projected from pdoom1 docs/ROADMAP.md, which is the SSOT.
- The existing website-work roadmap content is preserved verbatim at /docs/website-roadmap.md (retitled, plus a forward note that league cadence moves to monthly per the 2026-07-21 ruling -- affects #126 rollover validation).
- Serves as v1 of #81 (public roadmap); automated sync of this projection folds into the pdoom1#545 / pdoom1#723-724 mechanism later -- until then this page updates manually with each game release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)