### PR TITLE
Fix two broken promises, credit opt-in on bug form, hide orphaned pages

### DIFF
--- a/docs/ORPHANED_PAGES_TODO.md
+++ b/docs/ORPHANED_PAGES_TODO.md
@@ -1,0 +1,47 @@
+# Orphaned pages — cleanup TODO
+
+Hidden on **2026-07-24** (launch day) rather than fixed, because launch time was
+better spent on pages visitors could actually reach. **Hidden ≠ deleted** — each
+carries `<meta name="robots" content="noindex, nofollow">` and a `robots.txt`
+`Disallow`. Nothing was removed from `public/`.
+
+Deleting a file from `public/` removes it from production on the next
+`rsync --delete`, and Chesterton's fence applies: these are wired to real data
+pipelines someone may intend to revive. **Decide before deleting.**
+
+## What was hidden, and what's actually wrong with each
+
+| page | inbound links | the problem |
+|---|---|---|
+| `public/league/index.html` | 0 (nav, homepage, sitemap all absent) | Presents a **live** weekly competition: a running countdown (`DAYS HOURS MINUTES SECONDS`) for a week that **ended 5 days ago**, plus visible "Failed to load standings." |
+| `public/league/archive.html` | 0 | Reads `leaderboard/data/weekly/archive/index.json`, whose `last_updated` is **2025-10-31** — nine months stale. Shows "Failed to load archive data." |
+| `public/players/index.html` | 0 | Player profile with all-zero stats and "Failed to load player profile." |
+| `public/changelog/index.html` | 0 | 7 words of visible copy; its `data/changes.json` holds a single entry. |
+| `public/dev-notes/index.html` | 0 | 11 words of visible copy; renders `docs/DEV_NOTES.md` client-side. |
+
+One human path in survives and is intentionally unbroken: `stats/competition.html`
+links to `/league/`. `noindex` stops search engines using these as entry points; it
+does not break that link.
+
+## The decision to make (per page)
+
+For each, pick one:
+
+1. **Revive** — fix the data source, then remove the `noindex` **and** the
+   `robots.txt` `Disallow`, and add it back to `navigation.js`/`sitemap.xml`.
+   The league trio is only worth reviving once scores actually flow (pdoom1 #735)
+   and the rollover cadence is fixed (TECH_DEBT A9) — otherwise it will go stale
+   again the same way.
+2. **Retire** — delete from `public/` (accepting the production removal) and drop
+   the `robots.txt` entries. Check nothing links in first.
+3. **Keep hidden** — fine as a holding state, but revisit; a permanently hidden
+   page is dead weight that still ships in the deploy.
+
+## Related
+
+- The league trio's staleness is **downstream of the weekly rollover off-by-one**
+  (cron fires Sunday 14:00 UTC and derives the week from `now`, so it republishes
+  the week that ends hours later — TECH_DEBT A9). Fixing that is a precondition
+  for reviving them honestly.
+- `docs/L2_CUTOVER_RUNBOOK.md` covers the epoch move that will change what a
+  revived league page should read from.

--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -337,6 +337,26 @@
 					<div id="email-help" class="form-help">Only if you'd like a reply. Sent privately to the team &mdash; never published, never added to a public issue.</div>
 				</div>
 
+				<!-- Credit name. This is the PRIVACY-INVERSE of the email field above:
+				     email is never published, this may be. The two sit next to each
+				     other, so the copy has to make that difference unmissable or someone
+				     will type their real name expecting the email field's promise. -->
+				<div class="form-group">
+					<label for="bug-credit">Name for credit <span style="color:var(--text-muted);font-weight:normal">(optional)</span></label>
+					<input type="text" id="bug-credit" name="credit_name"
+						   placeholder="However you'd like to be credited"
+						   maxlength="80"
+						   autocomplete="nickname"
+						   aria-describedby="credit-help">
+					<div id="credit-help" class="form-help">
+						If you'd like credit for finding this, tell us what to call you &mdash; a
+						first name, a handle, anything. <strong>Unlike your email, this one may be
+						shown publicly</strong> (release notes, credits, or a linked issue).
+						<strong>Leave it blank and you stay anonymous</strong> &mdash; the report is
+						just as welcome either way.
+					</div>
+				</div>
+
 				<!-- Honeypot: off-screen and hidden from people, tempting to bots.
 				     A real submission leaves it empty; a filled one is dropped. -->
 				<div aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden">
@@ -364,7 +384,7 @@
 
 	<footer role="contentinfo">
 		<div class="footer-content">
-			<p>&copy; 2025 pdoom1. Not affiliated with any AI organization. For fun, education, and satire only.</p>
+			<p>&copy; 2026 pdoom1. Not affiliated with any AI organization. For fun, education, and satire only.</p>
 			<p>Privacy: No personal data collected | <a href="/" style="color: var(--accent-primary);">Back to Home</a></p>
 		</div>
 	</footer>
@@ -388,6 +408,7 @@
 					type: formData.get('type') || 'bug',
 					description: formData.get('description'),
 					email: (formData.get('email') || '').trim(),
+					credit_name: (formData.get('credit_name') || '').trim(),
 					hp: formData.get('hp') || '',
 					elapsed_ms: Math.round(performance.now()),
 					source: 'web'

--- a/public/bug-submit.php
+++ b/public/bug-submit.php
@@ -26,6 +26,7 @@ const THROTTLE_S  = 30;                      // seconds between reports per IP
 const MAX_TITLE   = 200;
 const MAX_DESC    = 5000;
 const MAX_EMAIL   = 200;
+const MAX_CREDIT  = 80;                      // name the reporter wants crediting as
 const TYPES       = ['bug', 'feature', 'documentation', 'performance'];
 
 header('Content-Type: application/json; charset=utf-8');
@@ -83,6 +84,10 @@ $desc  = $clean($data['description'] ?? '', MAX_DESC);
 $type  = in_array($data['type'] ?? '', TYPES, true) ? $data['type'] : 'bug';
 $email = $clean($data['email'] ?? '', MAX_EMAIL);
 $email = ($email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL)) ? $email : '';
