### PR TITLE
content: honesty + tone pass across reader-facing pages (v0.13.1)

### DIFF
--- a/public/about/index.html
+++ b/public/about/index.html
@@ -3,15 +3,15 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>About - p(Doom)1</title>
+	<title>About p(Doom)1 — a free, open-source AI safety strategy game</title>
 	<link rel="canonical" href="https://pdoom1.com/about/" />
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-	<meta name="description" content="Learn about p(Doom)1 development, the team behind the AI Safety Strategy Game, and our mission to make AI safety accessible through gaming." />
-	<meta name="author" content="p(Doom)1" />
+	<meta name="description" content="A strategy game about running an AI-safety lab: hiring, funding, compute, bureaucracy. Solo-built by Pip Foweraker, MIT-licensed, free, early alpha." />
+	<meta name="author" content="Pip Foweraker" />
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="p(Doom)1" />
 	<meta property="og:title" content="About p(Doom)1 - AI Safety Strategy Game" />
-	<meta property="og:description" content="Learn about the development and mission behind p(Doom)1 - the AI Safety Strategy Game." />
+	<meta property="og:description" content="Solo-built, MIT-licensed strategy game about running an AI-safety lab. Why it exists and how it's made." />
 	<meta property="og:url" content="https://pdoom1.com/about/" />
 	<meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
 	<meta name="twitter:card" content="summary_large_image" />
@@ -444,25 +444,25 @@
 	<main>
 		<section class="hero">
 			<h1>About p(Doom)1</h1>
-			<p>The story behind the AI Safety Strategy Game and our mission to make complex topics accessible through interactive gameplay</p>
+			<p>One developer, a strategy game about running an AI-safety lab, and the story of why it exists.</p>
 		</section>
 
 		<section class="section">
-			<h2>Our Mission</h2>
-			<p>p(Doom)1 was created to make AI Safety concepts accessible and engaging through interactive gameplay. We believe that games can be powerful educational tools, helping people understand complex topics by letting them experience the challenges firsthand.</p>
-			
-			<p>The game combines satirical humor with serious educational content, inspired by titles like Papers Please and Pandemic. Players navigate the complex world of AI development while managing resources, making policy decisions, and trying to prevent catastrophic outcomes.</p>
+			<h2>Why this exists</h2>
+			<p>I built p(Doom)1 because AI safety mostly lives in papers and blog posts, and I figured losing a strategy game to it might teach the ideas faster. You run an AI-safety lab &mdash; hiring, funding, compute &mdash; and try to lower p(doom) while the paperwork does its best to stop you.</p>
+
+			<p>The tone owes a lot to Papers, Please and Pandemic: satirical on the surface, serious underneath. You manage resources, make policy calls, and try to prevent catastrophic outcomes &mdash; mostly via spreadsheet.</p>
 
 			<div class="values-grid">
 				<div class="value-card">
-					<div class="icon">[ICON]</div>
+					<div class="icon" aria-hidden="true">[Teach]</div>
 					<h4>Educational First</h4>
 					<p>Every game mechanic is designed to teach real AI Safety concepts in an engaging way.</p>
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Open]</div>
 					<h4>Open Source</h4>
-					<p>Complete transparency in development with all code available for review and contribution.</p>
+					<p>MIT-licensed, all of it on GitHub &mdash; warts included. Contributions welcome.</p>
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Global]</div>
@@ -479,7 +479,7 @@
 
 		<section class="section">
 			<h2>Development Story</h2>
-			<p>p(Doom)1 began as an exploration of how games can communicate complex ideas about AI Safety and existential risks. The project evolved from simple prototypes into a comprehensive strategy game that balances entertainment with education.</p>
+			<p>p(Doom)1 started as an experiment in whether a game could carry ideas about AI safety and existential risk. It's grown from crude prototypes into an actual strategy game &mdash; early alpha, but a real one.</p>
 
 			<div class="timeline">
 				<div class="timeline-item">
