### PR TITLE
fix(honesty): truthful /issues/ page + solo-dev framing on /about/

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -6,7 +6,7 @@
 	<title>About - p(Doom)1</title>
 	<link rel="canonical" href="https://pdoom1.com/about/" />
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-	<meta name="description" content="Learn about p(Doom)1 development, the team behind the AI Safety Strategy Game, and our mission to make AI safety accessible through gaming." />
+	<meta name="description" content="Learn about p(Doom)1 development, the solo developer behind the AI Safety Strategy Game, and the mission to make AI safety accessible through gaming." />
 	<meta name="author" content="p(Doom)1" />
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="p(Doom)1" />
@@ -506,21 +506,21 @@
 		</section>
 
 		<section class="section">
-			<h2>Development Team</h2>
-			<p>p(Doom)1 is developed by a small team of passionate contributors who believe in the power of games to educate and inspire.</p>
+			<h2>Who's Building It</h2>
+			<p>p(Doom)1 is built by Pip Foweraker, working solo, in the belief that games can educate and inspire. It is developed in the open and MIT-licensed, so anyone is welcome to pitch in.</p>
 
 			<div class="grid">
 				<div class="team-member">
 					<div class="avatar">[IMG]</div>
-					<h4>Lead Developer</h4>
-					<div class="role">Game Design & Development</div>
-					<p>Responsible for core game mechanics, AI systems, and overall project direction.</p>
+					<h4>Pip Foweraker</h4>
+					<div class="role">Solo Developer</div>
+					<p>Design, code, AI systems, and overall direction &mdash; the whole thing, so far.</p>
 				</div>
 				<div class="team-member">
 					<div class="avatar">[IMG]</div>
-					<h4>Community Contributors</h4>
-					<div class="role">Open Source Development</div>
-					<p>Community members contributing code, ideas, and feedback through GitHub collaboration.</p>
+					<h4>Open to Contributors</h4>
+					<div class="role">MIT-Licensed, Built in the Open</div>
+					<p>Code, ideas, and feedback are welcome through GitHub. If you'd like to help, the door's open.</p>
 				</div>
 			</div>
 

--- a/public/issues/index.html
+++ b/public/issues/index.html
@@ -341,7 +341,11 @@
 		<section class="section" id="submit-issue">
 			<h2>Submit Feedback</h2>
 			<p style="color: var(--text-secondary); margin-bottom: 2rem;">
-				Tell us what's wrong or what could be better. We respect your privacy - only the information you provide will be shared.
+				Tell us what's wrong or what could be better. The quickest path is the
+				<a href="/bug-report/" style="color: var(--accent-primary);">direct bug reporter</a>,
+				which sends straight to the team &mdash; no email client, no GitHub account.
+				The form below is an alternative: it composes an email or a pre-filled GitHub
+				issue that <em>you</em> send. Nothing here is transmitted automatically.
 			</p>
 
 			<form id="issue-form" style="max-width: 700px; margin: 0 auto;">
@@ -384,13 +388,13 @@
 				</div>
 
 				<div style="background: var(--bg-tertiary); padding: 1rem; border-radius: var(--radius-sm); border: 1px solid var(--accent-primary); margin-bottom: 1.5rem;">
-					<h4 style="color: var(--accent-primary); margin-bottom: 0.5rem;">🔒 Privacy Promise</h4>
-					<p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 0.5rem 0;">
-						Your feedback will be shared with GitHub Issues and our community forum. Only the issue details you provide above will be posted publicly.
-						Contact information is stored separately and never shared publicly. You can submit anonymously.
-					</p>
-					<p style="font-size: 0.85rem; color: var(--text-muted); margin: 0;">
-						<strong>Note:</strong> We're currently setting up our community forum and automated forum posting &mdash; stay tuned!
+					<h4 style="color: var(--accent-primary); margin-bottom: 0.5rem;">🔒 What happens to your feedback</h4>
+					<p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0;">
+						This form doesn't transmit anything on its own. When you submit, it prepares
+						an email to the team &mdash; or a pre-filled GitHub issue &mdash; for you to send.
+						If you file it on GitHub, the issue text you wrote becomes public there; if you
+						email it, it stays private with the team. Any contact detail you add is used only
+						to reply, never posted publicly. You can submit anonymously.
 					</p>
 				</div>
 
