### PR TITLE
Launch green-lights: email-primary feedback, GDPR Tier 1

### DIFF
--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -322,14 +322,25 @@
 					<div id="description-error" class="error-message" role="alert" aria-live="polite"></div>
 				</div>
 
-				<!-- Email field removed 2026-07-22. It was labelled "Not stored or
-				     shared", but the only working submit path pastes the form into a
-				     PUBLIC GitHub issue -- so an address typed here was published on
-				     the issue tracker, contradicting this page's own promise and
-				     /privacy/'s "we never collect personally identifiable
-				     information". Follow-up now happens on the GitHub issue thread,
-				     where the reporter controls what they disclose. Do not
-				     reintroduce a contact field without a private sink to put it in. -->
+				<!-- Optional email reintroduced 2026-07-23. Safe now because there
+				     is a PRIVATE sink: bug-submit.php mails it to the team inbox. It
+				     is never added to the GitHub fallback (that stays public), so it
+				     cannot leak the way it would have before. -->
+				<div class="form-group">
+					<label for="bug-email">Your email <span style="color:var(--text-muted);font-weight:normal">(optional)</span></label>
+					<input type="email" id="bug-email" name="email"
+						   placeholder="you@example.com"
+						   autocomplete="email"
+						   aria-describedby="email-help">
+					<div id="email-help" class="form-help">Only if you'd like a reply. Sent privately to the team &mdash; never published, never added to a public issue.</div>
+				</div>
+
+				<!-- Honeypot: off-screen and hidden from people, tempting to bots.
+				     A real submission leaves it empty; a filled one is dropped. -->
+				<div aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden">
+					<label for="bug-hp">Do not fill this in</label>
+					<input type="text" id="bug-hp" name="hp" tabindex="-1" autocomplete="off">
+				</div>
 
 				<div class="form-group">
 					<label for="bug-attachment">Attach Log/File (Optional)</label>
@@ -374,6 +385,9 @@
 					title: formData.get('title'),
 					type: formData.get('type') || 'bug',
 					description: formData.get('description'),
+					email: (formData.get('email') || '').trim(),
+					hp: formData.get('hp') || '',
+					elapsed_ms: Math.round(performance.now()),
 					source: 'web'
 				};
 				
@@ -427,11 +441,13 @@
 					return;
 				}
 				
-				// Bug reports -> pdoom1 GitHub issues (backend decision). Try a configured
-				// server-side endpoint (config.bugApi) first; else / on failure open a
-				// pre-filled GitHub issue the reporter confirms. Never lose a report.
-				const cfg = window.__PDOOM_CONFIG__ || {};
-				const bugApi = (cfg.bugApi || '').replace(/\/$/, '');
+				// Feedback path: email-primary, GitHub as the never-lose-it fallback.
+				// bug-submit.php (same DreamHost box, PHP + mail()) sends the report
+				// privately to the team -- no GitHub account needed. On any failure we
+				// fall through to a prefilled GitHub issue below, so a report is never
+				// lost. Recipient is hardcoded server-side; a reporter's optional email
+				// goes ONLY to the private inbox, never into the public GitHub fallback.
+				const bugApi = '/bug-submit.php';
 
 				// Target the ISSUE FORM, not a blank issue. The game repo sets
 				// blank_issues_enabled:false, so /issues/new?title=&body= redirects

