### PR TITLE
content: tone + staleness pass across reachable pages (review before merge)

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -3,15 +3,15 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>About - p(Doom)1</title>
+	<title>About p(Doom)1 — a free, open-source AI safety strategy game</title>
 	<link rel="canonical" href="https://pdoom1.com/about/" />
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-	<meta name="description" content="Learn about p(Doom)1 development, the solo developer behind the AI Safety Strategy Game, and the mission to make AI safety accessible through gaming." />
-	<meta name="author" content="p(Doom)1" />
+	<meta name="description" content="A strategy game about running an AI-safety lab: hiring, funding, compute, bureaucracy. Solo-built by Pip Foweraker, MIT-licensed, free, early alpha." />
+	<meta name="author" content="Pip Foweraker" />
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="p(Doom)1" />
 	<meta property="og:title" content="About p(Doom)1 - AI Safety Strategy Game" />
-	<meta property="og:description" content="Learn about the development and mission behind p(Doom)1 - the AI Safety Strategy Game." />
+	<meta property="og:description" content="Solo-built, MIT-licensed strategy game about running an AI-safety lab. Why it exists and how it's made." />
 	<meta property="og:url" content="https://pdoom1.com/about/" />
 	<meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
 	<meta name="twitter:card" content="summary_large_image" />
@@ -444,25 +444,25 @@
 	<main>
 		<section class="hero">
 			<h1>About p(Doom)1</h1>
-			<p>The story behind the AI Safety Strategy Game and our mission to make complex topics accessible through interactive gameplay</p>
+			<p>One developer, a strategy game about running an AI-safety lab, and the story of why it exists.</p>
 		</section>
 
 		<section class="section">
-			<h2>Our Mission</h2>
-			<p>p(Doom)1 was created to make AI Safety concepts accessible and engaging through interactive gameplay. We believe that games can be powerful educational tools, helping people understand complex topics by letting them experience the challenges firsthand.</p>
-			
-			<p>The game combines satirical humor with serious educational content, inspired by titles like Papers Please and Pandemic. Players navigate the complex world of AI development while managing resources, making policy decisions, and trying to prevent catastrophic outcomes.</p>
+			<h2>Why this exists</h2>
+			<p>I built p(Doom)1 because AI safety mostly lives in papers and blog posts, and I figured losing a strategy game to it might teach the ideas faster. You run an AI-safety lab &mdash; hiring, funding, compute &mdash; and try to lower p(doom) while the paperwork does its best to stop you.</p>
+
+			<p>The tone owes a lot to Papers, Please and Pandemic: satirical on the surface, serious underneath. You manage resources, make policy calls, and try to prevent catastrophic outcomes &mdash; mostly via spreadsheet.</p>
 
 			<div class="values-grid">
 				<div class="value-card">
-					<div class="icon">[ICON]</div>
+					<div class="icon" aria-hidden="true">[Teach]</div>
 					<h4>Educational First</h4>
 					<p>Every game mechanic is designed to teach real AI Safety concepts in an engaging way.</p>
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Open]</div>
 					<h4>Open Source</h4>
-					<p>Complete transparency in development with all code available for review and contribution.</p>
+					<p>MIT-licensed, all of it on GitHub &mdash; warts included. Contributions welcome.</p>
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Global]</div>
@@ -479,7 +479,7 @@
 
 		<section class="section">
 			<h2>Development Story</h2>
-			<p>p(Doom)1 began as an exploration of how games can communicate complex ideas about AI Safety and existential risks. The project evolved from simple prototypes into a comprehensive strategy game that balances entertainment with education.</p>
+			<p>p(Doom)1 started as an experiment in whether a game could carry ideas about AI safety and existential risk. It's grown from crude prototypes into an actual strategy game &mdash; early alpha, but a real one.</p>
 
 			<div class="timeline">
 				<div class="timeline-item">
@@ -498,9 +498,9 @@
 					<p>Added leaderboard system, improved UI, and comprehensive type annotations.</p>
 				</div>
 				<div class="timeline-item">
-					<h4>Current Development</h4>
-					<div class="date">Present</div>
-					<p>Preparing for Steam release, expanding content, and building community features.</p>
+					<h4>Early Alpha</h4>
+					<div class="date">Now</div>
+					<p>Alpha builds shipping &mdash; Windows today, macOS and Linux coming soon. Current version is in the stats below, pulled live from the release data. Rough on purpose, held together with optimism in places.</p>
 				</div>
 			</div>
 		</section>
@@ -548,14 +548,14 @@
 				</div>
 				<div class="card">
 					<h3>Modular Architecture</h3>
-					<p>Clean, modular code structure with comprehensive type annotations for maintainability.</p>
+					<p>Modular GDScript, typed where it earns its keep &mdash; and held together with optimism in the remaining places.</p>
 				</div>
 			</div>
 		</section>
 
 		<section class="stats-banner">
 			<h2 style="color: var(--accent-primary); margin-bottom: 1rem;">Project Stats</h2>