@@ -498,29 +498,29 @@
 					<p>Added leaderboard system, improved UI, and comprehensive type annotations.</p>
 				</div>
 				<div class="timeline-item">
-					<h4>Current Development</h4>
-					<div class="date">Present</div>
-					<p>Preparing for Steam release, expanding content, and building community features.</p>
+					<h4>Early Alpha</h4>
+					<div class="date">Now</div>
+					<p>Alpha builds for Windows, macOS and Linux &mdash; Windows is the tested one, Mac and Linux are fresh and largely untested. Current version is in the stats below, pulled live from the release data. Rough on purpose, held together with optimism in places.</p>
 				</div>
 			</div>
 		</section>
 
 		<section class="section">
-			<h2>Development Team</h2>
-			<p>p(Doom)1 is developed by a small team of passionate contributors who believe in the power of games to educate and inspire.</p>
+			<h2>Who's Building It</h2>
+			<p>p(Doom)1 is built by Pip Foweraker, working solo, in the belief that games can educate and inspire. It is developed in the open and MIT-licensed, so anyone is welcome to pitch in.</p>
 
 			<div class="grid">
 				<div class="team-member">
 					<div class="avatar">[IMG]</div>
-					<h4>Lead Developer</h4>
-					<div class="role">Game Design & Development</div>
-					<p>Responsible for core game mechanics, AI systems, and overall project direction.</p>
+					<h4>Pip Foweraker</h4>
+					<div class="role">Solo Developer</div>
+					<p>Design, code, AI systems, and overall direction &mdash; the whole thing, so far.</p>
 				</div>
 				<div class="team-member">
 					<div class="avatar">[IMG]</div>
-					<h4>Community Contributors</h4>
-					<div class="role">Open Source Development</div>
-					<p>Community members contributing code, ideas, and feedback through GitHub collaboration.</p>
+					<h4>Open to Contributors</h4>
+					<div class="role">MIT-Licensed, Built in the Open</div>
+					<p>Code, ideas, and feedback are welcome through GitHub. If you'd like to help, the door's open.</p>
 				</div>
 			</div>
 
@@ -540,7 +540,7 @@
 				</div>
 				<div class="card">
 					<h3>Native Cross-Platform</h3>
-					<p>Exported to Windows, macOS, and Linux from a single Godot codebase, for smooth native gameplay.</p>
+					<p>Built to run natively on Windows, macOS, and Linux from a single Godot codebase. All three are available now &mdash; Windows is the tested build; macOS and Linux are new and largely untested.</p>
 				</div>
 				<div class="card">
 					<h3>Data-Driven Design</h3>
@@ -548,14 +548,14 @@
 				</div>
 				<div class="card">
 					<h3>Modular Architecture</h3>
-					<p>Clean, modular code structure with comprehensive type annotations for maintainability.</p>
+					<p>Modular GDScript, typed where it earns its keep &mdash; and held together with optimism in the remaining places.</p>
 				</div>
 			</div>
 		</section>
 
 		<section class="stats-banner">
 			<h2 style="color: var(--accent-primary); margin-bottom: 1rem;">Project Stats</h2>
-			<p style="color: var(--text-secondary);">Current development progress and community engagement</p>
+			<p style="color: var(--text-secondary);">Pulled live from the release data &mdash; a dash means the fetch failed, not that I'm hiding something.</p>
 			
 			<div class="stats-grid">
 				<div class="stat-item">
@@ -570,8 +570,12 @@
 					<span class="stat-label">Source License</span>
 				</div>
 				<div class="stat-item">
-					<span class="stat-number">3+</span>
-					<span class="stat-label">Platforms Supported</span>
+					<!-- Count of platforms with a shipped build, from version.json
+					     latest_release.platforms. Ships as a dash so a failed fetch
+					     shows "unknown" rather than a hardcoded "3+" that overclaims
+					     while only Windows is downloadable. -->
+					<span class="stat-number" id="platforms-available">&mdash;</span>
+					<span class="stat-label">Platforms Available</span>
 				</div>
 				<div class="stat-item">
 					<span class="stat-number">Active</span>