@@ -660,8 +664,8 @@
 
 			// Disable form
 			submitButton.disabled = true;
-			submitButton.textContent = 'Submitting...';
-			formStatus.textContent = 'Processing your feedback...';
+			submitButton.textContent = 'Preparing...';
+			formStatus.textContent = 'Preparing your report...';
 			formStatus.style.color = 'var(--accent-primary)';
 
 			try {
@@ -686,14 +690,16 @@ ${formData.contact !== 'Anonymous' ? `**Contact:** ${formData.contact}` : ''}
 				await new Promise(resolve => setTimeout(resolve, 1000));
 
 				formStatus.innerHTML = `
-					<div style="color: var(--success-color); margin-bottom: 1rem;">✅ Thank you for your feedback!</div>
+					<div style="color: var(--accent-primary); margin-bottom: 1rem;">📝 Your report is ready &mdash; one step left to send it:</div>
 					<div style="font-size: 0.9rem; color: var(--text-secondary);">
 						<a href="mailto:team@pdoom1.com?subject=${subject}&body=${body}"
 						   style="color: var(--accent-primary); text-decoration: underline;">
-							Click here to complete submission via email
+							Send it via email
 						</a>
-						<p style="margin-top: 0.5rem;">Or manually create an issue on
-						<a href="https://github.com/PipFoweraker/pdoom1/issues/new" target="_blank" style="color: var(--accent-primary);">GitHub</a></p>
+						<p style="margin-top: 0.5rem;">or file it on
+						<a href="https://github.com/PipFoweraker/pdoom1/issues/new/choose" target="_blank" style="color: var(--accent-primary);">GitHub</a>.
+						Prefer it to just go straight through? Use the
+						<a href="/bug-report/" style="color: var(--accent-primary);">direct bug reporter</a>.</p>
 					</div>
 				`;
 


### PR DESCRIPTION
**Stacked on #166** (both touch `about/index.html`). Review/merge #166 first; GitHub will retarget this to `main` automatically once it lands.

## /issues/ — was lying three ways
This nav-reachable page (the old, non-working feedback path) claimed things that aren't true:
- **Phantom forum:** "shared with … our community forum" and "setting up … automated forum posting — stay tuned!" — no forum exists, and line 474 of the same page already said "We're not running a separate forum."
- **False transmission:** "Your feedback will be shared with GitHub Issues" — the form only composes a `mailto`/GitHub link the user must click; nothing is sent.
- **Fabricated success:** after a fake 1-second delay it showed "✅ Thank you for your feedback!" before anything was sent.

**Now:** intro and result copy state plainly that the form *prepares* an email or a pre-filled GitHub issue for **you** to send; it points to the working [`/bug-report/`](/bug-report/) direct reporter as the no-email-client path; the success line reads "📝 Your report is ready — one step left to send it." GitHub link upgraded from blank `issues/new` (bounces when blank issues are disabled) to `issues/new/choose`.

## /about/ — "small team" → solo, honestly
Contributors are effectively just Pip (1038 commits; the other two are a bot and one drive-by commit). "A small team of passionate contributors" + a two-person "Development Team" grid overclaimed. Reframed as **solo-built by Pip, MIT-licensed and open to contributors** — truthful without diminishing.

## Verified TRUE, deliberately left alone: "Godot 4.5.1"
I flagged this for you as *possibly false* last round (the `PDoom.exe` packaging looked un-Godot). **It's true** — the game repo has `godot/project.godot`, 269 `.gd` files, and its README says "Built with Godot 4.5.1" (the exact string on the site). I was about to scrub it; the check caught the error. All four Godot mentions untouched.

## Still parked (data-refresh, separate mechanism — say the word)
- Leaderboard shows stale `v0.11.0` in its `meta` (its `leaderboard.json` is a pre-launch stub; `validate_data.py` already warns)
- Changelog data tops out at `v0.4.1` (`data/game-changes.json` is ~10 releases behind)

Both are generated-data refreshes, not prose — I'd do them as their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)