-			<p style="color: var(--text-secondary);">Current development progress and community engagement</p>
+			<p style="color: var(--text-secondary);">Pulled live from the release data &mdash; a dash means the fetch failed, not that I'm hiding something.</p>
 			
 			<div class="stats-grid">
 				<div class="stat-item">
@@ -586,7 +586,7 @@
 
 		<section class="section">
 			<h2>Community & Contact</h2>
-			<p>Join our growing community of players, contributors, and AI Safety enthusiasts. We welcome feedback, contributions, and discussions about the game and its educational goals.</p>
+			<p>There's no forum yet &mdash; it's one developer and a GitHub repo. Feedback goes through the in-game bug reporter or GitHub issues, and both genuinely get read.</p>
 
 			<div class="grid">
 				<div class="card" style="text-align: center;">
@@ -600,26 +600,23 @@
 					<a href="mailto:contact@pdoom1.com" style="color: var(--accent-primary); text-decoration: none;">Send Email</a>
 				</div>
 				<div class="card" style="text-align: center;">
-					<h3><span aria-hidden="true">[Chat]</span> Community</h3>
-					<p>Discussion and community interaction</p>
-					<a href="#discord" style="color: var(--accent-primary); text-decoration: none;">Join Discord</a>
+					<h3><span aria-hidden="true">[Chat]</span> Feedback</h3>
+					<p>Bug reports and ideas &mdash; in-game reporter or GitHub issues</p>
+					<a href="https://github.com/PipFoweraker/pdoom1/issues" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none;">Open an Issue</a>
 				</div>
 			</div>
 
 			<div class="social-links">
 				<a href="https://github.com/PipFoweraker/pdoom1" target="_blank" rel="noopener" title="GitHub">[Code]</a>
-				<a href="#twitter" title="Twitter">[Twitter]</a>
-				<a href="#discord" title="Discord">[Chat]</a>
 				<a href="mailto:contact@pdoom1.com" title="Email">[Mail]</a>
 			</div>
 		</section>
 
 		<section class="section" style="text-align: center;">
 			<h2>Ready to Play?</h2>
-			<p style="margin-bottom: 2rem;">Experience the challenge of AI Safety strategy for yourself</p>
+			<p style="margin-bottom: 2rem;">Free, open source, early alpha. Try to lower p(doom) &mdash; the paperwork usually wins.</p>
 			<div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
 				<a href="https://github.com/PipFoweraker/pdoom1/releases" style="background: var(--accent-primary); color: var(--bg-primary); text-decoration: none; padding: 1rem 2rem; border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);" target="_blank" rel="noopener">Download on GitHub</a>
-				<span style="background: var(--bg-tertiary); color: var(--text-muted); padding: 1rem 2rem; border-radius: var(--radius-md); font-weight: bold; cursor: default;" title="Coming soon to Steam">Coming to Steam</span>
 				<a href="/leaderboard/" style="background: transparent; color: var(--accent-primary); text-decoration: none; padding: 1rem 2rem; border: 2px solid var(--accent-primary); border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);">View Leaderboard</a>
 			</div>
 		</section>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -10,12 +10,12 @@
     <link rel="alternate" type="application/rss+xml" title="p(Doom)1 dev blog (RSS)" href="/blog/feed.xml" />
     <link rel="alternate" type="application/atom+xml" title="p(Doom)1 dev blog (Atom)" href="/blog/atom.xml" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-    <meta name="description" content="Behind-the-scenes development blog for p(Doom)1 - Follow our journey building an AI Safety strategy game with real technical insights, milestone achievements, and transparency." />
+    <meta name="description" content="Behind-the-scenes development blog for p(Doom)1 - One person building an AI Safety strategy game, writing down what shipped and what broke." />
     <meta name="author" content="p(Doom)1 Development Team" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="p(Doom)1" />
     <meta property="og:title" content="Developer Blog - p(Doom)1" />
-    <meta property="og:description" content="Behind-the-scenes development blog for p(Doom)1 - Follow our journey building an AI Safety strategy game." />
+    <meta property="og:description" content="Behind-the-scenes development blog for p(Doom)1 - one person building an AI Safety strategy game, writing down what shipped and what broke." />
     <meta property="og:url" content="https://pdoom1.com/blog/" />
     <meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -315,7 +315,7 @@
     <div class="container">
         <header class="blog-header">
             <h1>Developer Blog</h1>
-            <p>Follow our journey building p(Doom)1 - real technical insights, milestone achievements, and transparent development process</p>
+            <p>One person building an AI Safety strategy game, writing down what shipped and what broke.</p>
             <p class="feed-links">
                 Subscribe by feed &mdash; no account, no email, nothing collected:
                 <a href="/blog/feed.xml">RSS</a> &middot; <a href="/blog/atom.xml">Atom</a>

