### PR TITLE
Follow-up: download version-stamp fix + league seed ledger + L2 cutover runbook

### DIFF
--- a/docs/L2_CUTOVER_RUNBOOK.md
+++ b/docs/L2_CUTOVER_RUNBOOK.md
@@ -1,0 +1,97 @@
+# L2 ladder-epoch cutover — runbook
+
+Executable steps for moving the league from the L1 epoch (`(seed, v0.12.0)`
+weekly board) to the L2 epoch, per issue #151. Written on launch day
+(2026-07-24) so the cutover is a checklist, not a scramble at 3pm.
+
+**Blessed seed (from `docs/LEAGUE_SEED_LEDGER.md`):** `league_2026-07_7d6ced29`
+**New L2 board file:** `board_league_2026-07_7d6ced29__L2.json`
+**Legacy L1 board file:** `board_weekly-2026-w0__L1.json`
+
+---
+
+## Status of each step
+
+| # | step | side | state |
+|---|---|---|---|
+| 1 | Preserve L1 board as legacy | VPS (Pip) | **ready** — command below |
+| 2 | Confirm score API accepts the new `(seed, L2)` key | VPS/API | **BLOCKED** — needs the exact key string the v0.13 client POSTs |
+| 3 | Point website display at the L2 board | website | **contingent** — depends on step 2 + issue #735 |
+| 4 | Verify | website | **ready** — checks below |
+
+The two BLOCKED/contingent items hang on the follow-up you owe issue #151 (the
+exact board-key string once the v0.13 version-split lands) and on the answer to
+issue #735 (does v0.13 actually submit scores remotely). Nothing here fabricates
+those — the steps that can't be pinned down yet say so.
+
+---
+
+## Step 1 — preserve the L1 board (VPS, run as Pip)
+
+The live v0.12.0 board holds tonight's real friends-and-family tester scores.
+Copy it to the legacy key BEFORE any v0.13 client posts, so those scores survive
+as "legacy epoch L1". This runs on DreamCompute, not from this repo:
+
+```bash
+ssh -i ~/.ssh/pdoom-website-instance.pem ubuntu@208.113.200.215
+# on the VPS, in the score API DATA_DIR (confirm the path):
+cp -n board_weekly-2026-w0__v0.12.0.json board_weekly-2026-w0__L1.json
+ls -la board_weekly-2026-w0__*.json    # confirm both exist, same size
+```
+
+`-n` (no-clobber) so re-running never overwrites the legacy copy. The original
+keeps its seed string so the provenance of those scores stays legible.
+
+## Step 2 — confirm the API accepts the L2 key  [BLOCKED]
+
+The board key is client-supplied and the store is flat-file, so a new key should
+auto-create on first POST — but confirm no version allowlist rejects it. **This
+needs the exact key string the v0.13 build POSTs**, which lands with the #151
+follow-up. When known, a read of the (empty) new board is the cheap check:
+
+```bash
+# TEMPLATE — fill <API_BASE> and the exact key once known:
+curl -s "<API_BASE>/board?seed=league_2026-07_7d6ced29&ladder=L2" -o /dev/null -w "%{http_code}\n"
+# 200 (empty board) or a clean 404-that-will-autocreate = OK; a 4xx rejecting
+# the key = an allowlist to fix before the cutover.
+```
+
+## Step 3 — point the website display at L2  [contingent on #735]
+
+How the L2 board reaches the site depends on the answer to #735:
+
+- **If v0.13 submits scores remotely:** the site must ingest the L2 board. Today
+  `scripts/ingest_scores.py` aggregates local seed files into
+  `public/leaderboard/data/leaderboard.json` and stamps `meta.game_version` from
+  `public/data/version.json`, self-healing `data_status` to `"live"` once real
+  deployed-version scores appear. Wiring the L2 remote board into that ingest is
+  the work; it is **not built yet** (see `docs/GAME_UPLIFT_PLAN.md`).
+- **If v0.13 does NOT yet submit remotely:** nothing to point at. The leaderboard
+  stays on the honest pre-launch banner shipped in PR #155 (no scores recorded
+  yet), which is correct and needs no change. Leave the board out of the launch
+  posts.
+
+Either way the site is already honest; this step only adds real data when there
+is real data. **Do not stand up a second score store** (pdoom1 #679: the website
+is a read-only consumer of the one PHP score API).
+
+## Step 4 — verify
+
+```bash
+# blessed seed still derives correctly (guards against an edited ledger):
+python tools/derive_league_seed.py 2026-07     # -> league_2026-07_7d6ced29
+
+# leaderboard page is honest right now (pre-launch banner, empty toolbar hidden):
+curl -s https://pdoom1.com/leaderboard/ | grep -c "No scores recorded yet"   # >=1
+
+# if/when a live board publishes, validate it before trusting it:
+python scripts/validate_data.py
+```
+
+---
+
+## Straggler note (from #151)
+
+Old v0.12.0 clients keep posting to the L1 board after the copy. Pip is fine
+treating them as legacy — they stay on L1; the v0.13 build posts to L2. No action
+needed unless a cleaner cutover is wanted.

