### PR TITLE
Launch day: honest per-platform downloads, clean-slate leaderboard, campaign centre

### DIFF
--- a/content/campaigns/2026-07-24-alpha-launch.json
+++ b/content/campaigns/2026-07-24-alpha-launch.json
@@ -1,0 +1,38 @@
+{
+  "_README": "DRAFT COPY - rewrite freely, it should sound like you, not like a tool. Nothing is posted by any automation from this file; you post by hand today. Set posted[platform] to an ISO timestamp as each goes out, then commit. Check every link keeps its own platform's utm_source before posting.",
+
+  "campaign": "alpha-launch-2026-07-24",
+  "title": "p(Doom)1 friends-and-family alpha",
+  "url": "https://pdoom1.com/",
+  "approved": false,
+
+  "_facts_this_copy_must_not_break": [
+    "Windows and macOS builds ship today; Linux is coming within a week - say so, do not imply Linux now.",
+    "This is an early alpha. Promise rough edges, not polish.",
+    "Do NOT point anyone at the in-game F8 bug reporter: it does not transmit (pdoom1 #800).",
+    "Do NOT promise leaderboards or scores - remote submission is not live yet (pdoom1 #735).",
+    "The game is free and open source, and non-commercial."
+  ],
+
+  "copy": {
+    "linkedin": "I've been building a game about AI safety, and it's finally in a state where I can hand it to people.\n\np(Doom)1 puts you in charge of an AI safety lab. You hire researchers, chase funding, manage compute, and try to reduce the probability of catastrophe — mostly through meetings, budgets and paperwork. The bureaucracy is the game.\n\nThis is an early alpha, built solo. It is rough in places and that is the point of releasing it now: I want to know where it is confusing, where it drags, and where it is actually fun.\n\nWindows and macOS today. Linux within the week.\n\nFree, open source, non-commercial.\n\nhttps://pdoom1.com/?utm_source=linkedin&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
+
+    "facebook": "Okay — the thing I've been quietly working on is playable.\n\np(Doom)1 is a strategy game where you run an AI safety lab: hiring, funding, compute, and a lot of bureaucracy standing between you and saving the world.\n\nIt's an early alpha, so expect rough edges. I would genuinely love for you to play it badly and then tell me exactly what confused you — that's more useful to me right now than praise.\n\nWindows and Mac today, Linux next week. Free, no catch.\n\nhttps://pdoom1.com/?utm_source=facebook&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
+
+    "twitter": "p(Doom)1 is playable.\n\nRun an AI safety lab. Hire researchers, chase funding, fight the bureaucracy, try to lower p(doom).\n\nEarly alpha — rough, solo-built, free. Windows + macOS today, Linux next week.\n\nTell me what confuses you.\n\nhttps://pdoom1.com/?utm_source=twitter&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
+
+    "bluesky": "p(Doom)1 is playable.\n\nRun an AI safety lab: hiring, funding, compute, and a lot of bureaucracy between you and saving the world.\n\nEarly alpha — rough, free. Windows + macOS today, Linux next week.\n\nTell me what confuses you.\n\nhttps://pdoom1.com/?utm_source=bluesky&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
+
+    "instagram": "p(Doom)1 — an early alpha, out today.\n\nYou run an AI safety lab. Hiring, funding, compute, and a great deal of bureaucracy between you and saving the world.\n\nSolo-built, free, open source. Windows + macOS now, Linux next week.\n\nIt's rough. That's why I want you to play it and tell me what didn't make sense.\n\nLink in bio.\n\n#gamedev #indiedev #aisafety #strategygame #pixelart",
+
+    "_instagram_bio_link": "https://pdoom1.com/?utm_source=instagram&utm_medium=social&utm_campaign=alpha-launch-2026-07-24"
+  },
+
+  "posted": {
+    "linkedin": null,
+    "facebook": null,
+    "twitter": null,
+    "bluesky": null,
+    "instagram": null
+  }
+}

