### PR TITLE
Correct L2 seed to shipped client value + privacy artifacts + ship discipline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- Ship discipline (docs/SHIP_DISCIPLINE.md). Tick what applies; delete the rest.
+     This is a nudge, not a gate. Its job is to make future-you pause on the
+     things that erode under momentum, not to slow an honest change. -->
+
+## What & why
+
+<!-- One or two sentences. What changed, and what was wrong before. -->
+
+## Ship checklist
+
+- [ ] **Reader-facing prose:** every copy change is "this was false, now it's true" (not tone drift). Ran `python scripts/snapshot-copy.py --check` and read the diff.
+- [ ] **No new fallback literal** presented as current (version, price, date). Failures fail loud or read 'unknown', not a plausible-but-stale value.
+- [ ] **Personal data:** if this adds/changes a form field that collects personal data, `docs/privacy/PROCESSING_RECORD.md` has a matching row. (N/A? say so.)
+- [ ] **Generated content:** didn't delete generated/orphaned files without tracing them to source (Chesterton's fence).
+- [ ] **Tests:** ran the local suite (see `CLAUDE.md`); relevant ones pass.
+- [ ] **Preview:** verified on the Netlify deploy-preview, not only locally.
+
+## Notes for review
+
+<!-- Anything the reviewer (you) should look at hardest. Copy wording? A promise
+     made to players? A data-handling boundary? Name it. -->

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ scripts/game-integration-config.json
 # The .local suffix means per-machine by convention; tracking it makes every
 # permission grant a merge conflict.
 .claude/settings.local.json
+content_audit.json
+page_audit.json