--- a/docs/LEAGUE_SEED_LEDGER.md
+++ b/docs/LEAGUE_SEED_LEDGER.md
@@ -1,0 +1,36 @@
+# League seed ledger
+
+The authoritative, human-readable record of which competitive seed governs which
+league epoch — when it was blessed, and by whom. A "blessing" is Pip's explicit
+sign-off that a seed is the real one for an epoch; nothing else makes a seed
+canonical.
+
+Per ADR-0016 (league metabolism) the cycle is **monthly**, one baseline seed per
+month. The seed is derived deterministically so future months need no invention,
+only a blessing:
+
+```
+seed = "league_" + <YYYY-MM> + "_" + sha256("pdoom1_league_" + <YYYY-MM> + "_" + <ladder>).hexdigest()[:8]
+```
+
+Deriving a value is not the same as blessing it. A derived-but-unblessed seed is
+a proposal; only a row in this table with a blessing date is canonical.
+
+| epoch | month | seed | ladder | blessed (UTC) | by | notes |
+|---|---|---|---|---|---|---|
+| L2 | 2026-07 | `league_2026-07_7d6ced29` | L2 | 2026-07-24 | Pip | **First seed blessing.** Opens the L2 ladder epoch cut (issue #151), replacing the `(seed, v0.12.0)` weekly board. Legacy L1 board preserved as `board_weekly-2026-w0__L1.json`. |
+
+## Legacy / superseded
+
+- **L1 epoch** ran on the `(seed, game_version)` weekly key through v0.12.0. Its
+  live board (`board_weekly-2026-w0__v0.12.0.json` on the DreamCompute DATA_DIR)
+  is preserved at the L2 cutover as `board_weekly-2026-w0__L1.json` so real
+  tester scores from the friends-and-family alpha survive as "legacy epoch L1".
+  See `docs/L2_CUTOVER_RUNBOOK.md`.
+
+## How to add a row
+
+1. Derive the seed for the month (`tools/derive_league_seed.py <YYYY-MM> [ladder]`).
+2. Get Pip's explicit blessing — do not backfill a blessing you assumed.
+3. Add the row with the real UTC date. Never edit a past row's seed; a corrected
+   seed is a new epoch, not a rewrite of history.

--- a/public/index.html
+++ b/public/index.html
@@ -1642,13 +1642,17 @@ t	.hero {
 
 		// Track download button clicks with Plausible Analytics
 		function setupDownloadTracking() {
-			// Get current version from version.json (loaded by loadVersionInfo)
-			let currentVersion = 'v0.11.0'; // Default fallback
-
-			// Try to extract version from button text or use default
-			const versionMatch = document.querySelector('.version-number')?.textContent;
-			if (versionMatch) {
-				currentVersion = versionMatch.trim();
+			// Resolve the version at CLICK time from loadVersionInfo's authoritative
+			// read of version.json (window.pdoomGameVersion). The old code captured it
+			// once at setup time off the .version-number span -- but that span still
+			// holds its hardcoded default then, because loadVersionInfo's async fetch
+			// has not resolved yet. The result was every Download event stamped with
+			// the stale literal regardless of the real release. Reading at click time
+			// (seconds later, after the fetch) fixes the race; 'unknown' rather than a
+			// version literal is the fallback, so a failed lookup never fabricates a
+			// version in the analytics.
+			function currentVersion() {
+				return window.pdoomGameVersion || 'unknown';
 			}
 
 			// The download buttons point at github.com, so the click leaves our
@@ -1688,7 +1692,7 @@ t	.hero {
 					if (window.plausible) {
 						plausible('Download', {
 							props: Object.assign({
-								version: currentVersion,
+								version: currentVersion(),
 								platform: target.platform,
 								file: target.file
 							}, attributionProps())
@@ -1825,6 +1829,11 @@ t	.hero {
 
 			if (data.latest_release) {
 				const version = data.latest_release.version;
+				// Authoritative deployed version, published for the download tracker to
+				// stamp on its event. version.json is the real source; the tracker must
+				// NOT fall back to a hardcoded literal (a stale stamp is a quiet lie in
+				// the analytics), so it reads this or reports 'unknown'.
+				window.pdoomGameVersion = version;
 				const publishedDate = new Date(data.latest_release.published_at);
 				const formattedDate = publishedDate.toISOString().split('T')[0];
 

--- a/tools/derive_league_seed.py
+++ b/tools/derive_league_seed.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Derive the deterministic league seed for a month (ADR-0016 monthly cadence).
+
+    python tools/derive_league_seed.py 2026-07        # -> league_2026-07_7d6ced29 (L2)
+    python tools/derive_league_seed.py 2026-08 L2
+
+Deriving is not blessing. The output is a PROPOSAL until Pip signs off and it is
+recorded in docs/LEAGUE_SEED_LEDGER.md. See that file for the rule.
+"""
+import sys
+import hashlib
+import re
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+
+def derive(month: str, ladder: str = "L2") -> str:
+    if not re.fullmatch(r"\d{4}-\d{2}", month):
+        raise ValueError(f"month must be YYYY-MM, got {month!r}")
+    base = f"pdoom1_league_{month}_{ladder}"
+    return f"league_{month}_{hashlib.sha256(base.encode()).hexdigest()[:8]}"
+
+
+def main(argv):
+    if not (2 <= len(argv) <= 3):
+        print(__doc__)
+        return 2
+    month = argv[1]
+    ladder = argv[2] if len(argv) == 3 else "L2"
+    seed = derive(month, ladder)
+    print(seed)
+    print(f"  board file: board_{seed}__{ladder}.json", file=sys.stderr)
+    print("  (proposal until blessed + recorded in docs/LEAGUE_SEED_LEDGER.md)",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Non-launch-critical prep done while you were out. Nothing here touched prod — it is all on this branch for your review. Three things:

## 1. Download events were being stamped with the wrong version (real fix)

`setupDownloadTracking()` captured `currentVersion` **once at setup time** by reading the `.version-number` span — but that span still holds its hardcoded `v0.11.0` default at that moment, because `loadVersionInfo()`'s async fetch of `version.json` has not resolved when setup runs synchronously on the same `DOMContentLoaded`. Net effect: **every** Download event was stamped `v0.11.0` regardless of the real release. On launch day that mislabels the whole day's downloads.

Fix: `loadVersionInfo()` publishes the authoritative version as `window.pdoomGameVersion`, and the click handler reads it **at click time** (seconds after load, after the fetch resolves). Fallback is `unknown`, never a version literal — a fallback literal is a quiet lie in the data. Visitor-facing prose untouched.

Verified with a DOM/plausible shim: a version set *after* setup still lands on the event (proves click-time read), and a missing `version.json` yields `unknown`.

## 2. League seed ledger — the first blessing

`docs/LEAGUE_SEED_LEDGER.md` records it: the **L2 epoch runs on `league_2026-07_7d6ced29`, blessed 2026-07-24**. First-ever seed blessing. The ledger is the canonical record of which seed governs which epoch; a derived seed is only a proposal until it has a blessing row.

`tools/derive_league_seed.py` reproduces any month's seed deterministically (ADR-0016 monthly cadence) — verified that `2026-07` derives to `...7d6ced29`, the blessed value.

## 3. L2 cutover runbook

`docs/L2_CUTOVER_RUNBOOK.md` — an executable checklist for the #151 cutover, **honest about the two steps still blocked**: the exact board key the v0.13 client POSTs (your #151 follow-up) and whether v0.13 submits remotely at all (#735). The steps that can't be pinned down yet say so rather than guessing. The site is already honest either way — the runbook only adds real data when there is real data.

## Not included (your calls, flagged earlier)

- The six stale issues from GLIDEPATH §3 — not closing without your go.
- Social copy stays draft (`approved: false`).
- The visible `#versionNumber` span still defaults to `v0.11.0` if `version.json` fails — reader-facing, so left for copy review rather than changed unattended.