--- a/public/game-stats/index.html
+++ b/public/game-stats/index.html
@@ -159,7 +159,7 @@
             <div class="stat-card">
                 <span class="stat-number" id="baseline-doom">23%</span>
                 <div class="stat-label">Baseline Doom</div>
-                <div class="stat-description">Weekly calculated baseline p(doom) percentage representing current AI safety landscape assessment</div>
+                <div class="stat-description">Placeholder, honestly &mdash; pinned at 23% until the real calculation exists (methodology below).</div>
             </div>
             
             <div class="stat-card">

--- a/public/index.html
+++ b/public/index.html
@@ -1058,7 +1058,7 @@ t	.hero {
 						</div>
 						<div class="card">
 							<h3>Dynamic Events</h3>
-							<p>Handle unexpected challenges with our sophisticated event system featuring popup events, deferrals, and strategic timing.</p>
+							<p>Handle unexpected challenges with an event system with popups, deferrals, and timing decisions.</p>
 						</div>
 					</div>
 				</div>
@@ -1177,13 +1177,12 @@ t	.hero {
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
 						<li>Regular feature updates</li>
 						<li>Social media automation</li>
-						<li>Community forum launch</li>
 					</ul>
 				</a>
 				<a href="/docs/roadmap.md" class="card roadmap-card" style="text-decoration: none; color: inherit;">
 					<h3>Mid term (months) 🚀</h3>
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
-						<li>Steam release</li>
+						<li>Steam &mdash; eventually, no date</li>
 						<li>Reward system for contributors</li>
 						<li>Content pipeline automation</li>
 					</ul>
@@ -1225,7 +1224,7 @@ t	.hero {
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
 					<summary style="font-weight: bold; color: var(--accent-primary); cursor: pointer; margin-bottom: 0.8rem;">Is it free and open source?</summary>
-					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows is available now; macOS and Linux builds are coming soon. Steam release later.</p>
+					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows is available now; macOS and Linux builds are coming soon. Steam later, maybe &mdash; no date promised.</p>
 				</details>
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">

--- a/public/leaderboard/index.html
+++ b/public/leaderboard/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>p(Doom)1 Leaderboard - Top Players</title>
-  <meta name="description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings, achievements, and player statistics.">
+  <meta name="description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings and player statistics.">
   <link rel="canonical" href="https://pdoom1.com/leaderboard/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
   <meta name="author" content="p(Doom)1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="p(Doom)1" />
   <meta property="og:title" content="p(Doom)1 Leaderboard - Top Players" />
-  <meta property="og:description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings, achievements, and player statistics." />
+  <meta property="og:description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings and player statistics." />
   <meta property="og:url" content="https://pdoom1.com/leaderboard/" />
   <meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
   <meta name="twitter:card" content="summary_large_image" />

--- a/public/press/index.html
+++ b/public/press/index.html
@@ -355,11 +355,11 @@
 				</div>
 				<div class="factsheet-item">
 					<strong>Developer:</strong>
-					Independent Developer
+					Pip Foweraker (solo)
 				</div>
 				<div class="factsheet-item">
 					<strong>Release Status:</strong>
-					Early Access / Development
+					Early alpha, in active development
 				</div>
 				<div class="factsheet-item">
 					<strong>Engine:</strong>
@@ -384,7 +384,6 @@
 				<li>Economic simulation with resource management</li>
 				<li>Policy decision-making with real-world implications</li>
 				<li>Educational content about AI Safety concepts</li>
-				<li>Leaderboard system with community competition</li>
 				<li>Open source development model</li>
 			</ul>
 		</section>
@@ -451,17 +450,7 @@
 				<div class="download-card">
 					<h4>Screenshots</h4>
 					<p>In-game screenshots and interface examples</p>
-					<a href="#screenshots" class="download-btn">View Gallery</a>
-				</div>
-				<div class="download-card">
-					<h4>Trailer</h4>
-					<p>Gameplay trailer and promotional video</p>
-					<a href="#trailer" class="download-btn">Watch Trailer</a>
-				</div>
-				<div class="download-card">
-					<h4>Press Kit ZIP</h4>
-					<p>Complete press kit with all assets</p>
-					<a href="#presskit" class="download-btn">Download All</a>
+					<a href="/" class="download-btn">View Gallery</a>
 				</div>
 			</div>
 		</section>
@@ -469,10 +458,8 @@
 		<section class="press-section">
 			<h2>Legal & Compliance</h2>
 			<div class="legal-links">
-				<a href="#eula">End User License Agreement</a>
-				<a href="#privacy">Privacy Policy</a>
-				<a href="#support">Support Contact</a>
-				<a href="#terms">Terms of Service</a>
+				<a href="/privacy/">Privacy Policy</a>
+				<a href="mailto:press@pdoom1.com">Support Contact</a>
 			</div>
 
 			<div class="rating-info">
@@ -492,8 +479,6 @@
 				
 				<div class="social-links">
 					<a href="https://github.com/PipFoweraker/pdoom1" target="_blank" rel="noopener" title="GitHub">GitHub</a>
-					<a href="#discord" title="Discord Community">Discord</a>
-					<a href="#twitter" title="Twitter">Twitter</a>
 				</div>
 			</div>
 		</section>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -300,13 +300,13 @@
 	<main>
 		<div class="hero">
 			<h1>Privacy & Analytics</h1>
-			<p>Our commitment to privacy-preserving analytics</p>
+			<p>What the analytics collect, and how to switch them off.</p>
 		</div>
 
 		<section class="section">
 			<h2>Privacy-First Analytics</h2>
 			<p>
-				At p(Doom)1, we believe in respecting your privacy while understanding how our website is used.
+				We want to know whether pages get read &mdash; not who you are.
 				We use <strong>Plausible Analytics</strong>, a privacy-first analytics service that helps us improve
 				the website without compromising your privacy.
 			</p>


### PR DESCRIPTION
Applies the vetted tone + content pass. **Stacks on `fix/honesty-issues-page-and-solo-framing`** (base of this PR) — merge that one first, or retarget this to `main` after it lands. Do not merge without Pip's copy review.

## What changed, by theme

### SERP / meta text (first-person, honest)
- **/about/**: `<title>`, meta description, og:description, `author` → Pip Foweraker
- **/blog/**: meta description + hero → "One person building an AI Safety strategy game, writing down what shipped and what broke."
- **/leaderboard/**: dropped "achievements" from both descriptions (none exist)
- **/privacy/**: intro + subtitle → what's collected and how to switch it off

### Dead links removed
- **/about/**: "Coming to Steam" pill (linked nowhere), `#twitter`/`#discord` social anchors; Community card → "Feedback" card pointing at real GitHub issues
- **/press/**: "Watch Trailer" (`#trailer`) and "Download All" (`#presskit`) cards deleted; `#eula`/`#terms` legal links deleted; Discord/Twitter contact anchors deleted; kept logo PNG, GitHub links, press email

### Corporate → voice
- **/about/**: "Our Mission" → "Why this exists", hero subtitle, mission paras, dev-story para, Open Source + Modular Architecture cards, community para, CTA, stats subtitle, `[ICON]` placeholder → `[Teach]`
- **/index.html**: "our sophisticated event system" → plain description

### Stale facts
- **/press/**: "Independent Developer" → "Pip Foweraker (solo)"; "Early Access / Development" → "Early alpha, in active development"; removed "Leaderboard system with community competition" bullet (remote leaderboard isn't live)
- **/game-stats/**: baseline p(doom) description now says it's the 23% placeholder (verified: page pins 23%, methodology section exists)
- **/index.html**: "Community forum launch" roadmap line deleted; "Steam release" → "Steam — eventually, no date"; FAQ "Steam release later." → "Steam later, maybe — no date promised."
- **/about/** timeline: "Current Development / Present / Preparing for Steam release…" → "Early Alpha / Now / …"

## Deviations to eyeball (OLD didn't match, or I adjusted)

1. **Platform truth override (about timeline, edit 12).** The supplied copy said "Alpha builds shipping for Windows, macOS and Linux". `public/data/version.json` says `macos: false, linux: false` (v0.13.0, only a Windows asset). I wrote "Windows today, macOS and Linux coming soon" instead — matches the page's existing platform copy and keeps `check-platform-claims.py` green. If Mac/Linux ship before merge, restore the original wording.
2. **About meta description (edit 2):** OLD text had already been reworded by the solo-framing branch ("the solo developer behind…"), so I replaced that version — intent applied, exact-match didn't.
3. **Press legal links:** spec said delete `#eula`/`#terms` only. I also repointed the remaining two dead anchors: `#privacy` → `/privacy/` (page exists) and `#support` → `mailto:press@pdoom1.com`. Revert to plain deletion if preferred.
4. **Press "View Gallery":** spec offered `/#screenshots` or `/`. The homepage has no `#screenshots` id (screenshots live in a tab inside `#about`), so it points at `/`.
5. **Blog og:description:** not in the spec, but still carried "Follow our journey…" — updated to match the new meta description. Easy to revert.

## Checks run
- `python scripts/check-platform-claims.py` — OK (windows only, no page overclaims)
- `python scripts/snapshot-copy.py --check` — runs, reports the intended drift (16 pages incl. drift inherited from the base branch)
- Tag-balance parse on all 7 edited files — OK

Untouched on purpose: Godot 4.5.1 claims (true), the three 2024 timeline entries (correct history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)