@@ -582,7 +586,7 @@
 
 		<section class="section">
 			<h2>Community & Contact</h2>
-			<p>Join our growing community of players, contributors, and AI Safety enthusiasts. We welcome feedback, contributions, and discussions about the game and its educational goals.</p>
+			<p>There's no forum yet &mdash; it's one developer and a GitHub repo. Feedback goes through the in-game bug reporter or GitHub issues, and both genuinely get read.</p>
 
 			<div class="grid">
 				<div class="card" style="text-align: center;">
@@ -596,26 +600,23 @@
 					<a href="mailto:contact@pdoom1.com" style="color: var(--accent-primary); text-decoration: none;">Send Email</a>
 				</div>
 				<div class="card" style="text-align: center;">
-					<h3><span aria-hidden="true">[Chat]</span> Community</h3>
-					<p>Discussion and community interaction</p>
-					<a href="#discord" style="color: var(--accent-primary); text-decoration: none;">Join Discord</a>
+					<h3><span aria-hidden="true">[Chat]</span> Feedback</h3>
+					<p>Bug reports and ideas &mdash; in-game reporter or GitHub issues</p>
+					<a href="https://github.com/PipFoweraker/pdoom1/issues" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none;">Open an Issue</a>
 				</div>
 			</div>
 
 			<div class="social-links">
 				<a href="https://github.com/PipFoweraker/pdoom1" target="_blank" rel="noopener" title="GitHub">[Code]</a>
-				<a href="#twitter" title="Twitter">[Twitter]</a>
-				<a href="#discord" title="Discord">[Chat]</a>
 				<a href="mailto:contact@pdoom1.com" title="Email">[Mail]</a>
 			</div>
 		</section>
 
 		<section class="section" style="text-align: center;">
 			<h2>Ready to Play?</h2>
-			<p style="margin-bottom: 2rem;">Experience the challenge of AI Safety strategy for yourself</p>
+			<p style="margin-bottom: 2rem;">Free, open source, early alpha. Try to lower p(doom) &mdash; the paperwork usually wins.</p>
 			<div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
 				<a href="https://github.com/PipFoweraker/pdoom1/releases" style="background: var(--accent-primary); color: var(--bg-primary); text-decoration: none; padding: 1rem 2rem; border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);" target="_blank" rel="noopener">Download on GitHub</a>
-				<span style="background: var(--bg-tertiary); color: var(--text-muted); padding: 1rem 2rem; border-radius: var(--radius-md); font-weight: bold; cursor: default;" title="Coming soon to Steam">Coming to Steam</span>
 				<a href="/leaderboard/" style="background: transparent; color: var(--accent-primary); text-decoration: none; padding: 1rem 2rem; border: 2px solid var(--accent-primary); border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);">View Leaderboard</a>
 			</div>
 		</section>
@@ -636,19 +637,28 @@
 	</script>
 
 	<script>