--- a/public/bug-submit.php
+++ b/public/bug-submit.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Bug / feedback intake for pdoom1.com.
+ *
+ * Receives a JSON POST from public/bug-report/index.html and emails it to the
+ * team. Primary path; the form falls back to a prefilled GitHub issue if this
+ * ever fails, so a report is never lost.
+ *
+ * SECURITY POSTURE
+ * - The recipient is HARDCODED (below). It is never taken from user input, so
+ *   this cannot be turned into an open relay to spam third parties -- the worst
+ *   an attacker gets is spam into our own inbox, which the guards below blunt.
+ * - All user-supplied text goes in the email BODY only; every header (To, From,
+ *   Subject) is a constant. That removes email-header-injection entirely.
+ * - Spam guards: a honeypot field, a minimum fill-time, and a per-IP throttle.
+ *
+ * Runs on DreamHost shared hosting (PHP + mail()). PHP source is executed, not
+ * served, so nothing here is visible to a browser.
+ */
+
+// ---- config -------------------------------------------------------------
+const RECIPIENT   = 'team@pdoom1.com';      // hardcoded on purpose (see above)
+const FROM        = 'team@pdoom1.com';      // same domain -> passes SPF on DreamHost
+const MIN_FILL_MS = 3000;                    // faster than this = a bot
+const THROTTLE_S  = 30;                      // seconds between reports per IP
+const MAX_TITLE   = 200;
+const MAX_DESC    = 5000;
+const MAX_EMAIL   = 200;
+const TYPES       = ['bug', 'feature', 'documentation', 'performance'];
+
+header('Content-Type: application/json; charset=utf-8');
+
+function done(int $code, array $payload): void {
+    http_response_code($code);
+    echo json_encode($payload);
+    exit;
+}
+
+// ---- method -------------------------------------------------------------
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    done(405, ['ok' => false, 'error' => 'Method not allowed']);
+}
+
+// ---- parse --------------------------------------------------------------
+$raw = file_get_contents('php://input');
+if ($raw === false || strlen($raw) > 800 * 1024) {   // generous cap; attachments are base64
+    done(413, ['ok' => false, 'error' => 'Request too large']);
+}
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    done(400, ['ok' => false, 'error' => 'Malformed request']);
+}
+
+// ---- spam guards --------------------------------------------------------
+// Honeypot: a hidden field real users never fill. If it's set, pretend success
+// so the bot moves on and doesn't probe for the real behaviour.
+if (!empty($data['hp'])) {
+    done(200, ['ok' => true]);
+}
+// Time-trap: a human takes seconds to write a report; a bot posts instantly.
+if (isset($data['elapsed_ms']) && (int)$data['elapsed_ms'] < MIN_FILL_MS) {
+    done(200, ['ok' => true]);
+}
+// Per-IP throttle. Recipient is fixed, so this only limits inbox spam volume.
+$ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+$throttle = sys_get_temp_dir() . '/pdoom_bug_' . hash('sha256', $ip);
+$now = time();
+if (is_file($throttle) && ($now - (int)@file_get_contents($throttle)) < THROTTLE_S) {
+    done(429, ['ok' => false, 'error' => 'Please wait a moment before sending another report.']);
+}
+@file_put_contents($throttle, (string)$now);
+
+// ---- validate + normalise ----------------------------------------------
+$clean = static function ($v, int $max): string {
+    $v = is_string($v) ? $v : '';
+    // strip control chars except tab/newline; trim; cap length
+    $v = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $v);
+    return mb_substr(trim($v), 0, $max);
+};
+
+$title = $clean($data['title'] ?? '', MAX_TITLE);
+$desc  = $clean($data['description'] ?? '', MAX_DESC);
+$type  = in_array($data['type'] ?? '', TYPES, true) ? $data['type'] : 'bug';
+$email = $clean($data['email'] ?? '', MAX_EMAIL);
+$email = ($email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL)) ? $email : '';
+
+if ($title === '' || $desc === '') {
+    done(422, ['ok' => false, 'error' => 'A title and description are required.']);
+}
+
+$hasAttachment = isset($data['attachment']['filename']);
+$attNote = $hasAttachment
+    ? "\n\nAttachment: reporter attached \"" . $clean($data['attachment']['filename'], 120)
+      . "\" (" . (int)($data['attachment']['size'] ?? 0) . " bytes) -- not forwarded by email; "
+      . "reply to ask for it, or they can re-file on GitHub with the file attached."
+    : '';
+
+// ---- compose (all user text in the BODY; headers are constants) ---------
+$subject = 'p(Doom)1 ' . $type . ': ' . mb_substr($title, 0, 80);
+$subject = str_replace(["\r", "\n"], ' ', $subject);   // belt-and-braces
+
+$body = "New feedback from the pdoom1.com bug form.\n"
+      . "----------------------------------------\n"
+      . "Type:    $type\n"
+      . "Title:   $title\n"
+      . "Contact: " . ($email !== '' ? $email : '(none given)') . "\n"
+      . "When:    " . gmdate('Y-m-d H:i:s') . " UTC\n"
+      . "----------------------------------------\n\n"
+      . $desc
+      . $attNote . "\n";
+
+$headers = 'From: p(Doom)1 site <' . FROM . ">\r\n"
+         . 'Content-Type: text/plain; charset=utf-8' . "\r\n"
+         . 'X-Mailer: pdoom1-bug-form';
+
+$sent = @mail(RECIPIENT, $subject, $body, $headers);
+
+if ($sent) {
+    done(200, ['ok' => true]);
+}
+done(502, ['ok' => false, 'error' => 'Could not send. Please use the GitHub option below.']);