+// Opt-in credit name. Unlike $email this MAY be published, so it is labelled
+// explicitly in the mail -- whoever writes the release notes must be able to tell
+// at a glance that consent was given, and never mine the Contact line for a name.
+$credit = $clean($data['credit_name'] ?? '', MAX_CREDIT);
 
 if ($title === '' || $desc === '') {
     done(422, ['ok' => false, 'error' => 'A title and description are required.']);
@@ -104,6 +109,9 @@ $body = "New feedback from the pdoom1.com bug form.\n"
       . "Type:    $type\n"
       . "Title:   $title\n"
       . "Contact: " . ($email !== '' ? $email : '(none given)') . "\n"
+      . "Credit:  " . ($credit !== ''
+            ? $credit . '  <-- OK to credit publicly (reporter opted in)'
+            : '(anonymous -- do NOT name this reporter publicly)') . "\n"
       . "When:    " . gmdate('Y-m-d H:i:s') . " UTC\n"
       . "----------------------------------------\n\n"
       . $desc

--- a/public/cats/index.html
+++ b/public/cats/index.html
@@ -297,7 +297,7 @@
 	</main>
 
 	<footer>
-		<p>&copy; 2025 p(Doom)1. All cats are real and deserve treats.</p>
+		<p>&copy; 2026 p(Doom)1. All cats are real and deserve treats.</p>
 		<p style="margin-top: 0.5rem;">
 			<a href="/" style="color: var(--accent-primary);">Home</a> |
 			<a href="/about/" style="color: var(--accent-primary);">About</a> |

--- a/public/changelog/index.html
+++ b/public/changelog/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+	<!-- Orphaned pending revision: stale content, no inbound links.
+	     See docs/ORPHANED_PAGES_TODO.md before re-linking or deleting. -->
+	<meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>pdoom1 Changelog</title>
   <link rel="canonical" href="https://pdoom1.com/changelog/" />

--- a/public/data/integration-health.json
+++ b/public/data/integration-health.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-24T06:57:17.236429+00:00",
+  "generated": "2026-07-24T10:15:20.915650+00:00",
   "overall_status": "WARN",
   "summary": {
     "fail": 0,
@@ -35,12 +35,12 @@
     {
       "name": "league:freshness",
       "status": "OK",
-      "detail": "generated 4.7 days ago"
+      "detail": "generated 4.8 days ago"
     },
     {
       "name": "league:current_week",
       "status": "WARN",
-      "detail": "week 2026_W29 is marked is_current but ended 4.3 days ago -- rollover cadence off"
+      "detail": "week 2026_W29 is marked is_current but ended 4.4 days ago -- rollover cadence off"
     },
     {
       "name": "league:version_drift",

--- a/public/dev-notes/index.html
+++ b/public/dev-notes/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+	<!-- Orphaned pending revision: stale content, no inbound links.
+	     See docs/ORPHANED_PAGES_TODO.md before re-linking or deleting. -->
+	<meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>pdoom1 – Dev Notes</title>
   <link rel="canonical" href="https://pdoom1.com/dev-notes/" />

--- a/public/docs/CONTRIBUTING_TO_EVENTS.html
+++ b/public/docs/CONTRIBUTING_TO_EVENTS.html
@@ -612,7 +612,7 @@
 	</main>
 
 	<footer>
-		<p>&copy; 2025 p(Doom)1 | <a href="https://github.com/PipFoweraker/pdoom1">GitHub</a></p>
+		<p>&copy; 2026 p(Doom)1 | <a href="https://github.com/PipFoweraker/pdoom1">GitHub</a></p>
 		<p style="margin-top: 0.5rem; font-size: 0.9rem;">Event data from <a href="https://github.com/PipFoweraker/pdoom-data" target="_blank">pdoom-data</a></p>
 	</footer>
 </body>

--- a/public/frontier-labs/index.html
+++ b/public/frontier-labs/index.html
@@ -563,7 +563,7 @@
 	</main>
 
 	<footer style="background: var(--bg-secondary); border-top: 2px solid var(--accent-primary); text-align: center; padding: 2rem; margin-top: 4rem;">
-		<p>&copy; 2025 p(Doom)1 by <a href="https://github.com/PipFoweraker" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none; font-weight: bold;">Pip Foweraker</a></p>
+		<p>&copy; 2026 p(Doom)1 by <a href="https://github.com/PipFoweraker" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none; font-weight: bold;">Pip Foweraker</a></p>
 		<p style="margin-top: 0.5rem; color: var(--text-muted); font-size: 0.9rem;">
 			<a href="/" style="color: var(--accent-primary);">Home</a> |
 			<a href="/resources/" style="color: var(--accent-primary);">AI Safety Resources</a> |

--- a/public/index.html
+++ b/public/index.html
@@ -1321,7 +1321,7 @@ t	.hero {
 			</div>
 		</div>
 		<div class="footer-bottom">
-			<p>&copy; 2025 p(Doom)1 by <a href="https://github.com/PipFoweraker" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none; font-weight: bold;">Pip Foweraker</a></p>
+			<p>&copy; 2026 p(Doom)1 by <a href="https://github.com/PipFoweraker" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none; font-weight: bold;">Pip Foweraker</a></p>
 			<p class="footer-meta" style="margin-top: 0.5rem;">
 				Privacy: No personal data collected | Open Source |
 				Inspired by AI Safety research from <a href="https://stampy.ai" target="_blank" rel="noopener" style="color: var(--accent-primary);">Stampy.ai</a> and others

--- a/public/issues/index.html
+++ b/public/issues/index.html
@@ -465,10 +465,13 @@
 			<h2>Other Ways to Connect</h2>
 			<div class="grid">
 				<div class="card">
-					<h3>💬 Community Forum</h3>
-					<p>Discuss strategies, share stories, and connect with other players on our community forum.</p>
-					<p style="margin-top: 1rem; color: var(--text-muted); font-weight: bold;">
-						Coming soon &mdash; we're setting up the forum at a permanent home.
+					<h3>💬 Community Discussion</h3>
+					<p>Discuss strategies, share stories, and connect with other players.</p>
+					<p style="margin-top: 1rem;">
+						<a href="https://github.com/PipFoweraker/pdoom1/discussions" target="_blank" rel="noopener" style="color: var(--accent-primary); font-weight: bold;">GitHub Discussions &rarr;</a>
+					</p>
+					<p style="margin-top: 0.6rem; color: var(--text-muted); font-size: 0.9rem;">
+						That's where conversation happens today. We're not running a separate forum.
 					</p>
 				</div>
 				<div class="card">
@@ -491,7 +494,7 @@
 	</main>
 
 	<footer>
-		<p>&copy; 2025 pdoom1. For fun, education, and satire only.</p>
+		<p>&copy; 2026 pdoom1. For fun, education, and satire only.</p>
 		<p style="margin-top: 0.5rem; font-size: 0.9rem;">
 			<a href="/" style="color: var(--accent-primary);">Home</a> |
 			<a href="/docs/" style="color: var(--accent-primary);">Docs</a> |

--- a/public/league/archive.html
+++ b/public/league/archive.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+	<!-- Orphaned pending revision: stale content, no inbound links.
+	     See docs/ORPHANED_PAGES_TODO.md before re-linking or deleting. -->
+	<meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Weekly League Archives - p(Doom)1</title>
   <meta name="description" content="Browse historical weekly league competition data. View past standings, winners, and statistics from previous weeks.">

--- a/public/league/index.html
+++ b/public/league/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+	<!-- Orphaned pending revision: stale content, no inbound links.
+	     See docs/ORPHANED_PAGES_TODO.md before re-linking or deleting. -->
+	<meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Weekly League - p(Doom)1</title>
   <meta name="description" content="Compete in the weekly p(Doom)1 league. View current standings, track your ranking progress, and see historical competition data.">

--- a/public/players/index.html
+++ b/public/players/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+	<!-- Orphaned pending revision: stale content, no inbound links.
+	     See docs/ORPHANED_PAGES_TODO.md before re-linking or deleting. -->
+	<meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Player Profile - p(Doom)1</title>
   <meta name="description" content="View player statistics, performance history, and achievements in p(Doom)1 weekly leagues.">

--- a/public/press/index.html
+++ b/public/press/index.html
@@ -392,16 +392,29 @@
 		<section class="press-section">
 			<h2>Download Game</h2>
 			<p>Get the latest version of p(Doom)1 from our official channels:</p>
-			
+
+			<!-- The real download today is GitHub Releases. The Steam badge below is a
+			     NOT-YET marker, not a channel -- there is no store page to send press to,
+			     so it must not sit above the working link or read as available. -->
+			<p style="text-align: center; margin: 1.5rem 0;">
+				<a href="https://github.com/PipFoweraker/pdoom1/releases/latest" target="_blank" rel="noopener"
+				   style="display: inline-block; background: var(--accent-primary); color: #0b0e14; padding: 0.7rem 1.4rem; border-radius: 6px; font-weight: bold; text-decoration: none;">
+					Download from GitHub Releases &rarr;
+				</a>
+			</p>
+			<p style="text-align: center; color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1.5rem;">
+				Windows and macOS. Linux is in progress. Free and open source &mdash; no store account needed.
+			</p>
+
 			<!-- Steam badge - Valve compliant -->
 			<div style="text-align: center; margin: 2rem 0;">
-				<div class="steam-badge" title="Coming soon to Steam" style="display: inline-block;">
+				<div class="steam-badge" title="Not yet on Steam" style="display: inline-block;">
 					<div style="background: #171a21; color: #ffffff; padding: 12px 24px; border-radius: 4px; font-family: 'Motiva Sans', Arial, sans-serif; font-size: 14px; font-weight: normal; border: 1px solid #2a475e; opacity: 0.85;">
 						<div style="display: flex; align-items: center; gap: 8px;">
 							<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
 								<path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm4.64 13.36L12 11.72v-4.1c0-.55-.45-1-1-1s-1 .45-1 1v4.72l-2.64 1.64c-.18.11-.29.3-.29.51 0 .55.45 1 1 1 .21 0 .4-.11.51-.29L10 13.36l1.42.86c.11.18.3.29.51.29.55 0 1-.45 1-1 0-.21-.11-.4-.29-.51z"/>
 							</svg>
-							<span>Coming soon to Steam</span>
+							<span>Not yet on Steam</span>
 						</div>
 					</div>
 				</div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,6 +10,14 @@ Disallow: /assets/private/
 Disallow: /data/
 Disallow: /design/
 Disallow: /monitoring/
+
+# Orphaned pending revision (2026-07-24): no inbound links, stale content.
+# These also carry <meta name="robots" content="noindex">.
+# See docs/ORPHANED_PAGES_TODO.md before re-linking or removing.
+Disallow: /league/
+Disallow: /players/
+Disallow: /changelog/
+Disallow: /dev-notes/
 Disallow: /stats/
 Disallow: /dev-notes/
 


### PR DESCRIPTION
Launch-day content audit, acted on. Every prose change is justifiable as **"this was false, now it's true"** — no tone or phrasing rewritten for its own sake. Copy-drift check shows exactly these changes and nothing else.

## Two broken promises, now kept

**`issues/`** — the most-linked flagged page (6 homepage links + shared nav) — said:

> "Community Forum … **Coming soon** — we're setting up the forum at a permanent home."

`forum.pdoom1.com` has **no DNS record** and forum work was deprioritised for GitHub Discussions. Now points at Discussions and says plainly we're not running a separate forum.

**`press/`** — under *"get the latest version from our official channels"*, the only offer was **"Coming soon to Steam."** Press following that find nothing; the real download is GitHub. A prominent **GitHub Releases** button now leads, with platform reality stated (Windows + macOS, Linux in progress). The Steam badge stays as a not-yet marker, relabelled "Not yet on Steam".

Valve's own `©2025 Valve Corporation` trademark notice is **deliberately not edited** — rewriting another party's legal notice would misstate it.

## Copyright

Our footers advanced 2025 → 2026 across 6 pages, matched on our own name so both Valve notices are untouched.

## Credit opt-in (your ask)

New optional **"Name for credit"** field on the bug form. The design point worth your eye: it sits directly beside the email field, which promises *"never published, never added to a public issue"* — and this field is its **privacy-inverse**. So the help text makes the difference unmissable:

> *"Unlike your email, this one may be shown publicly (release notes, credits, or a linked issue). **Leave it blank and you stay anonymous** — the report is just as welcome either way."*

`bug-submit.php` forwards it on its own `Credit:` line that spells out consent **either way** — `<-- OK to credit publicly (reporter opted in)` or `(anonymous -- do NOT name this reporter publicly)`. That way nobody writing release notes mines the `Contact:` line for a name that was never offered.

## Orphans hidden, not deleted

`league/`, `league/archive`, `players/`, `changelog/`, `dev-notes/` now carry `noindex` + `robots.txt` `Disallow`. All have **zero** inbound links from homepage, `navigation.js` and `sitemap.xml`, while presenting a live countdown for a week that **ended 5 days ago**, all-zero player stats, and a **2025-10-31** archive.

**Not deleted** — removing from `public/` would drop them from production on the next `rsync --delete`, and they're wired to real data pipelines. `docs/ORPHANED_PAGES_TODO.md` records exactly what's wrong with each and the revive/retire/keep-hidden decision left for you. The one human path in (`stats/competition.html` → `/league/`) still works; `noindex` only stops search engines using them as entry points.

## Testing

Suite green: design-notes, analytics-optout, download-resolution, validate_data, feeds. No PHP CLI in this environment, so `bug-submit.php` was reviewed statically (balanced delimiters, edits confined to one const, one `$clean` call, one body line) — **worth a real submit as a smoke test after merge.**