-		// Project Stats "Current Version" comes from the canonical /data/version.json,
-		// never from a literal baked into this page.
-		(async function loadCurrentVersion() {
-			const el = document.getElementById('current-version');
-			if (!el) return;
+		// Project Stats "Current Version" and "Platforms Available" both come from the
+		// canonical /data/version.json, never from a literal baked into this page. On
+		// any failure the dashes stay put rather than asserting a stale/overclaimed value.
+		(async function loadProjectStats() {
+			const verEl = document.getElementById('current-version');
+			const platEl = document.getElementById('platforms-available');
+			if (!verEl && !platEl) return;
 			try {
 				const res = await fetch('/data/version.json', { cache: 'no-store' });
 				if (!res.ok) return;
 				const data = await res.json();
-				const version = (data.latest_release || {}).version;
-				if (version) el.textContent = version;
+				const release = data.latest_release || {};
+				if (verEl && release.version) verEl.textContent = release.version;
+				// platforms is { windows: bool, macos: bool, linux: bool }; count the
+				// ones with a shipped build. Only fill when the key is present, so an
+				// older version.json without it leaves the honest dash.
+				if (platEl && release.platforms && typeof release.platforms === 'object') {
+					const n = Object.values(release.platforms).filter(Boolean).length;
+					platEl.textContent = String(n);
+				}
 			} catch (e) {
-				// Leave the dash in place rather than showing a stale version.
+				// Leave the dashes in place rather than showing stale/overclaimed stats.
 			}
 		})();
 	</script>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -10,12 +10,12 @@
     <link rel="alternate" type="application/rss+xml" title="p(Doom)1 dev blog (RSS)" href="/blog/feed.xml" />
     <link rel="alternate" type="application/atom+xml" title="p(Doom)1 dev blog (Atom)" href="/blog/atom.xml" />
     <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-    <meta name="description" content="Behind-the-scenes development blog for p(Doom)1 - Follow our journey building an AI Safety strategy game with real technical insights, milestone achievements, and transparency." />
+    <meta name="description" content="Behind-the-scenes development blog for p(Doom)1 - One person building an AI Safety strategy game, writing down what shipped and what broke." />
     <meta name="author" content="p(Doom)1 Development Team" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="p(Doom)1" />
     <meta property="og:title" content="Developer Blog - p(Doom)1" />
-    <meta property="og:description" content="Behind-the-scenes development blog for p(Doom)1 - Follow our journey building an AI Safety strategy game." />
+    <meta property="og:description" content="Behind-the-scenes development blog for p(Doom)1 - one person building an AI Safety strategy game, writing down what shipped and what broke." />
     <meta property="og:url" content="https://pdoom1.com/blog/" />
     <meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -315,7 +315,7 @@
     <div class="container">
         <header class="blog-header">
             <h1>Developer Blog</h1>
-            <p>Follow our journey building p(Doom)1 - real technical insights, milestone achievements, and transparent development process</p>
+            <p>One person building an AI Safety strategy game, writing down what shipped and what broke.</p>
             <p class="feed-links">
                 Subscribe by feed &mdash; no account, no email, nothing collected:
                 <a href="/blog/feed.xml">RSS</a> &middot; <a href="/blog/atom.xml">Atom</a>

--- a/public/game-stats/index.html
+++ b/public/game-stats/index.html
@@ -159,7 +159,7 @@
             <div class="stat-card">
                 <span class="stat-number" id="baseline-doom">23%</span>
                 <div class="stat-label">Baseline Doom</div>
-                <div class="stat-description">Weekly calculated baseline p(doom) percentage representing current AI safety landscape assessment</div>
+                <div class="stat-description">Placeholder, honestly &mdash; pinned at 23% until the real calculation exists (methodology below).</div>
             </div>
             
             <div class="stat-card">

--- a/public/index.html
+++ b/public/index.html
@@ -840,9 +840,14 @@ t	.hero {
 				<div class="designer-credit">Pip Foweraker's</div>
 				<a href="#" class="logo" aria-label="p(Doom)1 home">p(Doom)1</a>
 			</div>
+			<!-- Ships empty: loadVersionInfo() fills these from /data/version.json.
+			     A hardcoded literal here asserts a stale release on every load before
+			     the fetch resolves, and forever if it fails -- silence beats a
+			     confident wrong number. (Previously carried a hardcoded version and
+			     date that had gone two releases stale.) -->
 			<div class="version-info" id="versionInfo">
-				<span class="version-number" id="versionNumber">v0.11.0</span>
-				<span id="versionDate">2025-12-07</span>
+				<span class="version-number" id="versionNumber"></span>
+				<span id="versionDate"></span>
 			</div>
 			<ul class="nav-links" role="menubar">
 				<li role="none"><a href="#home" role="menuitem">Game</a></li>
@@ -886,8 +891,11 @@ t	.hero {
 
 			<!-- Download Options - Platform-Specific CTAs -->
 			<div class="download-ctas" style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.4rem;">
-				<!-- hrefs default to the release PAGE (never 404s on any asset naming);
-				     resolveDownloads() upgrades them to direct per-platform asset URLs. -->
+				<!-- All three platforms have a shipped build (v0.13.1), so each defaults
+				     live to the release PAGE (never 404s on any asset naming);
+				     resolveDownloads() upgrades each to its direct asset URL, and would
+				     degrade a platform to "coming soon" only if a future release dropped
+				     its build. -->
 				<a id="download-windows" data-platform-label="Windows" href="https://github.com/PipFoweraker/pdoom1/releases/latest" class="cta-button" style="font-size: 0.85rem; padding: 0.5rem 0.8rem;" target="_blank" rel="noopener">
 					Download for Windows
 				</a>
@@ -934,7 +942,7 @@ t	.hero {
 			-->
 
 			<p style="font-size: 0.85rem; color: var(--text-muted); text-align: center;">
-				Windows, macOS, Linux | Free & Open Source
+				Windows, macOS & Linux · Free & Open Source
 			</p>
 		</section>
 
@@ -1048,7 +1056,7 @@ t	.hero {
 						</div>
 						<div class="card">
 							<h3>Dynamic Events</h3>
-							<p>Handle unexpected challenges with our sophisticated event system featuring popup events, deferrals, and strategic timing.</p>
+							<p>Handle unexpected challenges with an event system with popups, deferrals, and timing decisions.</p>
 						</div>
 					</div>
 				</div>
@@ -1107,7 +1115,7 @@ t	.hero {
 						</div>
 						<div class="card">
 							<h3>Quick Installation</h3>
-							<p style="margin-bottom: 0.8rem;">Download the build for your platform from the buttons above &mdash; no installation, no runtime needed.</p>
+							<p style="margin-bottom: 0.8rem;">Download your platform's build from the buttons above &mdash; no installation, no runtime needed. Windows is the tested build; macOS and Linux are new and largely untested, so tell me if they fall over.</p>
 <pre style="background: var(--bg-primary); padding: 0.8rem; border-radius: var(--radius-sm); overflow-x: auto; color: var(--accent-primary); font-size: 0.85rem; line-height: 1.4; margin: 0;">git clone https://github.com/PipFoweraker/pdoom1.git
 # then open the project in Godot 4.5.1 to run from source</pre>
 							<p style="margin-top: 0.8rem; font-size: 0.85rem; color: var(--text-muted);">
@@ -1167,13 +1175,12 @@ t	.hero {
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
 						<li>Regular feature updates</li>
 						<li>Social media automation</li>
-						<li>Community forum launch</li>
 					</ul>
 				</a>
 				<a href="/docs/roadmap.md" class="card roadmap-card" style="text-decoration: none; color: inherit;">
 					<h3>Mid term (months) 🚀</h3>
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
-						<li>Steam release</li>
+						<li>Steam &mdash; eventually, no date</li>
 						<li>Reward system for contributors</li>
 						<li>Content pipeline automation</li>
 					</ul>
@@ -1215,7 +1222,7 @@ t	.hero {
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
 					<summary style="font-weight: bold; color: var(--accent-primary); cursor: pointer; margin-bottom: 0.8rem;">Is it free and open source?</summary>
-					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows, macOS, and Linux supported. Steam release coming soon.</p>
+					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows, macOS and Linux are all available &mdash; Windows is the tested one; Mac and Linux are experimental, so tell me what breaks. Steam later, maybe &mdash; no date promised.</p>
 				</details>
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
@@ -1601,6 +1608,25 @@ t	.hero {
 				el.textContent = label + ' — coming soon';
 			}
 
+			// Inverse of markUnavailable: promote a button to a live download once a
+			// build for it is confirmed. macOS/Linux ship DISABLED in the HTML, so
+			// this is what turns them back on the day their build lands -- reachable
+			// only via a confirmed asset, never by default.
+			function markAvailable(el, url) {
+				if (!el) return;
+				const label = el.dataset.platformLabel || 'this platform';
+				el.href = url;
+				el.setAttribute('target', '_blank');
+				el.setAttribute('rel', 'noopener');
+				el.setAttribute('role', 'button');
+				el.removeAttribute('aria-disabled');
+				el.title = '';
+				el.style.opacity = '';
+				el.style.cursor = '';
+				el.style.pointerEvents = '';
+				el.textContent = 'Download for ' + label;
+			}
+
 			try {
 				const res = await fetch('https://api.github.com/repos/PipFoweraker/pdoom1/releases/latest',
 					{ headers: { 'Accept': 'application/vnd.github+json' } });
@@ -1621,7 +1647,7 @@ t	.hero {
 				for (const [id, asset] of found) {
 					const el = document.getElementById(id);
 					if (!el) continue;
-					if (asset) el.href = asset.browser_download_url;
+					if (asset) markAvailable(el, asset.browser_download_url);
 					else markUnavailable(el);
 				}
 				// Show the macOS first-run note only when a macOS build actually resolved.

--- a/public/issues/index.html
+++ b/public/issues/index.html
@@ -341,7 +341,11 @@
 		<section class="section" id="submit-issue">
 			<h2>Submit Feedback</h2>
 			<p style="color: var(--text-secondary); margin-bottom: 2rem;">
-				Tell us what's wrong or what could be better. We respect your privacy - only the information you provide will be shared.
+				Tell us what's wrong or what could be better. The quickest path is the
+				<a href="/bug-report/" style="color: var(--accent-primary);">direct bug reporter</a>,
+				which sends straight to the team &mdash; no email client, no GitHub account.
+				The form below is an alternative: it composes an email or a pre-filled GitHub
+				issue that <em>you</em> send. Nothing here is transmitted automatically.
 			</p>
 
 			<form id="issue-form" style="max-width: 700px; margin: 0 auto;">
@@ -384,13 +388,13 @@
 				</div>
 
 				<div style="background: var(--bg-tertiary); padding: 1rem; border-radius: var(--radius-sm); border: 1px solid var(--accent-primary); margin-bottom: 1.5rem;">
-					<h4 style="color: var(--accent-primary); margin-bottom: 0.5rem;">🔒 Privacy Promise</h4>
-					<p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 0.5rem 0;">
-						Your feedback will be shared with GitHub Issues and our community forum. Only the issue details you provide above will be posted publicly.
-						Contact information is stored separately and never shared publicly. You can submit anonymously.
-					</p>
-					<p style="font-size: 0.85rem; color: var(--text-muted); margin: 0;">
-						<strong>Note:</strong> We're currently setting up our community forum and automated forum posting &mdash; stay tuned!
+					<h4 style="color: var(--accent-primary); margin-bottom: 0.5rem;">🔒 What happens to your feedback</h4>
+					<p style="font-size: 0.9rem; color: var(--text-secondary); margin: 0;">
+						This form doesn't transmit anything on its own. When you submit, it prepares
+						an email to the team &mdash; or a pre-filled GitHub issue &mdash; for you to send.
+						If you file it on GitHub, the issue text you wrote becomes public there; if you
+						email it, it stays private with the team. Any contact detail you add is used only
+						to reply, never posted publicly. You can submit anonymously.
 					</p>
 				</div>
 
@@ -660,8 +664,8 @@
 
 			// Disable form
 			submitButton.disabled = true;
-			submitButton.textContent = 'Submitting...';
-			formStatus.textContent = 'Processing your feedback...';
+			submitButton.textContent = 'Preparing...';
+			formStatus.textContent = 'Preparing your report...';
 			formStatus.style.color = 'var(--accent-primary)';
 
 			try {
@@ -686,14 +690,16 @@ ${formData.contact !== 'Anonymous' ? `**Contact:** ${formData.contact}` : ''}
 				await new Promise(resolve => setTimeout(resolve, 1000));
 
 				formStatus.innerHTML = `
-					<div style="color: var(--success-color); margin-bottom: 1rem;">✅ Thank you for your feedback!</div>
+					<div style="color: var(--accent-primary); margin-bottom: 1rem;">📝 Your report is ready &mdash; one step left to send it:</div>
 					<div style="font-size: 0.9rem; color: var(--text-secondary);">
 						<a href="mailto:team@pdoom1.com?subject=${subject}&body=${body}"
 						   style="color: var(--accent-primary); text-decoration: underline;">
-							Click here to complete submission via email
+							Send it via email
 						</a>
-						<p style="margin-top: 0.5rem;">Or manually create an issue on
-						<a href="https://github.com/PipFoweraker/pdoom1/issues/new" target="_blank" style="color: var(--accent-primary);">GitHub</a></p>
+						<p style="margin-top: 0.5rem;">or file it on
+						<a href="https://github.com/PipFoweraker/pdoom1/issues/new/choose" target="_blank" style="color: var(--accent-primary);">GitHub</a>.
+						Prefer it to just go straight through? Use the
+						<a href="/bug-report/" style="color: var(--accent-primary);">direct bug reporter</a>.</p>
 					</div>
 				`;
 

--- a/public/leaderboard/index.html
+++ b/public/leaderboard/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>p(Doom)1 Leaderboard - Top Players</title>
-  <meta name="description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings, achievements, and player statistics.">
+  <meta name="description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings and player statistics.">
   <link rel="canonical" href="https://pdoom1.com/leaderboard/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
   <meta name="author" content="p(Doom)1" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="p(Doom)1" />
   <meta property="og:title" content="p(Doom)1 Leaderboard - Top Players" />
-  <meta property="og:description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings, achievements, and player statistics." />
+  <meta property="og:description" content="View the top players and scores in p(Doom)1, the AI Safety Strategy Game. See rankings and player statistics." />
   <meta property="og:url" content="https://pdoom1.com/leaderboard/" />
   <meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
   <meta name="twitter:card" content="summary_large_image" />

--- a/public/press/index.html
+++ b/public/press/index.html
@@ -351,15 +351,15 @@
 				</div>
 				<div class="factsheet-item">
 					<strong>Platform:</strong>
-					Windows, macOS, Linux
+					Windows, macOS &amp; Linux (Windows tested; macOS &amp; Linux experimental)
 				</div>
 				<div class="factsheet-item">
 					<strong>Developer:</strong>
-					Independent Developer
+					Pip Foweraker (solo)
 				</div>
 				<div class="factsheet-item">
 					<strong>Release Status:</strong>
-					Early Access / Development
+					Early alpha, in active development
 				</div>
 				<div class="factsheet-item">
 					<strong>Engine:</strong>
@@ -384,7 +384,6 @@
 				<li>Economic simulation with resource management</li>
 				<li>Policy decision-making with real-world implications</li>
 				<li>Educational content about AI Safety concepts</li>
-				<li>Leaderboard system with community competition</li>
 				<li>Open source development model</li>
 			</ul>
 		</section>
@@ -403,7 +402,7 @@
 				</a>
 			</p>
 			<p style="text-align: center; color: var(--text-muted); font-size: 0.9rem; margin-bottom: 1.5rem;">
-				Windows and macOS. Linux is in progress. Free and open source &mdash; no store account needed.
+				Windows, macOS and Linux &mdash; Windows tested, macOS and Linux experimental. Free and open source &mdash; no store account needed.
 			</p>
 
 			<!-- Steam badge - Valve compliant -->
@@ -451,17 +450,7 @@
 				<div class="download-card">
 					<h4>Screenshots</h4>
 					<p>In-game screenshots and interface examples</p>
-					<a href="#screenshots" class="download-btn">View Gallery</a>
-				</div>
-				<div class="download-card">
-					<h4>Trailer</h4>
-					<p>Gameplay trailer and promotional video</p>
-					<a href="#trailer" class="download-btn">Watch Trailer</a>
-				</div>
-				<div class="download-card">
-					<h4>Press Kit ZIP</h4>
-					<p>Complete press kit with all assets</p>
-					<a href="#presskit" class="download-btn">Download All</a>
+					<a href="/" class="download-btn">View Gallery</a>
 				</div>
 			</div>
 		</section>
@@ -469,10 +458,8 @@
 		<section class="press-section">
 			<h2>Legal & Compliance</h2>
 			<div class="legal-links">
-				<a href="#eula">End User License Agreement</a>
-				<a href="#privacy">Privacy Policy</a>
-				<a href="#support">Support Contact</a>
-				<a href="#terms">Terms of Service</a>
+				<a href="/privacy/">Privacy Policy</a>
+				<a href="mailto:press@pdoom1.com">Support Contact</a>
 			</div>
 
 			<div class="rating-info">
@@ -492,8 +479,6 @@
 				
 				<div class="social-links">
 					<a href="https://github.com/PipFoweraker/pdoom1" target="_blank" rel="noopener" title="GitHub">GitHub</a>
-					<a href="#discord" title="Discord Community">Discord</a>
-					<a href="#twitter" title="Twitter">Twitter</a>
 				</div>
 			</div>
 		</section>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -300,13 +300,13 @@
 	<main>
 		<div class="hero">
 			<h1>Privacy & Analytics</h1>
-			<p>Our commitment to privacy-preserving analytics</p>
+			<p>What the analytics collect, and how to switch them off.</p>
 		</div>
 
 		<section class="section">
 			<h2>Privacy-First Analytics</h2>
 			<p>
-				At p(Doom)1, we believe in respecting your privacy while understanding how our website is used.
+				We want to know whether pages get read &mdash; not who you are.
 				We use <strong>Plausible Analytics</strong>, a privacy-first analytics service that helps us improve
 				the website without compromising your privacy.
 			</p>


### PR DESCRIPTION
**One clean copy PR off current `main` (0.13.1).** Consolidates the reader-facing work that was stacked on the now-outmoded Windows-only branches — **supersedes #167 and #171** (close those; this is the same content, correctly based and with platform wording brought up to today's truth). HTML-only, so it lifted onto 0.13.1 with zero conflicts (`main` only ever touched data files).

### What changed, by theme
- **`/issues/`** — removed the phantom "community forum" + "automated forum posting" promises and the fabricated "✅ Thank you!" success; the form now honestly says it prepares an email/GitHub issue *you* send, and points to the working `/bug-report/`.
- **Solo framing** on `/about/` — "small team of passionate contributors" → built by Pip, solo, MIT-licensed, open to contributors.
- **Tone pass (Fable agent)** — SERP `<title>`/descriptions rewritten (your Google-search concern), corporate register ("Our Mission", "we believe in the power of games", "sophisticated event system") → first-person deadpan, **~8 dead `#`-anchor links removed** (Discord, Twitter, Steam, trailer, EULA, ToS), stale facts fixed (leaderboard "achievements", game-stats "live" p(doom), Sept-2025 stamp, press "Early Access").
- **Platform framing → today's truth** — all three builds ship (v0.13.1), so the Mac/Linux download buttons are **live** again and the prose reads *"Windows tested; macOS & Linux experimental, feedback wanted"* — matching the game's own release-notes platform table, not "coming soon."

### Checks
- No "coming soon" platform lie remains in visible prose; tag-balance OK on all 8 files.
- The platform-availability **guard** + generator derivation land in the separate infra PR (they're scripts/workflow, not HTML). Godot 4.5.1 claims left intact (verified true).

Review is copy-first — every diff is "was stale/false/off-voice → now current/true/in-voice." Nothing auto-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)