--- a/public/config.json
+++ b/public/config.json
@@ -1,7 +1,7 @@
 {
   "apiBase": "https://api.pdoom1.com",
   "scoreApi": "",
-  "bugApi": "",
+  "bugApi": "/bug-submit.php",
   "contactEmail": "team@pdoom1.com",
   "steamStoreUrl": "",
   "githubReleasesUrl": "https://github.com/PipFoweraker/pdoom1/releases",

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -321,8 +321,8 @@
 					<p>Our analytics never collect personally identifiable information.</p>
 				</div>
 				<div class="feature-item">
-					<h4>✅ GDPR Compliant</h4>
-					<p>Fully compliant with privacy regulations by design.</p>
+					<h4>✅ Privacy by Design</h4>
+					<p>No cookies and no personal data means no consent banner to click through &mdash; and nothing about you stored to misuse.</p>
 				</div>
 				<div class="feature-item">
 					<h4>🌍 Respects DNT</h4>
@@ -408,7 +408,7 @@
 				<li>Self-hosted by us, for full data ownership</li>
 				<li>Lightweight and fast (~5KB script)</li>
 				<li>Does not use cookies or track users across sites</li>
-				<li>GDPR, CCPA, and PECR compliant</li>
+				<li>Built to satisfy GDPR, CCPA and PECR by collecting no personal data and setting no cookies</li>
 			</ul>
 
 			<h3>Alternative Providers</h3>
@@ -421,8 +421,34 @@
 				<li><strong>Simple Analytics:</strong> Privacy-focused with carbon-conscious hosting</li>
 			</ul>
 			<p>
-				All three options are privacy-preserving and GDPR-compliant. We chose Plausible for its
+				All three are cookieless and collect no personal data. We chose Plausible for its
 				simplicity, open-source nature, and excellent documentation.
+			</p>
+		</section>
+
+		<section class="section">
+			<h2>The honest legal bit</h2>
+			<p>
+				We're a small, volunteer-made, non-commercial project, and we'd rather show you good
+				mechanics than wave a compliance badge. Plainly:
+			</p>
+			<ul>
+				<li><strong>Legal basis:</strong> our analytics process <em>no personal data</em> &mdash; no
+					names, emails, IP addresses or cross-session identifiers &mdash; so most of what GDPR
+					governs simply does not arise. For the aggregate counts we keep, the basis is our
+					legitimate interest in knowing whether the site works and is found.</li>
+				<li><strong>Where it lives:</strong> on our own server (a virtual machine currently hosted
+					in the United States), never with a third-party analytics company.</li>
+				<li><strong>No third parties:</strong> the analytics are self-hosted; nothing is shared
+					with, sold to, or processed by anyone else.</li>
+				<li><strong>Your rights:</strong> access, correction and deletion of <em>personal</em> data
+					are trivial for us to honour &mdash; we hold none. You can stop even the anonymous
+					counting any time via Do Not Track or the opt-out above.</li>
+			</ul>
+			<p>
+				If there is something here we could do better, please tell us &mdash; genuinely.
+				<a href="mailto:team@pdoom1.com" style="color: var(--accent-primary);">team@pdoom1.com</a>
+				or the issue tracker.
 			</p>
 		</section>
 


### PR DESCRIPTION
This window's decided items (palette pass deliberately held for your eyeballs).

## Feedback — email-primary, GitHub fallback
`public/bug-submit.php` mails reports to team@pdoom1.com; anyone can report privately, no GitHub account needed. Safe by construction:
- **Recipient hardcoded** — never user input, so it can't be an open relay to spam others.
- **All mail headers constant, user text in body only** — email-header injection is structurally impossible.
- Honeypot + 3s time-trap + 30s/IP throttle; `From:` is @pdoom1.com (SPF-clean on DreamHost).
- Form POSTs to it first, **falls through to the prefilled GitHub issue on any failure** — a report is never lost. Optional email reintroduced (safe now: private sink; never enters the public GitHub fallback).
- ⚠️ **Needs a prod smoke-test** after deploy (no PHP locally): submit one report, confirm it lands in team@.

## GDPR — Tier 1
Stopped *asserting* compliance, started *stating the facts* that make it true. New "honest legal bit" section: legal basis (no personal data → most of GDPR doesn't arise), data location (self-hosted VM, currently US), no third parties, user rights, real contact. Framed as a small volunteer non-commercial project doing right by people.

## PR #102 closed
Made /metrics public + nav-linked (against the "private for now" call) and conflicted with the nav rewrite. Closed with a note; honest copy will be reused when we build a public metrics page from the git snapshots.

Verified: JS parses, PHP structure sound (balanced, hardcoded recipient, constant headers), privacy sections balanced, prose diff is only the intended changes.