### PR TITLE
Receive bug-form attachments + second seed blessing + fix bug-page privacy lie

### DIFF
--- a/docs/LEAGUE_SEED_LEDGER.md
+++ b/docs/LEAGUE_SEED_LEDGER.md
@@ -17,7 +17,17 @@ picked here.
 
 | epoch | seed | ladder | board file | blessed (UTC) | by | notes |
 |---|---|---|---|---|---|---|
-| L2 | `weekly-2026-w30` | L2 | `board_weekly-2026-w30__L2.json` | 2026-07-24 (pending re-confirm) | Pip | **First epoch cut.** Client sends `version="L2"`, seed `weekly-2026-w30` (pdoom1 #151, gate-green; echoed in `public/data/version.json` release notes). Legacy L1 board preserved as `board_weekly-2026-w0__L1.json`. |
+| L2 | `weekly-2026-w30` | L2 | `board_weekly-2026-w30__L2.json` | 2026-07-25 | Pip | **First epoch cut.** Client sends `version="L2"`, seed `weekly-2026-w30` (pdoom1 #151, gate-green; echoed in `public/data/version.json` release notes). Legacy L1 board preserved as `board_weekly-2026-w0__L1.json`. |
+
+## Blessings log
+
+The ceremony, for the record — including the one that missed, because the log is
+history, not a tidy final answer.
+
+| # | when (AEST) | seed | rite | outcome |
+|---|---|---|---|---|
+| 1 | 2026-07-24 ~08:00 | `league_2026-07_7d6ced29` | *waves doom staff* | **Superseded.** Blessed in good faith, but conflicted with the already-shipped client key. Corrected same day. |
+| 2 | 2026-07-25 ~09:20 | `weekly-2026-w30` | *waves doom staff* | **Canonical.** Matches the shipped v0.13 client. This is the seed the L2 board uses. |
 
 ## Correction note (2026-07-24)
 

--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -287,10 +287,9 @@
 	<main id="main-content" role="main">
 		<h1>Report a Bug</h1>
 		<p class="intro">
-			Found a bug or need help? Report issues directly through our GitHub integration.
-			Please describe the problem in words &mdash; the email we receive carries your
-			text, but <strong>not</strong> an attached file. If you pick one, we are told its
-			name so we know to ask you for it.
+			Found a bug or need help? Send it straight to the team &mdash; no GitHub account needed.
+			You can <strong>attach a screenshot, log, or config file</strong> (up to 500&nbsp;KB) and it
+			comes through with your report.
 		</p>
 
 		<div class="form-container">
@@ -365,11 +364,11 @@
 				</div>
 
 				<div class="form-group">
-					<label for="bug-attachment">Name a File (Optional)</label>
+					<label for="bug-attachment">Attach a File (Optional)</label>
 					<input type="file" id="bug-attachment" name="attachment"
 						   accept=".txt,.log,.json,.zip,.png,.jpg,.jpeg"
 						   aria-describedby="attachment-help attachment-error">
-					<div id="attachment-help" class="form-help"><strong>The file itself is not sent to us</strong> &mdash; only its name and size, so we know to ask. To get a screenshot or log to us directly, mention it below and we will reply, or file on GitHub where you can attach it. (max 500 KB. Supported: .txt, .log, .json, .zip, .png, .jpg)</div>
+					<div id="attachment-help" class="form-help">A screenshot, log, or config file &mdash; it comes through attached to your report. Max 500&nbsp;KB. Supported: .txt, .log, .json, .zip, .png, .jpg</div>
 					<div id="attachment-error" class="error-message" role="alert" aria-live="polite"></div>
 				</div>
 
@@ -385,7 +384,7 @@
 	<footer role="contentinfo">
 		<div class="footer-content">
 			<p>&copy; 2026 pdoom1. Not affiliated with any AI organization. For fun, education, and satire only.</p>
-			<p>Privacy: No personal data collected | <a href="/" style="color: var(--accent-primary);">Back to Home</a></p>
+			<p>Privacy: we use what you send only to handle your report &mdash; <a href="/privacy/" style="color: var(--accent-primary);">details</a> | <a href="/" style="color: var(--accent-primary);">Back to Home</a></p>
 		</div>
 	</footer>
 
@@ -502,11 +501,9 @@
 				if (submitted) {
 					button.textContent = '[OK] Report Submitted!';
 					button.style.background = 'var(--success-color)';
-					// bug-submit.php forwards the attachment's NAME and SIZE, never its
-					// bytes. A reporter who picked a screenshot has just been shown a
-					// success state, and without this would reasonably believe we now
-					// hold the image. Say plainly that we do not, while the report is
-					// still fresh enough for them to act on it.
+					// Attachments now come through with the report (bug-submit.php
+					// MIME-attaches them). Confirm it, so a reporter who attached a
+					// screenshot knows we have it.
 					if (bugData.attachment && bugData.attachment.filename) {
 						let an = document.getElementById('bug-attach-note');
 						if (!an) {
@@ -515,13 +512,9 @@
 							an.style.cssText = 'margin-top:0.8rem; font-size:0.9rem; color: var(--text-secondary);';
 							button.insertAdjacentElement('afterend', an);
 						}
-						an.innerHTML = 'Your description reached us &mdash; but <strong>"' +
-							bugData.attachment.filename.replace(/[<>&]/g, '') +
-							'" did not.</strong> We only received its name. If the file matters, ' +
-							'reply to us at <a href="mailto:team@pdoom1.com" style="color: var(--accent-primary);">team@pdoom1.com</a> ' +
-							'with it attached, or <a href="' + ghUrl + '" target="_blank" rel="noopener" style="color: var(--accent-primary);">file it on GitHub &rarr;</a> where you can upload it.';
+						an.textContent = '\u{1F4CE} "' + bugData.attachment.filename + '" came through with your report.';
 					}
-					setTimeout(() => { button.textContent = originalText; button.style.background = ''; e.target.reset(); button.disabled = false; }, 3000);
+					setTimeout(() => { button.textContent = originalText; button.style.background = ''; e.target.reset(); button.disabled = false; const n = document.getElementById('bug-attach-note'); if (n) n.remove(); }, 3000);
 				} else {
 					window.open(ghUrl, '_blank', 'noopener');
 					button.textContent = 'Continue on GitHub \u2192';

--- a/public/bug-submit.php
+++ b/public/bug-submit.php
@@ -27,6 +27,7 @@ const MAX_TITLE   = 200;
 const MAX_DESC    = 5000;
 const MAX_EMAIL   = 200;
 const MAX_CREDIT  = 80;                      // name the reporter wants crediting as
+const MAX_ATTACH_BYTES = 550 * 1024;         // decoded cap; client caps the file at 500 KB
 const TYPES       = ['bug', 'feature', 'documentation', 'performance'];
 
 header('Content-Type: application/json; charset=utf-8');
@@ -93,18 +94,36 @@ if ($title === '' || $desc === '') {
     done(422, ['ok' => false, 'error' => 'A title and description are required.']);
 }
 
-$hasAttachment = isset($data['attachment']['filename']);
+// ---- attachment (optional) ---------------------------------------------
+// The client base64-encodes the picked file into attachment.content. We decode
+// it, hard-cap the size, and sanitise the filename to inert characters (no CR/LF
+// or quotes -> no header injection, no path traversal), then MIME-attach it. The
+// bytes are inert in an email and Gmail scans attachments on receipt; we never
+// execute, store, or trust the declared type -- everything is octet-stream.
+$att = $data['attachment'] ?? null;
+$attBytes = '';
+$attName = '';
+if (is_array($att) && !empty($att['content']) && is_string($att['content'])) {
+    $attName = preg_replace('/[^\w.\- ]+/u', '_', basename($clean($att['filename'] ?? 'attachment', 120)));
+    if ($attName === '') { $attName = 'attachment'; }
+    $decoded = base64_decode(preg_replace('/\s+/', '', $att['content']), true);
+    if ($decoded !== false && $decoded !== '' && strlen($decoded) <= MAX_ATTACH_BYTES) {
+        $attBytes = $decoded;
+    }
+}
+$hasAttachment = ($attBytes !== '');
 $attNote = $hasAttachment
-    ? "\n\nAttachment: reporter attached \"" . $clean($data['attachment']['filename'], 120)
-      . "\" (" . (int)($data['attachment']['size'] ?? 0) . " bytes) -- not forwarded by email; "
-      . "reply to ask for it, or they can re-file on GitHub with the file attached."
-    : '';
+    ? "\n\nAttachment: \"$attName\" (" . strlen($attBytes) . " bytes) is attached to this email."
+    : (isset($att['filename'])
+        ? "\n\nAttachment: reporter picked \"" . $clean($att['filename'] ?? '', 120)
+          . "\" but it could not be attached (too large or unreadable) -- reply to ask for it."
+        : '');
 
 // ---- compose (all user text in the BODY; headers are constants) ---------
 $subject = 'p(Doom)1 ' . $type . ': ' . mb_substr($title, 0, 80);
 $subject = str_replace(["\r", "\n"], ' ', $subject);   // belt-and-braces
 
-$body = "New feedback from the pdoom1.com bug form.\n"
+$textBody = "New feedback from the pdoom1.com bug form.\n"
       . "----------------------------------------\n"
       . "Type:    $type\n"
       . "Title:   $title\n"
@@ -117,9 +136,29 @@ $body = "New feedback from the pdoom1.com bug form.\n"
       . $desc
       . $attNote . "\n";
 
-$headers = 'From: p(Doom)1 site <' . FROM . ">\r\n"
-         . 'Content-Type: text/plain; charset=utf-8' . "\r\n"
-         . 'X-Mailer: pdoom1-bug-form';
+if ($hasAttachment) {
+    // multipart/mixed: the text report + the file, in one email.
+    $boundary = '=_pdoom_' . bin2hex(random_bytes(12));
+    $headers = 'From: p(Doom)1 site <' . FROM . ">\r\n"
+             . "MIME-Version: 1.0\r\n"
+             . 'Content-Type: multipart/mixed; boundary="' . $boundary . '"' . "\r\n"
+             . 'X-Mailer: pdoom1-bug-form';
+    $body = "--$boundary\r\n"
+          . "Content-Type: text/plain; charset=utf-8\r\n"
+          . "Content-Transfer-Encoding: 8bit\r\n\r\n"
+          . $textBody . "\r\n"
+          . "--$boundary\r\n"
+          . "Content-Type: application/octet-stream; name=\"$attName\"\r\n"
+          . "Content-Transfer-Encoding: base64\r\n"
+          . "Content-Disposition: attachment; filename=\"$attName\"\r\n\r\n"
+          . chunk_split(base64_encode($attBytes)) . "\r\n"
+          . "--$boundary--\r\n";
+} else {
+    $headers = 'From: p(Doom)1 site <' . FROM . ">\r\n"
+             . 'Content-Type: text/plain; charset=utf-8' . "\r\n"
+             . 'X-Mailer: pdoom1-bug-form';
+    $body = $textBody;
+}
 
 $sent = @mail(RECIPIENT, $subject, $body, $headers);
 


### PR DESCRIPTION
## ⚠️ Must be live-tested before trusting

`bug-submit.php` **cannot be PHP-linted here** (no PHP/Docker; Netlify previews don't run PHP). I reviewed it statically — balanced delimiters, parenthesised nested ternary (safe on PHP 8+), concatenation chains intact — but *static ≠ executed*. **After merge, I'll POST a real attachment to the live endpoint and you confirm the file lands in team@.** Please don't treat attachments as working until that passes.

## Attachments (your ask)

The client already base64-encoded the file into `attachment.content`; the PHP ignored it. Now it decodes, **hard-caps at 550 KB**, **sanitises the filename** to inert chars (no CR/LF or quotes → no header injection / path traversal), and MIME-attaches it as `application/octet-stream` in a `multipart/mixed` email. Declared type never trusted; nothing executed or stored; Gmail scans on receipt (the virus tradeoff you signed off).

Reverted the interim *"the file is not sent to us"* copy — it's now true that files come through, so the intro, label (**Attach a File**), help, and success note say so.

## Smoke-test diagnosis (why your tests vanished)

**Not delivery** — your `pdoom1.com` MX is Google Workspace and my diagnostic POST hit your inbox in ~1s. It's the **anti-bot guards silently dropping legit submissions as fake-success** (`bug-submit.php:58-64`): the honeypot (browser autofill) or the **3-second time-trap** (you testing fast). The form says "Submitted!" and drops it, with no server-side record. That's a real launch-day feedback-loss risk and a "never lie" violation. **Not fixed in this PR** — it's a security-posture call. Options for a follow-up: lower/remove the time-trap, and/or log every attempt (incl. drops) server-side so nothing is ever silently lost. Recommend the logging route — it doubles as the ledger seed from the CMS workshop.

## Second blessing

`weekly-2026-w30` re-blessed (was pending re-confirm) → canonical. Added a **Blessings log** recording both the superseded first blessing and this one. *waves doom staff.*

## Bug-page lie fixed

Footer said *"No personal data collected"* while the form takes email + credit name. Now truthful, links `/privacy/`.

Do not auto-merge — merge when you're ready and I'll run the live attachment test immediately after.