### PR TITLE
fix(honesty): platform prose truthful + derive availability from a source

### DIFF
--- a/.github/workflows/content-honesty.yml
+++ b/.github/workflows/content-honesty.yml
@@ -1,0 +1,47 @@
+name: Content Honesty
+
+# Guards reader-facing claims that silently rot into lies. Today it enforces one
+# thing: no page a visitor can reach may advertise a platform that has no shipped
+# build. The source of truth is public/data/version.json -> latest_release.platforms
+# (derived from the release's actual assets by update-version-info.py), so this can
+# never drift from what actually shipped.
+#
+# Fails the PR check on violation -- that is the whole signal; it does not open
+# issues (unlike the data-contract workflow, this runs only on human-driven events,
+# so a red check is seen immediately). No secrets, read-only.
+
+on:
+  pull_request:
+    paths:
+      - 'public/**/*.html'
+      - 'public/data/version.json'
+      - 'scripts/check-platform-claims.py'
+      - 'scripts/test-download-resolution.js'
+  push:
+    branches: [main]
+    paths:
+      - 'public/**/*.html'
+      - 'public/data/version.json'
+      - 'scripts/check-platform-claims.py'
+      - 'scripts/test-download-resolution.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  honesty:
+    name: Platform-claims + download resolution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: No reachable page claims an unshipped platform
+        run: python scripts/check-platform-claims.py
+      - name: Download buttons resolve/degrade correctly
+        run: node scripts/test-download-resolution.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,21 @@ node    scripts/test-analytics-optout.js  # opt-out, DNT, no-injection regressio
 python  scripts/test_ingest_scores.py     # leaderboard read path
 python  scripts/validate_data.py          # data contracts
 python  scripts/check-stale-facts.py      # hardcoded facts that rot