--- a/content/campaigns/2026-07-24-alpha-launch.json
+++ b/content/campaigns/2026-07-24-alpha-launch.json
@@ -1,11 +1,9 @@
 {
   "_README": "DRAFT COPY - rewrite freely, it should sound like you, not like a tool. Nothing is posted by any automation from this file; you post by hand today. Set posted[platform] to an ISO timestamp as each goes out, then commit. Check every link keeps its own platform's utm_source before posting.",
-
   "campaign": "alpha-launch-2026-07-24",
   "title": "p(Doom)1 friends-and-family alpha",
   "url": "https://pdoom1.com/",
   "approved": false,
-
   "_facts_this_copy_must_not_break": [
     "Windows and macOS builds ship today; Linux is coming within a week - say so, do not imply Linux now.",
     "This is an early alpha. Promise rough edges, not polish.",
@@ -13,21 +11,14 @@
     "Do NOT promise leaderboards or scores - remote submission is not live yet (pdoom1 #735).",
     "The game is free and open source, and non-commercial."
   ],
-
   "copy": {
     "linkedin": "I've been building a game about AI safety, and it's finally in a state where I can hand it to people.\n\np(Doom)1 puts you in charge of an AI safety lab. You hire researchers, chase funding, manage compute, and try to reduce the probability of catastrophe — mostly through meetings, budgets and paperwork. The bureaucracy is the game.\n\nThis is an early alpha, built solo. It is rough in places and that is the point of releasing it now: I want to know where it is confusing, where it drags, and where it is actually fun.\n\nWindows and macOS today. Linux within the week.\n\nFree, open source, non-commercial.\n\nhttps://pdoom1.com/?utm_source=linkedin&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
-
     "facebook": "Okay — the thing I've been quietly working on is playable.\n\np(Doom)1 is a strategy game where you run an AI safety lab: hiring, funding, compute, and a lot of bureaucracy standing between you and saving the world.\n\nIt's an early alpha, so expect rough edges. I would genuinely love for you to play it badly and then tell me exactly what confused you — that's more useful to me right now than praise.\n\nWindows and Mac today, Linux next week. Free, no catch.\n\nhttps://pdoom1.com/?utm_source=facebook&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
-
     "twitter": "p(Doom)1 is playable.\n\nRun an AI safety lab. Hire researchers, chase funding, fight the bureaucracy, try to lower p(doom).\n\nEarly alpha — rough, solo-built, free. Windows + macOS today, Linux next week.\n\nTell me what confuses you.\n\nhttps://pdoom1.com/?utm_source=twitter&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
-
-    "bluesky": "p(Doom)1 is playable.\n\nRun an AI safety lab: hiring, funding, compute, and a lot of bureaucracy between you and saving the world.\n\nEarly alpha — rough, free. Windows + macOS today, Linux next week.\n\nTell me what confuses you.\n\nhttps://pdoom1.com/?utm_source=bluesky&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
-
+    "bluesky": "p(Doom)1 is playable.\n\nRun an AI safety lab: hiring, funding, compute, and a great deal of bureaucracy.\n\nEarly alpha — rough, free. Windows + macOS today, Linux next week.\n\nTell me what confuses you.\n\nhttps://pdoom1.com/?utm_source=bluesky&utm_medium=social&utm_campaign=alpha-launch-2026-07-24",
     "instagram": "p(Doom)1 — an early alpha, out today.\n\nYou run an AI safety lab. Hiring, funding, compute, and a great deal of bureaucracy between you and saving the world.\n\nSolo-built, free, open source. Windows + macOS now, Linux next week.\n\nIt's rough. That's why I want you to play it and tell me what didn't make sense.\n\nLink in bio.\n\n#gamedev #indiedev #aisafety #strategygame #pixelart",
-
     "_instagram_bio_link": "https://pdoom1.com/?utm_source=instagram&utm_medium=social&utm_campaign=alpha-launch-2026-07-24"
   },
-
   "posted": {
     "linkedin": null,
     "facebook": null,

--- a/content/campaigns/README.md
+++ b/content/campaigns/README.md
@@ -1,0 +1,112 @@
+# Campaigns — the publication coordination centre
+
+A **campaign** is a coordinated push that is *not* a blog post: a launch, a
+trailer drop, a milestone. Blog posts already have a pipeline
+(`.github/workflows/syndicate-content.yml` → `content/syndication/<slug>.json`);
+this directory is the same idea for everything else.
+
+It inherits that pipeline's governing rule, and so should you:
+
+> **INBOUND AUTOMATED, OUTBOUND HUMAN-GATED.**
+> Syncing content into the site is automatic. Publishing words out into the
+> world is a decision a person makes.
+
+Because a campaign is a committed file, git history is the audit trail of what
+went out, where, and when.
+
+---
+
+## 1. The UTM convention (agree this BEFORE posting anything)
+
+This is the one part with a hard deadline. Plausible groups traffic by
+`utm_source` / `utm_medium` / `utm_campaign`, and `public/index.html`
+(`attributionProps()`) copies them onto the **Download** event — the download
+button leaves for github.com, so that click is the *only* place a download can
+ever be joined to the channel that produced it.
+
+**Post a link without UTMs and that attribution is gone permanently.** There is
+no way to reconstruct it afterwards.
+
+| param | value | notes |
+|---|---|---|
+| `utm_source` | `linkedin` `facebook` `twitter` `bluesky` `instagram` | lowercase, no spaces, stable forever — these become your analytics groupings |
+| `utm_medium` | `social` | use `email` / `forum` / `press` when those apply |
+| `utm_campaign` | `alpha-launch-2026-07-24` | one slug per campaign, reused across every platform in it |
+
+Canonical form:
+
+```
+https://pdoom1.com/?utm_source=bluesky&utm_medium=social&utm_campaign=alpha-launch-2026-07-24
+```
+
+**Rules that keep the data clean:**
+
+- Never reuse a `utm_source` value with different spelling (`twitter` vs `x` vs
+  `Twitter` become three separate rows that never re-merge).
+- Link to **`https://pdoom1.com/`**, not directly to the GitHub release. A
+  direct GitHub link bypasses the site, so the visit is invisible to analytics
+  *and* the download is unattributable. The site's buttons resolve to the right
+  per-platform asset anyway.
+- Instagram has no clickable link in post captions — put the UTM'd link in the
+  **profile bio** and say "link in bio". Use `utm_source=instagram` there so bio
+  clicks are still counted.
+
+---
+
+## 2. File format
+
+One JSON file per campaign, named `YYYY-MM-DD-slug.json`. Same shape as a
+syndication draft, so the existing publisher can consume it later without
+rework:
+
+```jsonc
+{
+  "campaign": "alpha-launch-2026-07-24",  // matches utm_campaign exactly
+  "title": "...",
+  "url": "https://pdoom1.com/",           // base URL, before UTMs
+  "approved": false,                       // nothing goes out until a human sets true
+  "copy":   { "<platform>": "..." },       // exact text to post
+  "posted": { "<platform>": null }         // ISO timestamp once posted; null = not yet
+}
+```
+
+`approved: false` and `posted: null` are the safety interlocks. Fill `posted`
+in as you go — it is your checklist *and* the record.
+
+---
+
+## 3. Running a campaign
+
+1. Draft copy in the JSON. Edit freely — it is your voice, not the tool's.
+2. Check every link carries the UTM triple for **its own** platform.
+3. Post. Work down the platforms, stamping `posted` as each goes out.
+4. Log what comes back in `feedback-intake.md` — see §4.
+5. Commit the file. The diff is the audit trail.
+
+**Post in slowest-feedback-first order.** LinkedIn and Facebook keep showing a
+post for hours or days; Twitter and Bluesky are near-realtime and mostly dead
+within the hour. Posting the slow ones first means they are accumulating reach
+while you handle the fast ones, and it staggers the replies you have to answer.
+
+---
+
+## 4. Collecting feedback (the half that usually gets dropped)
+
+Feedback will arrive across at least five surfaces, none of which talk to each
+other: social replies and DMs on each platform, the website form, direct texts
+and calls, and GitHub. Without one intake point, the quiet-but-important report
+is the one that gets lost.
+
+`feedback-intake.md` is that point. Append one line per item, from wherever you
+are. It is deliberately plain text so it costs nothing to add to on a phone.
+
+**Two things to know about today's channels:**
+
+- **The in-game F8 bug reporter does not transmit** (pdoom1 issue #800). It
+  writes to the tester's own disk and then tells them a report was filed. Do
+  not point anyone at it until that ships a fix — direct people to
+  `https://pdoom1.com/bug-report/` or a plain reply instead.
+- **The website form is fail-silent to you.** If DreamHost's PHP `mail()` drops
+  a message, the sender sees success and you never learn it existed. Smoke-test
+  it before you announce (`docs/GLIDEPATH.md` §7), and if the day looks
+  suspiciously quiet, suspect the pipe before concluding nobody cared.

--- a/content/campaigns/feedback-intake.md
+++ b/content/campaigns/feedback-intake.md
@@ -1,0 +1,54 @@
+# Feedback intake
+
+One line per piece of feedback, from any channel. Append as it arrives — the
+point is that nothing gets lost between five platforms that don't talk to each
+other. Terse is fine. Raw quotes beat your summary of them.
+
+**Format:** `| date | who | channel | verbatim-ish | action |`
+
+Channels: `linkedin` `facebook` `twitter` `bluesky` `instagram` `web-form`
+`direct` (text/call/in-person) `github`
+
+Actions: `triaged #<issue>` · `needs-repro` · `wontfix` · `duplicate` · `—`
+
+> Keep the wording people actually used. "I didn't know what to click" and
+> "the UI is confusing" point at different fixes, and the second is usually
+> your paraphrase of the first.
+
+---
+
+## 2026-07-24 — alpha launch
+
+| date | who | channel | what they said | action |
+|---|---|---|---|---|
+|  |  |  |  |  |
+
+---
+
+## Patterns worth watching for
+
+Not every report is what it says it is. A few known confusions for this launch:
+
+- **"It won't open" on macOS** → almost certainly Gatekeeper refusing an
+  un-notarised build, not a crash. The site now carries the right-click→Open
+  workaround, but people who downloaded before reading it will report a broken
+  download.
+- **"I filed a bug in the game"** → it did not reach you (pdoom1 #800). Ask
+  them to resend via the website form or just paste it to you directly.
+- **"My score didn't show up"** → expected; remote score submission is not live
+  (pdoom1 #735). Not a bug on their end, and worth saying so quickly so they
+  don't think they broke something.
+- **Silence from a whole platform** → check the link you posted actually
+  carried its UTM and resolves. A dead or unattributed link looks exactly like
+  disinterest.
+
+## Triage, end of day
+
+Three buckets, in this order:
+
+1. **Blocks play** — they could not start, or could not finish a run. Fix first,
+   these people are gone otherwise.
+2. **Confused, kept playing** — onboarding and legibility. This is the most
+   valuable category at alpha and the easiest to dismiss.
+3. **Wants / opinions** — feature requests and balance takes. Log, do not act
+   on yet; they need many data points before they mean anything.

--- a/content/campaigns/feedback-intake.md
+++ b/content/campaigns/feedback-intake.md
@@ -21,7 +21,22 @@ Actions: `triaged #<issue>` · `needs-repro` · `wontfix` · `duplicate` · `—
 
 | date | who | channel | what they said | action |
 |---|---|---|---|---|
-|  |  |  |  |  |
+| 2026-07-24 03:03 UTC | Helpful Stranger (pip.f.temp@) | web-form | Smoke test. Confirms the form → team@pdoom1.com path **works**. | — (channel verified) |
+| 2026-07-24 03:03 UTC | Helpful Stranger | web-form | "this event system probably needs some love and at least one human eyeball involved in the system that reviews and promotes it, just like the system that y'all have for doing art assets in game. Pip would love to spend a month manually reviewing AI papers" | needs-issue — see below |
+| 2026-07-24 03:03 UTC | (surfaced by above) | web-form | Reporter attached `Screenshot 2026-07-15 161002.png` (201,249 bytes). The file was **not forwarded** — only its name reached us, and the reporter was shown "Report Submitted!" with no indication. | fixed on `launch/2026-07-24-alpha` |
+
+### On the event-curation point
+
+Read past the joke and it lands on a real gap. The events pipeline
+(pdoom-data → `sync-events.py` → ~2,194 generated pages) has **no human review or
+promotion stage**. The art asset pipeline does. ADR-0016 assumes one — its monthly
+cycle is *"collect real-world events, suggestions on papers etc → author a
+world-update pack"* — and "author" is the step that does not exist as tooling.
+
+The sarcasm carries the actual argument: nobody will hand-review a month of AI
+papers, so an unreviewed firehose is the default outcome unless something makes
+curation cheap. Worth an issue against the monthly world-update cadence, not a
+launch-day fix.
 
 ---
 

--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -287,8 +287,10 @@
 	<main id="main-content" role="main">
 		<h1>Report a Bug</h1>
 		<p class="intro">
-			Found a bug or need help? Report issues directly through our GitHub integration. 
-			You can attach log files, screenshots, or config files to help us debug faster.
+			Found a bug or need help? Report issues directly through our GitHub integration.
+			Please describe the problem in words &mdash; the email we receive carries your
+			text, but <strong>not</strong> an attached file. If you pick one, we are told its
+			name so we know to ask you for it.
 		</p>
 
 		<div class="form-container">
@@ -343,11 +345,11 @@
 				</div>
 
 				<div class="form-group">
-					<label for="bug-attachment">Attach Log/File (Optional)</label>
-					<input type="file" id="bug-attachment" name="attachment" 
+					<label for="bug-attachment">Name a File (Optional)</label>
+					<input type="file" id="bug-attachment" name="attachment"
 						   accept=".txt,.log,.json,.zip,.png,.jpg,.jpeg"
 						   aria-describedby="attachment-help attachment-error">
-					<div id="attachment-help" class="form-help">Upload logs, screenshots, or config files (max 500 KB). Supported: .txt, .log, .json, .zip, .png, .jpg</div>
+					<div id="attachment-help" class="form-help"><strong>The file itself is not sent to us</strong> &mdash; only its name and size, so we know to ask. To get a screenshot or log to us directly, mention it below and we will reply, or file on GitHub where you can attach it. (max 500 KB. Supported: .txt, .log, .json, .zip, .png, .jpg)</div>
 					<div id="attachment-error" class="error-message" role="alert" aria-live="polite"></div>
 				</div>
 
@@ -479,6 +481,25 @@
 				if (submitted) {
 					button.textContent = '[OK] Report Submitted!';
 					button.style.background = 'var(--success-color)';
+					// bug-submit.php forwards the attachment's NAME and SIZE, never its
+					// bytes. A reporter who picked a screenshot has just been shown a
+					// success state, and without this would reasonably believe we now
+					// hold the image. Say plainly that we do not, while the report is
+					// still fresh enough for them to act on it.
+					if (bugData.attachment && bugData.attachment.filename) {
+						let an = document.getElementById('bug-attach-note');
+						if (!an) {
+							an = document.createElement('p');
+							an.id = 'bug-attach-note';
+							an.style.cssText = 'margin-top:0.8rem; font-size:0.9rem; color: var(--text-secondary);';
+							button.insertAdjacentElement('afterend', an);
+						}
+						an.innerHTML = 'Your description reached us &mdash; but <strong>"' +
+							bugData.attachment.filename.replace(/[<>&]/g, '') +
+							'" did not.</strong> We only received its name. If the file matters, ' +
+							'reply to us at <a href="mailto:team@pdoom1.com" style="color: var(--accent-primary);">team@pdoom1.com</a> ' +
+							'with it attached, or <a href="' + ghUrl + '" target="_blank" rel="noopener" style="color: var(--accent-primary);">file it on GitHub &rarr;</a> where you can upload it.';
+					}
 					setTimeout(() => { button.textContent = originalText; button.style.background = ''; e.target.reset(); button.disabled = false; }, 3000);
 				} else {
 					window.open(ghUrl, '_blank', 'noopener');

--- a/public/index.html
+++ b/public/index.html
@@ -888,16 +888,26 @@ t	.hero {
 			<div class="download-ctas" style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.4rem;">
 				<!-- hrefs default to the release PAGE (never 404s on any asset naming);
 				     resolveDownloads() upgrades them to direct per-platform asset URLs. -->
-				<a id="download-windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<a id="download-windows" data-platform-label="Windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Windows
 				</a>
-				<a id="download-macos" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<a id="download-macos" data-platform-label="macOS" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for macOS
 				</a>
-				<a id="download-linux" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
+				<a id="download-linux" data-platform-label="Linux" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Linux
 				</a>
 			</div>
+
+			<!-- Shown by resolveDownloads() only when a macOS build actually resolved.
+			     An unsigned/un-notarised Godot .app is refused by Gatekeeper on first
+			     open with "the developer cannot be verified", which reads as a broken
+			     download; most testers bounce silently rather than report it. -->
+			<p id="macos-gatekeeper-note" style="display: none; text-align: center; margin: 0 auto 0.6rem; max-width: 46rem; font-size: 0.8rem; color: var(--text-secondary); line-height: 1.5;">
+				<strong>On macOS:</strong> the first launch is blocked because the build isn't
+				Apple-notarised yet. Right-click (or Control-click) the app and choose
+				<strong>Open</strong>, then confirm — you only need to do this once.
+			</p>
 
 			<div style="text-align: center; margin-bottom: 0.8rem;">
 				<a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-secondary); text-decoration: none; font-size: 0.9rem;">
@@ -1570,16 +1580,55 @@ t	.hero {
 				'download-linux': /linux|x86_64|\.appimage/i
 			};
 			const isBuild = /\.(zip|dmg|appimage|x86_64|exe|tar\.gz)$/i;
+
+			// A platform with no build in the latest release must SAY so. Leaving the
+			// release-page baseline in place would send (say) a Linux visitor to a page
+			// carrying only Windows and macOS zips -- a dead end that looks like a
+			// working button. Absence of evidence is not evidence of absence, though:
+			// only degrade when the asset list was actually fetched. On rate-limit or
+			// offline we cannot know what shipped, so every button keeps the baseline.
+			function markUnavailable(el) {
+				if (!el) return;
+				const label = el.dataset.platformLabel || el.textContent.trim();
+				el.removeAttribute('href');
+				el.removeAttribute('target');
+				el.setAttribute('role', 'note');
+				el.setAttribute('aria-disabled', 'true');
+				el.title = label + ' build is not in the current release yet';
+				el.style.opacity = '0.55';
+				el.style.cursor = 'default';
+				el.style.pointerEvents = 'none';
+				el.textContent = label + ' — coming soon';
+			}
+
 			try {
 				const res = await fetch('https://api.github.com/repos/PipFoweraker/pdoom1/releases/latest',
 					{ headers: { 'Accept': 'application/vnd.github+json' } });
 				if (!res.ok) return; // rate-limited/offline -> keep release-page baseline
 				const assets = (await res.json()).assets || [];
-				for (const [id, rx] of Object.entries(platforms)) {
+
+				// Resolve every platform BEFORE mutating anything, so the "we recognised
+				// nothing" case can bail out without having already degraded buttons.
+				const found = Object.entries(platforms).map(([id, rx]) => [
+					id, assets.find(a => rx.test(a.name) && isBuild.test(a.name))
+				]);
+
+				// Zero recognised builds in a release that HAS assets means our filename
+				// guess is wrong, not that nothing shipped. Keep the working baseline
+				// rather than tell every visitor the game is unavailable on every OS.
+				if (!found.some(([, asset]) => asset)) return;
+
+				for (const [id, asset] of found) {
 					const el = document.getElementById(id);
 					if (!el) continue;
-					const asset = assets.find(a => rx.test(a.name) && isBuild.test(a.name));
 					if (asset) el.href = asset.browser_download_url;
+					else markUnavailable(el);
+				}
+				// Show the macOS first-run note only when a macOS build actually resolved.
+				const macNote = document.getElementById('macos-gatekeeper-note');
+				if (macNote) {
+					const macEl = document.getElementById('download-macos');
+					macNote.style.display = (macEl && macEl.hasAttribute('href')) ? 'block' : 'none';
 				}
 			} catch (_) { /* keep baseline */ }
 		}

--- a/public/leaderboard/index.html
+++ b/public/leaderboard/index.html
@@ -816,10 +816,23 @@
       const banner = document.getElementById('data-status-banner');
       if (!banner) return;
       const status = (data && data.data_status) || 'live';
-      if (status === 'live') { banner.style.display = 'none'; return; }
-      const ver = (data.meta && data.meta.game_version) || '';
+      const controls = document.querySelector('.controls-section');
+      if (status === 'live') {
+        banner.style.display = 'none';
+        if (controls) controls.style.display = '';
+        return;
+      }
+      // Pre-launch the board is empty, so the search/sort/filter toolbar only offers
+      // a visitor ways to filter nothing. Hide it and let the banner carry the whole
+      // message; it comes back automatically once real scores publish.
+      if (controls) controls.style.display = 'none';
+
+      // Deliberately names no version. The board is stamped with whatever release last
+      // exported, which drifts behind the live game, and a stale number here reads as a
+      // promise about a specific build. Naming the *condition* instead stays true
+      // whichever release turns submission on.
       banner.innerHTML = (status === 'pre-launch')
-        ? `&#9432; <strong>Leaderboards launch with the next release.</strong> No competitive scores are recorded yet &mdash; the live board (${ver}) arrives when in-game score submission ships.`
+        ? `&#9432; <strong>No scores recorded yet.</strong> The board turns on when in-game score submission ships &mdash; until then this page is a placeholder, not an empty ranking.`
         : `&#9432; <strong>Showing sample / pre-release data</strong> &mdash; not live competitive results.`;
       banner.style.display = 'block';
     }
@@ -1214,9 +1227,20 @@
         if (response.ok) {
           const weekData = await response.json();
           const seedsGroup = document.getElementById('recent-seeds-group');
-          
-          // Add current week's seed
-          if (weekData.seed) {
+
+          // Only offer a week that has not already finished. The rollover cron fires
+          // Sunday 14:00 UTC and derives the week from `now`, so it re-publishes the
+          // week that ends hours later (TECH_DEBT A9) -- current.json therefore keeps
+          // claiming `is_current` for days after the week closed. Trusting that flag
+          // would show a fresh visitor a competition that is already over, so the
+          // end timestamp is the authority here, not the flag. Self-heals the moment
+          // the rollover cadence is fixed; no league logic is changed by this.
+          const endsAt = Date.parse(
+            weekData.week_info?.end_timestamp || weekData.meta?.end_date || ''
+          );
+          const weekStillOpen = Number.isFinite(endsAt) && endsAt > Date.now();
+
+          if (weekData.seed && weekStillOpen) {
             const option = document.createElement('option');
             option.value = weekData.seed;
             option.textContent = `Week ${weekData.meta?.week_id || 'Current'} - ${weekData.seed}`;

--- a/scripts/test-download-resolution.js
+++ b/scripts/test-download-resolution.js
@@ -1,0 +1,81 @@
+// Extracts resolveDownloads() from public/index.html and exercises it against a
+// minimal DOM/fetch shim. Verifies the launch-day contract:
+//   - a platform WITH an asset gets a direct download href
+//   - a platform WITHOUT one says "coming soon" instead of silently pointing at a
+//     release page that has no build for it
+//   - an unreachable API degrades NOTHING (we cannot know what shipped)
+const fs = require('fs');
+const path = require('path');
+const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+
+const m = src.match(/async function resolveDownloads\(\) \{[\s\S]*?\n\t\t\}/);
+if (!m) { console.error('FAIL: could not extract resolveDownloads()'); process.exit(1); }
+
+const BASE = 'https://github.com/PipFoweraker/pdoom1/releases/latest';
+
+function makeEl(id, label) {
+  return {
+    id, dataset: { platformLabel: label }, textContent: 'Download for ' + label,
+    style: {}, _attrs: { href: BASE, target: '_blank' },
+    hasAttribute(k) { return k in this._attrs; },
+    removeAttribute(k) { delete this._attrs[k]; },
+    setAttribute(k, v) { this._attrs[k] = v; },
+    get href() { return this._attrs.href; },
+    set href(v) { this._attrs.href = v; },
+  };
+}
+
+async function run(name, assets, { ok = true } = {}) {
+  const els = {
+    'download-windows': makeEl('download-windows', 'Windows'),
+    'download-macos': makeEl('download-macos', 'macOS'),
+    'download-linux': makeEl('download-linux', 'Linux'),
+    'macos-gatekeeper-note': { id: 'note', style: { display: 'none' } },
+  };
+  const document = { getElementById: (id) => els[id] || null };
+  const fetch = async () => ({ ok, json: async () => ({ assets }) });
+  // The extracted source references bare `document` / `fetch` globals, so inject
+  // them as parameters rather than trying to bind `this`.
+  const fn = new Function('document', 'fetch', 'return ' + m[0])(document, fetch);
+  await fn();
+  return els;
+}
+
+(async () => {
+  let failures = 0;
+  const check = (cond, msg) => { console.log((cond ? '  PASS  ' : '  FAIL  ') + msg); if (!cond) failures++; };
+
+  const A = (n) => ({ name: n, browser_download_url: 'https://gh/' + n });
+
+  // Scenario 1: today's intended shape -- Windows + macOS ship, Linux does not.
+
+  let els = await run('win+mac', [A('PDoom-v0.13.0-windows.zip'), A('PDoom-v0.13.0-macOS.zip')]);
+  console.log('Scenario 1: Windows + macOS assets, no Linux');
+  check(els['download-windows'].href === 'https://gh/PDoom-v0.13.0-windows.zip', 'Windows -> direct asset');
+  check(els['download-macos'].href === 'https://gh/PDoom-v0.13.0-macOS.zip', 'macOS -> direct asset');
+  check(!els['download-linux'].hasAttribute('href'), 'Linux -> href removed (not a dead link)');
+  check(/coming soon/i.test(els['download-linux'].textContent), 'Linux -> says "coming soon"');
+  check(els['macos-gatekeeper-note'].style.display === 'block', 'Gatekeeper note shown (mac resolved)');
+
+  // Scenario 2: Windows only -- the CURRENT v0.12.0 shape. Mac must degrade too.
+  els = await run('win only', [A('PDoom-v0.12.0-windows.zip')]);
+  console.log('Scenario 2: Windows only (current v0.12.0 shape)');
+  check(els['download-windows'].href === 'https://gh/PDoom-v0.12.0-windows.zip', 'Windows -> direct asset');
+  check(!els['download-macos'].hasAttribute('href'), 'macOS -> degraded');
+  check(els['macos-gatekeeper-note'].style.display === 'none', 'Gatekeeper note hidden (no mac build)');
+
+  // Scenario 3: API unreachable -- we know nothing, so change nothing.
+  els = await run('rate limited', [], { ok: false });
+  console.log('Scenario 3: API rate-limited / offline');
+  check(els['download-windows'].href === BASE, 'Windows keeps release-page baseline');
+  check(els['download-linux'].href === BASE, 'Linux keeps baseline (NOT falsely "coming soon")');
+
+  // Scenario 4: assets exist but none match our naming guess -> keep baseline.
+  els = await run('unrecognised', [A('SomethingWeird.bin'), A('checksums.txt')]);
+  console.log('Scenario 4: release has assets, none recognised as builds');
+  check(els['download-windows'].href === BASE, 'Windows keeps baseline');
+  check(els['download-linux'].href === BASE, 'Linux keeps baseline');
+
+  console.log(failures ? `\n${failures} FAILURE(S)` : '\nAll checks passed.');
+  process.exit(failures ? 1 : 0);
+})();


### PR DESCRIPTION
Three launch-day changes, per this morning's decisions: v0.13 today, Windows + macOS shipping with Linux following within the week, and a clean slate for fresh visitors.

## Downloads — the one that most affects a visitor today

`resolveDownloads()` upgraded buttons to direct asset URLs but left a platform with **no** build pointing at the release page. With a Windows+macOS release that sends a Linux visitor to a page carrying no Linux build — a dead end wearing a working button. A platform with no matching asset now degrades to a non-clickable **"Linux — coming soon"**.

The degrade is deliberately conservative:

| situation | behaviour | why |
|---|---|---|
| asset found | direct download URL | unchanged |
| asset list fetched, platform absent | "coming soon", not clickable | evidence of absence |
| API rate-limited / offline | **all** buttons keep the release-page baseline | we cannot know what shipped |
| assets present, none recognised | **all** keep baseline | our filename guess is wrong, not "unavailable on every OS" |

This also means that if the macOS build slips, the macOS button degrades on its own — no code change needed at 4pm.

Adds a **macOS first-run note**, shown only when a macOS build actually resolved. An un-notarised Godot `.app` is refused by Gatekeeper with "the developer cannot be verified", which reads as a broken download; testers bounce silently rather than report it.

## Leaderboard — clean slate

- The seed dropdown was offering week `2026_W29`, which **ended 3.5 days ago**. The rollover cron fires Sunday 14:00 UTC and derives the week from `now`, so it republishes the week that ends hours later (TECH_DEBT A9) and `is_current` stays true for days. The end timestamp is now the authority, not the flag. Self-heals when the cadence is fixed; **no league logic changed.**
- The pre-launch banner named a stale `v0.11.0` and promised "leaderboards launch with the next release" — which today's release would falsify. It now names the condition, not a version.
- The search/sort toolbar hides while the board is empty and returns automatically when real scores publish.

## Campaign centre

`content/campaigns/` — the pipeline for coordinated pushes that are not blog posts, mirroring the syndication draft format so the existing human-gated publisher can consume campaign files later. Nothing posts automatically; `approved` stays `false`.

The urgent part is the **UTM convention**. `attributionProps()` copies `utm_source`/`utm_campaign` onto the Plausible `Download` event, and since the button leaves for github.com that click is the only place a download can ever be joined to its channel. **A link posted without UTMs is unattributable forever.**

Draft per-platform copy included, verified against each platform's character limit (Bluesky counts the full URL; X wraps to 23 via t.co — the first Bluesky draft was 320/300 and would have been rejected at post time).

## Testing

Adds `scripts/test-download-resolution.js`, covering all four resolution cases against a DOM/fetch shim. All pass.

Local suite otherwise unchanged. `test_ingest_scores.py` and `test-header-consistency.js` fail — **verified failing on `main` too**, not introduced here.

## Needs your eye

- **Leaderboard banner wording** is reader-facing prose, and `snapshot-copy.py` cannot see it — the text lives in JS and the guard only extracts static HTML. Worth a read.
- **Campaign copy is draft.** It should sound like you.