--- a/docs/DATA_AND_CMS_WORKSHOP.md
+++ b/docs/DATA_AND_CMS_WORKSHOP.md
@@ -1,0 +1,67 @@
+# Data & CMS workshop — prep + parking lot
+
+**Scheduled:** the week of 2026-08-03, once v0.13 and the game's technical
+patching have settled. **Parked until then** — this doc holds the seed thinking so
+the workshop starts from something, not a blank page. Do not build any of this
+before the workshop; the point is to decide, then build once.
+
+Linked from: `docs/privacy/PROCESSING_RECORD.md` (the data this would manage),
+`content/campaigns/feedback-intake.md` (feedback that will accumulate).
+
+---
+
+## The question
+
+You'll accumulate *content-shaped data*: bug/feature reports, contributor names,
+cats (#159), feedback from campaigns. At some point a mailbox + markdown files
+stops scaling and you want a CMS. The question is **what to build now** so that
+"eventually migrate to a real CMS" is an export, not a rewrite.
+
+## The trap to avoid
+
+**Building a CMS.** The failure mode is scope-creep: you set out to "log
+submissions" and end up hand-rolling an admin UI, auth, roles, a WYSIWYG editor —
+reinventing Directus/Strapi/Ghost badly, then still having to migrate. A homebrew
+*store* is cheap and right at your scale; a homebrew *CMS* is a tar pit.
+
+## The seed proposal (to sharpen or reject at the workshop)
+
+**Don't build a CMS. Build a ledger.** An append-mostly structured store whose
+schema *is* the processing record — every row carries what/when/purpose/basis/
+retention-due. That single move buys three things at once:
+
+1. **Compliance for free** — the store and the Art. 30 / APP record are the same
+   artifact; retention purging is a `DELETE WHERE retention_due < today`.
+2. **Searchability** — "every report about the ledger UI", "all contributors who
+   opted into credit" become queries, not inbox archaeology.
+3. **A clean migration** — standard schema + boring formats (SQLite / JSONL) means
+   moving to a real CMS later is an export/import, not a data-archaeology project.
+
+**Candidate shape:** SQLite (one file, no server, trivially backed up, queryable,
+and every real CMS can import from it) with ~3 tables — `submissions`,
+`contributors`, `cats` — plus a 30-line read-only HTML view that reads an export.
+No write-UI, no auth, no admin app. You add rows by a small ingest script the bug
+form's mail path (or a future POST endpoint) calls.
+
+**The migration trigger — name it now so "I'll notice when it's annoying" becomes
+a rule, not a vibe:** migrate to a real CMS when *either* (a) more than one person
+needs to edit content, or (b) you're spending >30 min/week hand-managing the
+ledger. Until a trigger trips, the homebrew ledger is correct, not a compromise.
+
+## Workshop agenda (½ day)
+
+1. **Decide store vs CMS-now.** Confirm or reject "ledger, not CMS."
+2. **Schema.** The 3 tables + the processing-record columns. One hour, done.
+3. **Ingest path.** How a bug report becomes a row (extend `bug-submit.php`? a
+   nightly mailbox sweep? a real POST endpoint tied to the game's api.pdoom1.com
+   Tier-2 work in #800?). This is the one genuinely architectural choice.
+4. **Retention automation.** The purge job + how it logs what it purged.
+5. **The migration trigger** — write it into `docs/SHIP_DISCIPLINE.md` as a real
+   checkpoint, not a feeling.
+6. **Explicitly out of scope for v1:** write-UI, auth, multi-user, rich editing.
+
+## Pre-reading
+
+- `docs/privacy/PROCESSING_RECORD.md` — the schema is basically already here.
+- pdoom1 #800 Tier-2 (POST to api.pdoom1.com) — if that lands, the game and the
+  website want *one* ingest contract, not two. Coordinate.

--- a/docs/L2_CUTOVER_RUNBOOK.md
+++ b/docs/L2_CUTOVER_RUNBOOK.md
@@ -4,9 +4,14 @@ Executable steps for moving the league from the L1 epoch (`(seed, v0.12.0)`
 weekly board) to the L2 epoch, per issue #151. Written on launch day
 (2026-07-24) so the cutover is a checklist, not a scramble at 3pm.
 
-**Blessed seed (from `docs/LEAGUE_SEED_LEDGER.md`):** `league_2026-07_7d6ced29`
-**New L2 board file:** `board_league_2026-07_7d6ced29__L2.json`
+**Board key (from the shipped v0.13 client — pdoom1 #151, gate-green):**
+`(weekly-2026-w30, L2)` → `board_weekly-2026-w30__L2.json`
 **Legacy L1 board file:** `board_weekly-2026-w0__L1.json`
+
+> The seed is `weekly-2026-w30`, NOT the earlier website-side proposal
+> `league_2026-07_7d6ced29` — see the correction note in
+> `docs/LEAGUE_SEED_LEDGER.md`. The client POSTs to `weekly-2026-w30`; the board
+> must match it or scores vanish silently.
 
 ---
 
@@ -15,14 +20,14 @@ weekly board) to the L2 epoch, per issue #151. Written on launch day
 | # | step | side | state |
 |---|---|---|---|
 | 1 | Preserve L1 board as legacy | VPS (Pip) | **ready** — command below |
-| 2 | Confirm score API accepts the new `(seed, L2)` key | VPS/API | **BLOCKED** — needs the exact key string the v0.13 client POSTs |
-| 3 | Point website display at the L2 board | website | **contingent** — depends on step 2 + issue #735 |
+| 2 | Confirm score API accepts `(weekly-2026-w30, L2)` | VPS/API | **ready** — key now known; check below |
+| 3 | Point website display at the L2 board | website | **contingent on #735** — does v0.13 submit remotely |
 | 4 | Verify | website | **ready** — checks below |
 
-The two BLOCKED/contingent items hang on the follow-up you owe issue #151 (the
-exact board-key string once the v0.13 version-split lands) and on the answer to
-issue #735 (does v0.13 actually submit scores remotely). Nothing here fabricates
-those — the steps that can't be pinned down yet say so.
+The values that were blocked are now known (client is built). Step 3 remains
+contingent only on whether v0.13 actually submits scores remotely (issue #735) —
+if it does not, there is nothing to display yet and the honest pre-launch banner
+is correct as-is.
 
 ---
 
@@ -42,18 +47,18 @@ ls -la board_weekly-2026-w0__*.json    # confirm both exist, same size
 `-n` (no-clobber) so re-running never overwrites the legacy copy. The original
 keeps its seed string so the provenance of those scores stays legible.
 
-## Step 2 — confirm the API accepts the L2 key  [BLOCKED]
+## Step 2 — confirm the API accepts `(weekly-2026-w30, L2)`
 
-The board key is client-supplied and the store is flat-file, so a new key should
-auto-create on first POST — but confirm no version allowlist rejects it. **This
-needs the exact key string the v0.13 build POSTs**, which lands with the #151
-follow-up. When known, a read of the (empty) new board is the cheap check:
+The board key is client-supplied and the store is flat-file, so it should
+auto-create on first POST — but confirm no version allowlist rejects the new
+`L2` epoch form (the game flagged this against #149). Read of the (empty) new
+board is the cheap check:
 
 ```bash
-# TEMPLATE — fill <API_BASE> and the exact key once known:
-curl -s "<API_BASE>/board?seed=league_2026-07_7d6ced29&ladder=L2" -o /dev/null -w "%{http_code}\n"
+# fill <API_BASE>:
+curl -s "<API_BASE>/board?seed=weekly-2026-w30&ladder=L2" -o /dev/null -w "%{http_code}\n"
 # 200 (empty board) or a clean 404-that-will-autocreate = OK; a 4xx rejecting
-# the key = an allowlist to fix before the cutover.
+# the key = a version allowlist to widen for L<n> before the cutover.
 ```
 
 ## Step 3 — point the website display at L2  [contingent on #735]
@@ -78,8 +83,8 @@ is a read-only consumer of the one PHP score API).
 ## Step 4 — verify
 
 ```bash
-# blessed seed still derives correctly (guards against an edited ledger):
-python tools/derive_league_seed.py 2026-07     # -> league_2026-07_7d6ced29
+# the shipped seed is referenced in the release notes (sanity anchor):
+grep -o "weekly-2026-w30" public/data/version.json    # 1 hit
 
 # leaderboard page is honest right now (pre-launch banner, empty toolbar hidden):
 curl -s https://pdoom1.com/leaderboard/ | grep -c "No scores recorded yet"   # >=1

--- a/docs/LEAGUE_SEED_LEDGER.md
+++ b/docs/LEAGUE_SEED_LEDGER.md
@@ -2,35 +2,53 @@
 
 The authoritative, human-readable record of which competitive seed governs which
 league epoch — when it was blessed, and by whom. A "blessing" is Pip's explicit
-sign-off that a seed is the real one for an epoch; nothing else makes a seed
-canonical.
+sign-off that a seed is the real one for an epoch.
 
-Per ADR-0016 (league metabolism) the cycle is **monthly**, one baseline seed per
-month. The seed is derived deterministically so future months need no invention,
-only a blessing:
+**The seed is not a free website-side choice.** The game client is built to POST
+scores under a specific `(seed, ladder_version)` key; the board MUST use exactly
+that key or submitted scores land in a board nobody displays — a silent failure
+with no error shown to the player. So the canonical seed is **whatever the
+shipped client sends**, confirmed against the game's protocol docs, not a value
+picked here.
 
-```
-seed = "league_" + <YYYY-MM> + "_" + sha256("pdoom1_league_" + <YYYY-MM> + "_" + <ladder>).hexdigest()[:8]
-```
+**Authoritative source (read these, not issue comments):**
+- `pdoom1/docs/game-design/BUILD_VS_LADDER_VERSION_SPLIT.md` — key/epoch nomenclature + bump rule
+- `pdoom1/docs/RELEASE_AND_LEAGUE_CYCLE.html` — cadence + epoch-cut runbook
 
-Deriving a value is not the same as blessing it. A derived-but-unblessed seed is
-a proposal; only a row in this table with a blessing date is canonical.
-
-| epoch | month | seed | ladder | blessed (UTC) | by | notes |
+| epoch | seed | ladder | board file | blessed (UTC) | by | notes |
 |---|---|---|---|---|---|---|
-| L2 | 2026-07 | `league_2026-07_7d6ced29` | L2 | 2026-07-24 | Pip | **First seed blessing.** Opens the L2 ladder epoch cut (issue #151), replacing the `(seed, v0.12.0)` weekly board. Legacy L1 board preserved as `board_weekly-2026-w0__L1.json`. |
+| L2 | `weekly-2026-w30` | L2 | `board_weekly-2026-w30__L2.json` | 2026-07-24 (pending re-confirm) | Pip | **First epoch cut.** Client sends `version="L2"`, seed `weekly-2026-w30` (pdoom1 #151, gate-green; echoed in `public/data/version.json` release notes). Legacy L1 board preserved as `board_weekly-2026-w0__L1.json`. |
+
+## Correction note (2026-07-24)
+
+The first blessing initially landed on `league_2026-07_7d6ced29`, a website-side
+**proposal** for a monthly-derived naming scheme (`league_<YYYY-MM>_<hash>`). That
+proposal was made after — and without reconciling against — the game side's
+already-shipped key `weekly-2026-w30` (pdoom1 #151 comment, 01:50 UTC). The client
+wins by construction (it is the thing that actually POSTs scores), so this ledger
+records `weekly-2026-w30`. `league_2026-07_7d6ced29` is **superseded for this
+cut** and must not appear in any board file or page.
+
+**Pip: this needs a one-line re-bless of `weekly-2026-w30`** — the marker above
+stays "pending re-confirm" until you do, because the first blessing was cast on
+the wrong value in good faith.
+
+The monthly-derivation *idea* is not dead — it is parked for the game's own
+**release/league nomenclature reflective review (pdoom1 #808, on/after
+2026-08-24)**, where a naming change belongs (it's a client const, cheap to
+re-cut between epochs, expensive to fork mid-launch). `tools/derive_league_seed.py`
+stays as a reference implementation of that *proposed* scheme, not the current one.
 
 ## Legacy / superseded
 
 - **L1 epoch** ran on the `(seed, game_version)` weekly key through v0.12.0. Its
   live board (`board_weekly-2026-w0__v0.12.0.json` on the DreamCompute DATA_DIR)
-  is preserved at the L2 cutover as `board_weekly-2026-w0__L1.json` so real
-  tester scores from the friends-and-family alpha survive as "legacy epoch L1".
-  See `docs/L2_CUTOVER_RUNBOOK.md`.
+  is preserved at the L2 cutover as `board_weekly-2026-w0__L1.json`, read-only, so
+  the friends-and-family alpha scores survive as "legacy epoch L1".
 
 ## How to add a row
 
-1. Derive the seed for the month (`tools/derive_league_seed.py <YYYY-MM> [ladder]`).
-2. Get Pip's explicit blessing — do not backfill a blessing you assumed.
+1. Read the seed the **shipped client** sends, from the game's protocol docs above.
+2. Get Pip's explicit blessing on that value.
 3. Add the row with the real UTC date. Never edit a past row's seed; a corrected
    seed is a new epoch, not a rewrite of history.

--- a/docs/SHIP_DISCIPLINE.md
+++ b/docs/SHIP_DISCIPLINE.md
@@ -1,0 +1,71 @@
+# Ship discipline — guardrails against future-me shipping hasty
+
+Pip's own framing: a standing tension between the **build-and-push urge** and the
+**ship-with-quality urge**. This file exists so the quality side has *mechanisms*,
+not just good intentions — because good intentions are exactly what erode under
+launch pressure and momentum.
+
+## The design principle for the guardrails themselves
+
+**Prompt and fail-loud; don't hard-block, and never train reflexive dismissal.**
+
+A hard block on a solo founder's own repo gets disabled the first time it's
+inconvenient. A guardrail that makes you mash Enter to continue trains you to mash
+Enter *without reading* — it actively manufactures the sloppiness it claims to
+prevent. So:
+
+- **Checklists** that are visible and quick (a PR template) — nudge, don't gate.
+- **CI checks** that fail *loudly and legibly* (you can read exactly what's wrong
+  in 5 seconds) — these can gate, because they're objective and fast to satisfy.
+- **No "press Enter to continue" prompts.** They're theatre. (The current
+  `.husky/pre-commit` has one — see "Known anti-pattern" below.)
+
+## The disciplines (what "shipped with quality" means here)
+
+1. **Never lie to a visitor.** Every reader-facing prose change is justifiable as
+   "this was false, now it's true." Run `python scripts/snapshot-copy.py --check`
+   and eyeball the diff before merging copy.
+2. **Fallback literals are lies waiting to happen.** A default value ships exactly
+   when the real lookup failed. Prefer failing loud or 'unknown' over a plausible
+   literal (see the download version-stamp fix, 2026-07-24).
+3. **New personal-data field ⇒ a row in `docs/privacy/PROCESSING_RECORD.md` in the
+   same change.** A form field with no processing-record row is silent collection
+   nobody decided on.
+4. **Trace generated content to its source before deleting** (Chesterton's fence —
+   the alignmentforum pages, the orphaned league trio).
+5. **Run the local suite before opening a PR** (the list in `CLAUDE.md`).
+6. **Verify on the Netlify preview, not just locally**, before merge.
+
+## Mechanisms (status)
+
+| mechanism | what it does | gate or nudge | status |
+|---|---|---|---|
+| `.github/pull_request_template.md` | the checklist above, in front of you at PR time | nudge | **shipping now** |
+| local test suite (`CLAUDE.md` list) | correctness/regression | nudge (you run it) | exists |
+| `snapshot-copy.py --check` | reader-facing copy drift | nudge | exists |
+| CI: tests on PR (health-check, version-check) | objective pass/fail | gate | exists |
+| **CI: personal-data guardrail** | fail a PR that adds a form `<input>` without touching PROCESSING_RECORD.md | gate | **proposed — see below** |
+| **CI: copy-drift comment** | post the `snapshot-copy` diff as a PR comment so drift is seen, not skipped | nudge | proposed |
+
+## Proposed: personal-data CI guardrail
+
+A tiny workflow that, on any PR touching a form page, checks whether
+`docs/privacy/PROCESSING_RECORD.md` was also touched — and fails with a legible
+message if not:
+
+> "This PR changes a form but not the processing record. If you added or changed a
+> field that collects personal data, add/adjust its row. If not, say so in the PR
+> and re-run."
+
+Objective, 5-second-legible, satisfiable by one honest line — so it can gate
+without becoming friction you'll want to disable. **Not built yet; decide at the
+data workshop whether it's worth the wire.**
+
+## Known anti-pattern to fix
+
+`.husky/pre-commit` currently ends with "Press Enter to continue or Ctrl+C to
+cancel" on every `feat:`/`fix:` commit. That is the reflexive-dismissal trainer
+described above — it teaches you to mash Enter past a reminder you've stopped
+reading. **Recommend:** replace the interactive pause with a non-blocking printed
+reminder (it says its piece and lets the commit through), or drop it in favour of
+the PR template. Left as-is pending your call, since it touches your commit flow.

--- a/docs/privacy/PRIVACY_NOTICE_DRAFT.md
+++ b/docs/privacy/PRIVACY_NOTICE_DRAFT.md
@@ -1,0 +1,66 @@
+# Privacy notice — DRAFT for Pip's review
+
+Plain-language, in your voice. This is the *forms & contact* half of privacy —
+the existing `/privacy/` page already covers analytics well, and the forms clause
+there was updated 2026-07-24 to match this. This draft is the fuller version to
+fold in when the tone pass (#160) runs; it is **not deployed** until you sign off.
+
+Every line must stay true to `docs/privacy/PROCESSING_RECORD.md`. If they drift,
+the record wins and this gets corrected — never the other way round.
+
+---
+
+## What happens to what you tell us
+
+We keep this short because the honest version *is* short: we collect almost
+nothing, and what you hand us we use only for the reason you handed it over.
+
+**If you just visit** — we don't collect anything about you personally. No
+cookies, no account, no name, no email, no IP kept. (The full analytics story is
+above.)
+
+**If you file a bug or feature report:**
+
+- **Your email** (optional) is used for one thing: replying to you about that
+  report. We keep it with the report while it's open, then clear it. It never
+  goes on a mailing list, we never sell or share it, and we won't email you about
+  anything you didn't raise.
+- **A name for credit** (optional) is the one thing here that can be *public* — if
+  you fill it in, we may credit you in release notes or a linked issue. That's the
+  whole point of the field. **Leave it blank and you stay anonymous** — the report
+  is just as welcome either way.
+- **The report itself** comes to our team privately by email. If that send fails,
+  the form offers to open a pre-filled GitHub issue instead — that one is public,
+  and the form tells you so before you continue.
+
+**If you email us** — we get what you wrote, and use it to reply. That's it.
+
+## Your say over it
+
+- **See it or delete it:** email <team@pdoom1.com> and ask what we hold about you,
+  or to delete it. We hold very little, so this is easy for us to honour.
+- **Stop the anonymous counting:** turn on Do Not Track, or use the opt-out on the
+  analytics page. Nothing else is needed.
+
+## The honest bit about who we are
+
+We're a small, volunteer-made, non-commercial project. We'd rather show you good
+mechanics than wave a compliance badge — but the substance matters, so plainly:
+we process almost no personal data, keep it only as long as its purpose lasts,
+store it on our own systems, and share it with no one. If there's something here
+we could do better, tell us — genuinely. <team@pdoom1.com>.
+
+---
+
+## Notes for Pip (not for publication)
+
+- **Deploy target:** fold into `public/privacy/index.html` under a "Forms &
+  Contact" section during the tone pass (#160), gated through
+  `snapshot-copy.py --check`.
+- **Blog parser constraint** does not apply here (this is a real HTML page, not a
+  markdown blog post) — headings/lists are fine.
+- **When a database exists:** add a line on where data lives and how deletion
+  works mechanically. Until then, "email us to delete" is honest — deletion is
+  literally us finding the mail and removing it.
+- **Do not add** language promising things we don't do (a newsletter, an account
+  system) even if they're planned. Notice describes *now*, not the roadmap.

--- a/docs/privacy/PROCESSING_RECORD.md
+++ b/docs/privacy/PROCESSING_RECORD.md
@@ -1,0 +1,58 @@
+# Processing record — what personal data we hold, and why
+
+The single source of truth for every piece of personal data the site touches.
+It doubles as the "record of processing" both GDPR (Art. 30) and the Australian
+Privacy Principles expect you to keep — so keeping it current *is* most of the
+compliance work, not paperwork on top of it.
+
+**The rule the whole table enforces (purpose limitation):** each item may be used
+only for the purpose it was given for, and kept only while that purpose is alive.
+The unit is the **(data, purpose) pair**, not the data type — which is why the
+same field can be fine for one use and off-limits for another.
+
+**Status (2026-07-24):** we do not yet have a database. Form data currently lives
+in the **team@pdoom1.com mailbox** (the report path) and in **GitHub** (only if a
+reporter takes the public fallback). The mailbox is a datastore — so this record
+describes reality today, not a future system.
+
+| # | data | collected where | purpose (why they gave it) | lawful basis | may we use it for… | retention | stored where (today) |
+|---|---|---|---|---|---|---|---|
+| 1 | **Email** | bug form (optional) | reply to the reporter about *this* report | consent-by-provision / legitimate interest in supporting a user who asked | replying about this report **only** — never marketing, never a list | life of the report thread, then clear | team@ mailbox |
+| 2 | **Name for credit** | bug form (optional) | credit the reporter for the contribution | **explicit opt-in consent** (they typed it knowing it may be public) | crediting them publicly (release notes / linked issue) **only** | until they ask to remove it | team@ mailbox; published credit where used |
+| 3 | **Report text** | bug/issue form | describe the bug/feature | legitimate interest in fixing the product | triage, fixing, and — if the private send fails — a **public** GitHub issue they’re warned about | life of the issue | team@ mailbox or public GitHub |
+| 4 | **Email (direct)** | someone emailing team@ | whatever they wrote | consent-by-provision | replying about their message | until resolved, then housekeeping | team@ mailbox |
+| 5 | **Analytics events** | every page (Plausible) | understand site usage | legitimate interest | aggregate stats only | Plausible's retention; no raw PII stored | self-hosted Plausible VM |
+| — | ~~IP address~~ | — | — | — | **not stored** (anonymised at request time) | n/a | n/a |
+
+## The two lawful bases we actually use, in plain terms
+
+- **"You gave it to me for exactly this."** Using the email a reporter typed into
+  a "your email (for a reply)" box, to reply — needs no separate checkbox; the act
+  of typing it into a purpose-labelled field *is* the consent. Rows 1, 3, 4, 5.
+- **A separate, affirmative opt-in** for any *secondary* purpose — publishing an
+  identity (row 2), or ever emailing someone about something they didn't ask
+  about (a newsletter — **we don't do this, and it's not in the table**; adding it
+  would need a new row and its own unbundled, default-off opt-in).
+
+## The design rule that keeps it consistent
+
+**One opt-in per secondary purpose. Unbundled. Default off. Independently
+revocable.** Never fuse "reply to me" + "credit me" + "email me updates" into one
+tick. The primary purpose (reply using the reply-email) gets no box; every extra
+purpose gets its own.
+
+## The cheat code
+
+**The less we keep, the less we owe.** Every field not persisted is a whole row of
+obligation not incurred. Row 1's ideal end-state: email used transactionally and
+never persisted beyond the report thread. Minimisation isn't a constraint here —
+it's what keeps this table short and the compliance surface tiny.
+
+## Change discipline
+
+**Adding any new field that collects personal data means adding a row here first.**
+That's the guardrail — see `docs/SHIP_DISCIPLINE.md`. A field in a form with no
+row in this table is the failure mode: silent collection nobody decided on.
+
+_Companion: `docs/privacy/PRIVACY_NOTICE_DRAFT.md` is the public-facing statement
+of this same table. They must stay in step — if one changes, change the other._

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -352,9 +352,15 @@
 			</ul>
 			<p>
 				<strong>That covers analytics only.</strong> If you use one of our forms or email us, we receive
-				whatever you choose to send, including any contact details you add. Bug and issue reports filed
-				through the site can end up in a public GitHub issue, so don't put anything in them you wouldn't
-				want published.
+				whatever you choose to send. We use each thing only for the reason you gave it to us:
+			</p>
+			<ul>
+				<li><strong>Your email</strong> (bug form) — used only to reply to you about that report. Kept with the report while it's open, then cleared. Never added to a mailing list, never published.</li>
+				<li><strong>Name for credit</strong> (bug form, optional) — used only to credit you, and <em>only</em> because you chose to fill it in. This one <strong>may appear publicly</strong> (release notes or a linked issue). Leave it blank to stay anonymous.</li>
+				<li><strong>The report itself</strong> — goes privately to our team by email. If that send fails, the form offers to open a pre-filled <em>public</em> GitHub issue instead, so don't put anything in the description you wouldn't want published.</li>
+			</ul>
+			<p>
+				We don't sell or share any of it, and you can ask us to delete what we hold about you any time — <a href="mailto:team@pdoom1.com">team@pdoom1.com</a>.
 			</p>
 		</section>
 


### PR DESCRIPTION
## Launch-critical: the blessed seed was wrong

The game agent's #151 comment (01:50 UTC) already gave the shipped client's board key — **`(weekly-2026-w30, L2)`** — before my 03:46 proposal. The monthly-derivation seed I proposed and you blessed (`league_2026-07_7d6ced29`) **conflicts** with it. The client wins by construction: it POSTs to `weekly-2026-w30`, so a board keyed to my value would receive nothing and render empty — silent score loss. `version.json`'s v0.13 notes already say `weekly-2026-w30`, confirming it.

Corrected the ledger + runbook + memory to ground truth. **The ledger marks your blessing 'pending re-confirm' — needs a one-line re-bless of `weekly-2026-w30`.** The monthly idea is parked for the game's nomenclature review (#808).

## Privacy artifacts (requested)

- **`docs/privacy/PROCESSING_RECORD.md`** — the (data, purpose, basis, boundary, retention) table; doubles as your GDPR Art.30 / APP record. Scored by *purpose*, which is what makes 'email reply-only but name may-be-public' consistent instead of weird.
- **`docs/privacy/PRIVACY_NOTICE_DRAFT.md`** — plain-language notice in your voice, DRAFT, folds into `/privacy/` during the tone pass (#160).
- **`public/privacy/index.html`** — the live forms clause was honest but **incomplete** (understated the private team@ path, predated the email/credit split). Now accurate. Correction to what I said in chat: this was **not** a live lie — the page already scoped 'no personal data' to analytics; I overstated it before reading far enough.

## CMS / workshop

**`docs/DATA_AND_CMS_WORKSHOP.md`** — parked to week of 2026-08-03. Seed thesis: build a **ledger** (SQLite, schema *is* the processing record), not a CMS, with a **named migration trigger** so 'I'll notice when it's annoying' becomes a rule.

## Ship discipline (requested)

- **`docs/SHIP_DISCIPLINE.md`** — guardrail principle: *prompt/fail-loud, never train reflexive dismissal*. Flags your `.husky/pre-commit` 'press Enter to continue' as exactly that anti-pattern.
- **`.github/pull_request_template.md`** — the checklist, shipping now.
- Personal-data CI guardrail **proposed, not built** — decide at the workshop.

Docs + one accuracy patch to /privacy/. No launch-path code touched.