+python  scripts/check-platform-claims.py  # no reachable page claims an unshipped OS
+node    scripts/test-download-resolution.js # download buttons resolve/degrade right
 python  scripts/snapshot-copy.py --check  # reader-facing prose drift
 python  scripts/generate-feeds.py --check # feeds in step with the blog
 node    scripts/test-header-consistency.js
 ```
+
+**Platform availability is a *derived* fact, not prose.** The source of truth is
+`public/data/version.json` → `latest_release.platforms` ({windows,macos,linux}
+booleans), which `scripts/update-version-info.py` derives from the GitHub release's
+actual **assets** (a build is either attached or it is not). Pages must not hardcode
+"available on Windows/Mac/Linux"; say "coming soon" for anything unshipped, or read
+the field (see `about/index.html`'s `platforms-available` stat). `check-platform-claims.py`
+(also wired to CI via `content-honesty.yml`) fails if a reachable page advertises a
+platform that has no build.
 
 ## Automation notes
 - Weekly-league rollover only opens a GitHub issue **on failure**

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -540,7 +540,7 @@
 				</div>
 				<div class="card">
 					<h3>Native Cross-Platform</h3>
-					<p>Exported to Windows, macOS, and Linux from a single Godot codebase, for smooth native gameplay.</p>
+					<p>Built to run natively on Windows, macOS, and Linux from a single Godot codebase. The Windows build is available now; macOS and Linux are coming soon.</p>
 				</div>
 				<div class="card">
 					<h3>Data-Driven Design</h3>
@@ -570,8 +570,12 @@
 					<span class="stat-label">Source License</span>
 				</div>
 				<div class="stat-item">
-					<span class="stat-number">3+</span>
-					<span class="stat-label">Platforms Supported</span>
+					<!-- Count of platforms with a shipped build, from version.json
+					     latest_release.platforms. Ships as a dash so a failed fetch
+					     shows "unknown" rather than a hardcoded "3+" that overclaims
+					     while only Windows is downloadable. -->
+					<span class="stat-number" id="platforms-available">&mdash;</span>
+					<span class="stat-label">Platforms Available</span>
 				</div>
 				<div class="stat-item">
 					<span class="stat-number">Active</span>
@@ -636,19 +640,28 @@
 	</script>
 
 	<script>
-		// Project Stats "Current Version" comes from the canonical /data/version.json,
-		// never from a literal baked into this page.
-		(async function loadCurrentVersion() {
-			const el = document.getElementById('current-version');
-			if (!el) return;
+		// Project Stats "Current Version" and "Platforms Available" both come from the
+		// canonical /data/version.json, never from a literal baked into this page. On
+		// any failure the dashes stay put rather than asserting a stale/overclaimed value.
+		(async function loadProjectStats() {
+			const verEl = document.getElementById('current-version');
+			const platEl = document.getElementById('platforms-available');
+			if (!verEl && !platEl) return;
 			try {
 				const res = await fetch('/data/version.json', { cache: 'no-store' });
 				if (!res.ok) return;
 				const data = await res.json();
-				const version = (data.latest_release || {}).version;
-				if (version) el.textContent = version;
+				const release = data.latest_release || {};
+				if (verEl && release.version) verEl.textContent = release.version;
+				// platforms is { windows: bool, macos: bool, linux: bool }; count the
+				// ones with a shipped build. Only fill when the key is present, so an
+				// older version.json without it leaves the honest dash.
+				if (platEl && release.platforms && typeof release.platforms === 'object') {
+					const n = Object.values(release.platforms).filter(Boolean).length;
+					platEl.textContent = String(n);
+				}
 			} catch (e) {
-				// Leave the dash in place rather than showing a stale version.
+				// Leave the dashes in place rather than showing stale/overclaimed stats.
 			}
 		})();
 	</script>

--- a/public/data/version.json
+++ b/public/data/version.json
@@ -4,7 +4,12 @@
     "name": "P(Doom) v0.13.0 -- First Contact league (L2)",
     "published_at": "2026-07-24T11:15:26Z",
     "html_url": "https://github.com/PipFoweraker/pdoom1/releases/tag/v0.13.0",
-    "body": "New league epoch L2 (seed weekly-2026-w30). Story cold-open, hiring pipeline, non-profit/for-profit choice, costs-on-buttons, day-precise ledger, candidate portraits, and a chain of soft-lock fixes. Extract the whole zip first, then run PDoom.exe. Unsigned alpha -- SmartScreen: More info -> Run anyway."
+    "body": "New league epoch L2 (seed weekly-2026-w30). Story cold-open, hiring pipeline, non-profit/for-profit choice, costs-on-buttons, day-precise ledger, candidate portraits, and a chain of soft-lock fixes. Extract the whole zip first, then run PDoom.exe. Unsigned alpha -- SmartScreen: More info -> Run anyway.",
+    "platforms": {
+      "windows": true,
+      "macos": false,
+      "linux": false
+    }
   },
   "repository_stats": {
     "stars": 8,

--- a/public/index.html
+++ b/public/index.html
@@ -840,9 +840,14 @@ t	.hero {
 				<div class="designer-credit">Pip Foweraker's</div>
 				<a href="#" class="logo" aria-label="p(Doom)1 home">p(Doom)1</a>
 			</div>
+			<!-- Ships empty: loadVersionInfo() fills these from /data/version.json.
+			     A hardcoded literal here asserts a stale release on every load before
+			     the fetch resolves, and forever if it fails -- silence beats a
+			     confident wrong number. (Previously carried a hardcoded version and
+			     date that had gone two releases stale.) -->
 			<div class="version-info" id="versionInfo">
-				<span class="version-number" id="versionNumber">v0.11.0</span>
-				<span id="versionDate">2025-12-07</span>
+				<span class="version-number" id="versionNumber"></span>
+				<span id="versionDate"></span>
 			</div>
 			<ul class="nav-links" role="menubar">
 				<li role="none"><a href="#home" role="menuitem">Game</a></li>
@@ -886,16 +891,21 @@ t	.hero {
 
 			<!-- Download Options - Platform-Specific CTAs -->
 			<div class="download-ctas" style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.4rem;">
-				<!-- hrefs default to the release PAGE (never 404s on any asset naming);
-				     resolveDownloads() upgrades them to direct per-platform asset URLs. -->
+				<!-- Windows has a shipped build, so it defaults live (release PAGE href,
+				     which never 404s on any asset naming); resolveDownloads() upgrades it
+				     to the direct asset URL. macOS and Linux default to a DISABLED
+				     "coming soon" state and are upgraded to live ONLY when a matching
+				     build is confirmed in the latest release. That inverts the old
+				     fail direction: a rate-limited/offline visitor now sees the honest
+				     "coming soon" rather than a live-looking button that leads nowhere. -->
 				<a id="download-windows" data-platform-label="Windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Windows
 				</a>
-				<a id="download-macos" data-platform-label="macOS" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
-					Download for macOS
+				<a id="download-macos" data-platform-label="macOS" role="note" aria-disabled="true" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem; opacity: 0.55; cursor: default; pointer-events: none;">
+					macOS — coming soon
 				</a>
-				<a id="download-linux" data-platform-label="Linux" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
-					Download for Linux
+				<a id="download-linux" data-platform-label="Linux" role="note" aria-disabled="true" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem; opacity: 0.55; cursor: default; pointer-events: none;">
+					Linux — coming soon
 				</a>
 			</div>
 
@@ -934,7 +944,7 @@ t	.hero {
 			-->
 
 			<p style="font-size: 0.85rem; color: var(--text-muted); text-align: center;">
-				Windows, macOS, Linux | Free & Open Source
+				Windows now · macOS & Linux coming soon | Free & Open Source
 			</p>
 		</section>
 
@@ -1093,7 +1103,7 @@ t	.hero {
 							<h3>System Requirements</h3>
 							<p style="margin-bottom: 0.8rem;"><strong>Minimum:</strong></p>
 							<ul style="color: var(--text-secondary); margin: 0 0 1rem 1.2rem; line-height: 1.8;">
-								<li>64-bit Windows, macOS, or Linux</li>
+								<li>64-bit Windows (macOS &amp; Linux builds coming soon)</li>
 								<li>Native build &mdash; no runtime to install</li>
 								<li>Basic graphics support</li>
 								<li>Built with Godot 4.5.1</li>
@@ -1101,13 +1111,13 @@ t	.hero {
 							<p style="margin-bottom: 0.5rem;"><strong>Platforms:</strong></p>
 							<div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
 								<span style="background: var(--bg-primary); padding: 0.3rem 0.6rem; border-radius: var(--radius-sm); font-size: 0.85rem;">Windows</span>
-								<span style="background: var(--bg-primary); padding: 0.3rem 0.6rem; border-radius: var(--radius-sm); font-size: 0.85rem;">macOS</span>
-								<span style="background: var(--bg-primary); padding: 0.3rem 0.6rem; border-radius: var(--radius-sm); font-size: 0.85rem;">Linux</span>
+								<span style="background: var(--bg-primary); padding: 0.3rem 0.6rem; border-radius: var(--radius-sm); font-size: 0.85rem; opacity: 0.6;">macOS — soon</span>
+								<span style="background: var(--bg-primary); padding: 0.3rem 0.6rem; border-radius: var(--radius-sm); font-size: 0.85rem; opacity: 0.6;">Linux — soon</span>
 							</div>
 						</div>
 						<div class="card">
 							<h3>Quick Installation</h3>
-							<p style="margin-bottom: 0.8rem;">Download the build for your platform from the buttons above &mdash; no installation, no runtime needed.</p>
+							<p style="margin-bottom: 0.8rem;">Download the Windows build from the buttons above &mdash; no installation, no runtime needed. macOS &amp; Linux builds are coming soon.</p>
 <pre style="background: var(--bg-primary); padding: 0.8rem; border-radius: var(--radius-sm); overflow-x: auto; color: var(--accent-primary); font-size: 0.85rem; line-height: 1.4; margin: 0;">git clone https://github.com/PipFoweraker/pdoom1.git
 # then open the project in Godot 4.5.1 to run from source</pre>
 							<p style="margin-top: 0.8rem; font-size: 0.85rem; color: var(--text-muted);">
@@ -1215,7 +1225,7 @@ t	.hero {
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
 					<summary style="font-weight: bold; color: var(--accent-primary); cursor: pointer; margin-bottom: 0.8rem;">Is it free and open source?</summary>
-					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows, macOS, and Linux supported. Steam release coming soon.</p>
+					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows is available now; macOS and Linux builds are coming soon. Steam release later.</p>
 				</details>
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
@@ -1601,6 +1611,25 @@ t	.hero {
 				el.textContent = label + ' — coming soon';
 			}
 
+			// Inverse of markUnavailable: promote a button to a live download once a
+			// build for it is confirmed. macOS/Linux ship DISABLED in the HTML, so
+			// this is what turns them back on the day their build lands -- reachable
+			// only via a confirmed asset, never by default.
+			function markAvailable(el, url) {
+				if (!el) return;
+				const label = el.dataset.platformLabel || 'this platform';
+				el.href = url;
+				el.setAttribute('target', '_blank');
+				el.setAttribute('rel', 'noopener');
+				el.setAttribute('role', 'button');
+				el.removeAttribute('aria-disabled');
+				el.title = '';
+				el.style.opacity = '';
+				el.style.cursor = '';
+				el.style.pointerEvents = '';
+				el.textContent = 'Download for ' + label;
+			}
+
 			try {
 				const res = await fetch('https://api.github.com/repos/PipFoweraker/pdoom1/releases/latest',
 					{ headers: { 'Accept': 'application/vnd.github+json' } });
@@ -1621,7 +1650,7 @@ t	.hero {
 				for (const [id, asset] of found) {
 					const el = document.getElementById(id);
 					if (!el) continue;
-					if (asset) el.href = asset.browser_download_url;
+					if (asset) markAvailable(el, asset.browser_download_url);
 					else markUnavailable(el);
 				}
 				// Show the macOS first-run note only when a macOS build actually resolved.

--- a/public/index.html
+++ b/public/index.html
@@ -1585,7 +1585,9 @@ t	.hero {
 		// asset naming; on rate-limit/offline it silently keeps the working release-page href.
 		async function resolveDownloads() {
 			const platforms = {
-				'download-windows': /win/i,
+				// `.exe$` catches a bare PDoom.exe (v0.13.1+ dropped the "windows" in the
+				// filename); "win" still catches PDoom-...-windows.zip (v0.13.0 style).
+				'download-windows': /win|\.exe$/i,
 				'download-macos': /mac|osx|darwin|\.app|\.dmg/i,
 				'download-linux': /linux|x86_64|\.appimage/i
 			};

--- a/public/press/index.html
+++ b/public/press/index.html
@@ -351,7 +351,7 @@
 				</div>
 				<div class="factsheet-item">
 					<strong>Platform:</strong>
-					Windows, macOS, Linux
+					Windows (available now); macOS &amp; Linux coming soon
 				</div>
 				<div class="factsheet-item">
 					<strong>Developer:</strong>
@@ -403,7 +403,7 @@
 				</a>
 			</p>
 			<p style="text-align: center; color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1.5rem;">
-				Windows and macOS. Linux is in progress. Free and open source &mdash; no store account needed.
+				Windows now. macOS and Linux coming soon. Free and open source &mdash; no store account needed.
 			</p>
 
 			<!-- Steam badge - Valve compliant -->

--- a/scripts/check-platform-claims.py
+++ b/scripts/check-platform-claims.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Guard: no reachable page may claim a platform is available that has no shipped build.
+
+The rot this prevents (it bit us on 2026-07-25): the site said "Windows, macOS,
+Linux" while only a Windows build existed. The single source of truth for "which
+platforms shipped" is public/data/version.json -> latest_release.platforms, which
+update-version-info.py derives from the release's actual assets (a build is either
+attached or it is not -- un-fakeable). This script cross-checks the reader-facing
+pages against that source.
+
+HEURISTIC, and deliberately biased toward flagging. For each platform the source
+marks UNavailable, it flags a reachable-page line that mentions that platform in an
+availability context -- i.e. the line lists two or more OS names together, OR uses
+an availability verb (download/available/supported/...) -- UNLESS the line also
+carries a soft qualifier (coming soon / this week / in progress / later / a dash).
+A qualified line ("macOS -- coming soon") is honest and passes; a bare list
+("Windows, macOS, Linux") is not and fails.
+
+Limits (stated, not hidden): it reads raw HTML lines, so a claim split across lines
+can slip through, and it only scans the curated reachable set below. It is a
+regression net for the specific failure mode above, not a proof of total honesty.
+
+Exit 1 on any finding (so CI blocks it). Genuine false positives go in ALLOWLIST
+with a reason, never by loosening the heuristic.
+"""
+
+import json
+import os
+import re
+import sys
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+VERSION_JSON = os.path.join(ROOT, "public", "data", "version.json")
+
+# Pages a visitor can actually walk to (the navigation.js menu + the download flow
+# and the forms reached from it). Deliberately NOT the ~2,200 generated event pages.
+REACHABLE = [
+    "public/index.html",
+    "public/press/index.html",
+    "public/about/index.html",
+    "public/game-stats/index.html",
+    "public/leaderboard/index.html",
+    "public/bug-report/index.html",
+    "public/privacy/index.html",
+    "public/cats/index.html",
+    "public/issues/index.html",
+    "public/game-changelog/index.html",
+    "public/docs/index.html",
+    "public/blog/index.html",
+    "public/resources/index.html",
+]
+
+# Word-boundary name matchers per platform key in version.json.
+PLATFORM_NAMES = {
+    "windows": re.compile(r"\bwindows\b", re.I),
+    "macos": re.compile(r"\bmac\s?os\b|\bmacos\b|\bos\s?x\b|\bosx\b", re.I),
+    "linux": re.compile(r"\blinux\b", re.I),
+}
+
+# A line that says one of these near a platform is asserting availability.
+AVAILABILITY_VERB = re.compile(
+    r"\b(download|available|supported|exported to|runs? on|native on|"
+    r"get it on|play on|ships? on|grab the)\b",
+    re.I,
+)
+
+# ...unless it is softened into a promise, not a claim of the present.
+SOFT_QUALIFIER = re.compile(
+    r"coming soon|coming|\bsoon\b|this week|in progress|\bplanned\b|not yet|"
+    r"\blater\b|roadmap|\bfuture\b|work in progress|\bwip\b|"
+    r"—|&mdash;|--",  # an em dash, as in "macOS -- coming soon"
+    re.I,
+)
+
+# (file substring, line substring) pairs that are known-honest despite tripping the
+# heuristic. Add with a comment saying WHY; do not weaken the rules to clear one.
+ALLOWLIST = [
+    # (none yet)
+]
+
+
+def strip_to_visible_text(html):
+    """Reduce HTML to what a visitor actually reads: drop <script>/<style>/comment
+    blocks and all tags (so element ids like `download-macos` and JS regexes can't
+    masquerade as prose), while preserving line numbers by replacing each removed
+    span with as many newlines as it contained."""
+    def blank(m):
+        return "\n" * m.group(0).count("\n")
+    html = re.sub(r"<script\b[^>]*>.*?</script>", blank, html, flags=re.I | re.S)
+    html = re.sub(r"<style\b[^>]*>.*?</style>", blank, html, flags=re.I | re.S)
+    html = re.sub(r"<!--.*?-->", blank, html, flags=re.S)
+    html = re.sub(r"<[^>]+>", blank, html)  # remaining tags (attrs live here) -> gone
+    return html
+
+
+def load_available_platforms():
+    with open(VERSION_JSON, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    platforms = (data.get("latest_release") or {}).get("platforms")
+    if not isinstance(platforms, dict):
+        return None
+    return platforms
+
+
+def allowlisted(path, line):
+    for f_sub, l_sub in ALLOWLIST:
+        if f_sub in path and l_sub in line:
+            return True
+    return False
+
+
+def scan():
+    platforms = load_available_platforms()
+    if platforms is None:
+        print("SKIP: version.json has no latest_release.platforms; nothing to check.")
+        print("      (An older version.json predates the platforms field.)")
+        return 0
+
+    unavailable = [p for p, ok in platforms.items() if not ok]
+    available = [p for p, ok in platforms.items() if ok]
+    print(f"version.json platforms -> available: {available or '(none)'} | "
+          f"unavailable: {unavailable or '(none)'}")
+    if not unavailable:
+        print("No unavailable platforms to guard against. OK.")
+        return 0
+
+    findings = []
+    for rel in REACHABLE:
+        path = os.path.join(ROOT, rel)
+        if not os.path.isfile(path):
+            print(f"  note: {rel} not found, skipped")
+            continue
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            visible = strip_to_visible_text(f.read())
+        for n, raw in enumerate(visible.split("\n"), 1):
+                line = raw.rstrip("\n")
+                if SOFT_QUALIFIER.search(line):
+                    continue  # a softened promise, not a present-tense claim
+                names_hit = [p for p, rx in PLATFORM_NAMES.items() if rx.search(line)]
+                unavail_hit = [p for p in names_hit if p in unavailable]
+                if not unavail_hit:
+                    continue
+                is_list = len(names_hit) >= 2
+                is_verb = bool(AVAILABILITY_VERB.search(line))
+                if (is_list or is_verb) and not allowlisted(rel, line):
+                    findings.append((rel, n, unavail_hit, line.strip()[:160]))
+
+    if not findings:
+        print(f"OK: no reachable page claims {unavailable} as available.")
+        return 0
+
+    print(f"\nFAIL: {len(findings)} line(s) claim an unshipped platform as available:\n")
+    for rel, n, hit, text in findings:
+        print(f"  {rel}:{n}  (claims: {', '.join(hit)})")
+        print(f"      {text}")
+    print("\nFix: add a soft qualifier (\"coming soon\") or remove the platform, or")
+    print("if the release now ships it, update version.json/its assets. Genuine false")
+    print("positives go in ALLOWLIST with a reason.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(scan())

--- a/scripts/test-download-resolution.js
+++ b/scripts/test-download-resolution.js
@@ -89,6 +89,14 @@ async function run(name, assets, { ok = true } = {}) {
   check(els['download-windows'].href === BASE, 'Windows keeps baseline');
   check(!els['download-macos'].hasAttribute('href'), 'macOS stays disabled');
 
+  // Scenario 5: v0.13.1 naming -- bare PDoom.exe / PDoom.x86_64 / PDoom.app.zip.
+  // The Windows asset lost its "windows" substring, so /win|\.exe$/ must catch it.
+  els = await run('v0.13.1', [A('PDoom.exe'), A('PDoom.x86_64'), A('PDoom.app.zip')]);
+  console.log('Scenario 5: v0.13.1 bare-name assets (PDoom.exe / .x86_64 / .app.zip)');
+  check(els['download-windows'].href === 'https://gh/PDoom.exe', 'Windows -> PDoom.exe resolved (not missed)');
+  check(els['download-macos'].href === 'https://gh/PDoom.app.zip', 'macOS -> PDoom.app.zip resolved');
+  check(els['download-linux'].href === 'https://gh/PDoom.x86_64', 'Linux -> PDoom.x86_64 resolved');
+
   console.log(failures ? `\n${failures} FAILURE(S)` : '\nAll checks passed.');
   process.exit(failures ? 1 : 0);
 })();

--- a/scripts/test-download-resolution.js
+++ b/scripts/test-download-resolution.js
@@ -1,9 +1,10 @@
 // Extracts resolveDownloads() from public/index.html and exercises it against a
 // minimal DOM/fetch shim. Verifies the launch-day contract:
-//   - a platform WITH an asset gets a direct download href
-//   - a platform WITHOUT one says "coming soon" instead of silently pointing at a
-//     release page that has no build for it
-//   - an unreachable API degrades NOTHING (we cannot know what shipped)
+//   - a platform WITH an asset gets a direct download href AND a live label
+//   - a platform WITHOUT one says "coming soon" instead of a live-looking button
+//   - an unreachable API degrades NOTHING and, crucially, never UPGRADES an
+//     unshipped platform: macOS/Linux ship disabled in the HTML, so a rate-limited
+//     visitor keeps the honest "coming soon" rather than being shown a live button.
 const fs = require('fs');
 const path = require('path');
 const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
@@ -13,10 +14,18 @@ if (!m) { console.error('FAIL: could not extract resolveDownloads()'); process.e
 
 const BASE = 'https://github.com/PipFoweraker/pdoom1/releases/latest';
 
-function makeEl(id, label) {
+// Model the REAL initial DOM: Windows ships live (release-page baseline); macOS and
+// Linux ship DISABLED ("coming soon", no href) and must only go live on a confirmed
+// asset. `available` picks which starting state to build.
+function makeEl(id, label, available) {
+  const attrs = available
+    ? { href: BASE, target: '_blank' }   // Windows: live baseline
+    : {};                                 // macOS/Linux: disabled, no href
   return {
-    id, dataset: { platformLabel: label }, textContent: 'Download for ' + label,
-    style: {}, _attrs: { href: BASE, target: '_blank' },
+    id, dataset: { platformLabel: label },
+    textContent: available ? ('Download for ' + label) : (label + ' — coming soon'),
+    style: available ? {} : { opacity: '0.55', pointerEvents: 'none', cursor: 'default' },
+    _attrs: attrs,
     hasAttribute(k) { return k in this._attrs; },
     removeAttribute(k) { delete this._attrs[k]; },
     setAttribute(k, v) { this._attrs[k] = v; },
@@ -27,9 +36,9 @@ function makeEl(id, label) {
 
 async function run(name, assets, { ok = true } = {}) {
   const els = {
-    'download-windows': makeEl('download-windows', 'Windows'),
-    'download-macos': makeEl('download-macos', 'macOS'),
-    'download-linux': makeEl('download-linux', 'Linux'),
+    'download-windows': makeEl('download-windows', 'Windows', true),
+    'download-macos': makeEl('download-macos', 'macOS', false),
+    'download-linux': makeEl('download-linux', 'Linux', false),
     'macos-gatekeeper-note': { id: 'note', style: { display: 'none' } },
   };
   const document = { getElementById: (id) => els[id] || null };
@@ -47,34 +56,38 @@ async function run(name, assets, { ok = true } = {}) {
 
   const A = (n) => ({ name: n, browser_download_url: 'https://gh/' + n });
 
-  // Scenario 1: today's intended shape -- Windows + macOS ship, Linux does not.
-
-  let els = await run('win+mac', [A('PDoom-v0.13.0-windows.zip'), A('PDoom-v0.13.0-macOS.zip')]);
+  // Scenario 1: a future release where Windows + macOS ship, Linux does not.
+  let els = await run('win+mac', [A('PDoom-v0.14.0-windows.zip'), A('PDoom-v0.14.0-macOS.zip')]);
   console.log('Scenario 1: Windows + macOS assets, no Linux');
-  check(els['download-windows'].href === 'https://gh/PDoom-v0.13.0-windows.zip', 'Windows -> direct asset');
-  check(els['download-macos'].href === 'https://gh/PDoom-v0.13.0-macOS.zip', 'macOS -> direct asset');
-  check(!els['download-linux'].hasAttribute('href'), 'Linux -> href removed (not a dead link)');
+  check(els['download-windows'].href === 'https://gh/PDoom-v0.14.0-windows.zip', 'Windows -> direct asset');
+  check(els['download-macos'].href === 'https://gh/PDoom-v0.14.0-macOS.zip', 'macOS -> direct asset (upgraded from disabled)');
+  check(els['download-macos'].textContent === 'Download for macOS', 'macOS -> label restored to live');
+  check(!els['download-linux'].hasAttribute('href'), 'Linux -> no href (not a dead link)');
   check(/coming soon/i.test(els['download-linux'].textContent), 'Linux -> says "coming soon"');
   check(els['macos-gatekeeper-note'].style.display === 'block', 'Gatekeeper note shown (mac resolved)');
 
-  // Scenario 2: Windows only -- the CURRENT v0.12.0 shape. Mac must degrade too.
-  els = await run('win only', [A('PDoom-v0.12.0-windows.zip')]);
-  console.log('Scenario 2: Windows only (current v0.12.0 shape)');
-  check(els['download-windows'].href === 'https://gh/PDoom-v0.12.0-windows.zip', 'Windows -> direct asset');
-  check(!els['download-macos'].hasAttribute('href'), 'macOS -> degraded');
+  // Scenario 2: Windows only -- TODAY's real shape (v0.13.0).
+  els = await run('win only', [A('PDoom-v0.13.0-windows.zip')]);
+  console.log('Scenario 2: Windows only (current v0.13.0 shape)');
+  check(els['download-windows'].href === 'https://gh/PDoom-v0.13.0-windows.zip', 'Windows -> direct asset');
+  check(!els['download-macos'].hasAttribute('href'), 'macOS -> stays "coming soon" (no href)');
+  check(/coming soon/i.test(els['download-macos'].textContent), 'macOS -> says "coming soon"');
   check(els['macos-gatekeeper-note'].style.display === 'none', 'Gatekeeper note hidden (no mac build)');
 
-  // Scenario 3: API unreachable -- we know nothing, so change nothing.
+  // Scenario 3: API unreachable -- change nothing. Windows keeps its live baseline;
+  // macOS/Linux keep the honest disabled default (NEVER upgraded without an asset).
   els = await run('rate limited', [], { ok: false });
   console.log('Scenario 3: API rate-limited / offline');
   check(els['download-windows'].href === BASE, 'Windows keeps release-page baseline');
-  check(els['download-linux'].href === BASE, 'Linux keeps baseline (NOT falsely "coming soon")');
+  check(!els['download-macos'].hasAttribute('href'), 'macOS stays disabled (NOT falsely upgraded)');
+  check(/coming soon/i.test(els['download-macos'].textContent), 'macOS still says "coming soon"');
+  check(!els['download-linux'].hasAttribute('href'), 'Linux stays disabled (NOT falsely upgraded)');
 
-  // Scenario 4: assets exist but none match our naming guess -> keep baseline.
+  // Scenario 4: assets exist but none match our naming guess -> keep baseline / defaults.
   els = await run('unrecognised', [A('SomethingWeird.bin'), A('checksums.txt')]);
   console.log('Scenario 4: release has assets, none recognised as builds');
   check(els['download-windows'].href === BASE, 'Windows keeps baseline');
-  check(els['download-linux'].href === BASE, 'Linux keeps baseline');
+  check(!els['download-macos'].hasAttribute('href'), 'macOS stays disabled');
 
   console.log(failures ? `\n${failures} FAILURE(S)` : '\nAll checks passed.');
   process.exit(failures ? 1 : 0);

--- a/scripts/update-version-info.py
+++ b/scripts/update-version-info.py
@@ -7,9 +7,18 @@ Fetches latest release info and updates website data files
 import json
 import os
 import re
+import sys
 import urllib.request
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
+# Windows console is cp1252; the check marks below (U+2713) would raise
+# UnicodeEncodeError on the FIRST print, aborting before any work. Force UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
 
 GITHUB_API_BASE = 'https://api.github.com'
 REPO_OWNER = 'PipFoweraker'
@@ -44,6 +53,34 @@ def read_existing_version_json() -> Dict[str, Any]:
         return {}
 
 
+# Same filename heuristics resolveDownloads() uses in index.html. Keep the two in
+# step: if the button can resolve a build for a platform, this must report that
+# platform available, and vice versa.
+_PLATFORM_PATTERNS = {
+    'windows': re.compile(r'win', re.I),
+    'macos':   re.compile(r'mac|osx|darwin|\.app|\.dmg', re.I),
+    'linux':   re.compile(r'linux|x86_64|\.appimage', re.I),
+}
+_BUILD_SUFFIX = re.compile(r'\.(zip|dmg|appimage|x86_64|exe|tar\.gz)$', re.I)
+
+
+def derive_platforms(assets: List[Dict[str, Any]]) -> Dict[str, bool]:
+    """Which OS builds are actually attached to the release.
+
+    A platform is 'available' iff a matching downloadable build exists -- the one
+    un-fakeable source of truth (the file is either in the release or it is not).
+    Pages and the platform-claims guard read this instead of trusting hand-typed
+    prose, which is what silently rots into a lie. NOTE: this is only meaningful on
+    a FRESH asset list; an empty list from a failed fetch would read as 'nothing
+    shipped anywhere', so callers must preserve the prior value on failure rather
+    than write all-False. See get_latest_release()."""
+    names = [a.get('name', '') for a in (assets or [])]
+    return {
+        os_key: any(pat.search(n) and _BUILD_SUFFIX.search(n) for n in names)
+        for os_key, pat in _PLATFORM_PATTERNS.items()
+    }
+
+
 def get_latest_release() -> Dict[str, Any]:
     """Get latest release information"""
     data = fetch_github_data(f"/repos/{REPO_OWNER}/{REPO_NAME}/releases/latest")
@@ -54,7 +91,10 @@ def get_latest_release() -> Dict[str, Any]:
             'name': data.get('name'),
             'published_at': data.get('published_at'),
             'html_url': data.get('html_url'),
-            'body': data.get('body', '')
+            'body': data.get('body', ''),
+            # Derived from THIS release's assets. Fresh fetch, so it is safe to
+            # write; the failure branch below keeps the last known-good instead.
+            'platforms': derive_platforms(data.get('assets', [])),
         }
 
     # API failed. This function's output is written straight into version.json, which

--- a/scripts/update-version-info.py
+++ b/scripts/update-version-info.py
@@ -57,7 +57,9 @@ def read_existing_version_json() -> Dict[str, Any]:
 # step: if the button can resolve a build for a platform, this must report that
 # platform available, and vice versa.
 _PLATFORM_PATTERNS = {
-    'windows': re.compile(r'win', re.I),
+    # '\.exe$' catches a bare PDoom.exe (v0.13.1+ dropped "windows" from the name);
+    # 'win' still catches PDoom-...-windows.zip (v0.13.0 style).
+    'windows': re.compile(r'win|\.exe$', re.I),
     'macos':   re.compile(r'mac|osx|darwin|\.app|\.dmg', re.I),
     'linux':   re.compile(r'linux|x86_64|\.appimage', re.I),
 }


### PR DESCRIPTION
## Why
A visitor walking in from the launch posts ("Windows today; Mac/Linux this week") landed on pages that said **"Windows, macOS, Linux"** as if all three were downloadable. Only `PDoom-v0.13.0-windows.zip` ships. That contradiction is the prime-directive failure ("never lie to a visitor"), and it was on every nav-reachable page.

Verify the preview: homepage download area, System Requirements, FAQ; `/press/`; `/about/`.

## What changed

**Tier-1 prose — now truthful** (every unshipped platform says "coming soon"):
- `index.html` — platform summary line, System Requirements + platform chips, Quick Installation, FAQ
- `press/index.html` — factsheet Platform line + download caption
- `about/index.html` — "Native Cross-Platform" card

**A source for platform availability (there was none as data):**
- `version.json` → `latest_release.platforms` `{windows,macos,linux}` booleans
- `update-version-info.py` derives them from the release's **actual assets** (a build is either attached or it isn't — un-fakeable), and inherits the file's preserve-on-failure discipline
- `about/`'s stat card now reads that field, fail-hidden to a dash (demonstrates the single-source pattern)

**Fail toward honest:**
- macOS/Linux download buttons ship **disabled** ("coming soon"); `resolveDownloads()` upgrades them to live only on a confirmed asset (`markAvailable`). Fixes the fail-open where a rate-limited visitor saw a live-looking Mac button.
- Homepage version literal `v0.11.0 / 2025-12-07` → empty spans filled from `version.json` (silence beats a stale number on fetch failure)

**Durable guard (so it can't rot back):**
- `scripts/check-platform-claims.py` — fails if any reachable page advertises a platform `version.json` marks unshipped. Scans rendered text only; "coming soon"/dash qualifiers pass. Proven to block the three original lies and pass the honest lines.
- Wired to CI via `.github/workflows/content-honesty.yml` (PRs touching reachable HTML or `version.json`)
- `test-download-resolution.js` updated to the new fail-toward-honest contract (all pass)

## Tests
- `node scripts/test-download-resolution.js` — all pass
- `python scripts/check-platform-claims.py` — OK (and no other reachable page over-claims)
- `python scripts/check-stale-facts.py` — homepage stale version literals gone

## Deliberately NOT in this PR (your call / needs verification)
- **"Godot 4.5.1"** engine claims (index/about/press) — both auditors flagged as possibly false vs the `PDoom.exe` packaging. Is the game actually Godot?
- Solo-vs-**"small team"** framing on about/press
- Stale **leaderboard v0.11.0** meta and **v0.4.1** changelog data (data-refresh, separate — `validate_data.py` already warns on the leaderboard one)
- The `issues/` page's fabricated "community forum" copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)