### PR TITLE
docs: doom-clock + stats-page design capture (+ sample manual article)

### DIFF
--- a/docs/DOOM_CLOCK_AND_STATS_DESIGN.md
+++ b/docs/DOOM_CLOCK_AND_STATS_DESIGN.md
@@ -1,0 +1,181 @@
+# Doom Clock & Stats Page — design capture
+
+Status: **workshop notes, 2026-07-26.** Pip is the architect; this captures his
+calls and the agreed shape so a build can start without re-deriving. Not a
+committed spec — the graph and weighting deliberately stay loose (see "extemporise").
+Nothing here is reader-facing yet; it lives in `docs/`, which does not deploy.
+
+A companion visual mockup was produced as a private Artifact (see the session) —
+this doc is the words behind that picture.
+
+---
+
+## The one-line idea
+
+Replace the current stubbed `/game-stats/` with a **stack of grounded countdowns**,
+most-editorial at the top, most-factual at the bottom. Every editorial number is a
+*hook that opens onto shown logic* — inheriting the `/dashboard/` discipline (`TOY
+MODEL` tags, "these prices are typed in by hand"). A number the reader can't
+interrogate is a number we don't ship.
+
+---
+
+## Pip's calls (captured)
+
+**Foo (the calibration fudge-factor): blank for now, but here's the method.**
+> "Run a perfectly baseline simulation of p(Doom) and see when the engine naturally
+> tops out at 100%. If it's past today's date, accept it and say 'this is super out
+> of tune but we're going to update it every time we patch and we think it will hone
+> in on a reasonable prediction reasonably quickly.'"
+
+- Foo is the hand-wave between the **pure baseline sim** and **lived game experience**
+  — it absorbs the difference so we don't have to answer awkward questions (e.g. the
+  rival, and the weirdness of the player being cast in opposition to *actual people*).
+- Future: an **Institutional Brier Score** — we score our own past predictions and
+  publish the calibration. That's the honest end-state; Foo is the honest interim.
+
+**Direction of truth: the game leads.** The game's calibration is canonical; the
+website *derives and displays* it — it does not compute its own competing number.
+(Matches cross-repo protocol rule #3: pdoom1 owns game-truth.)
+
+**The graph: extemporise it.** It represents our picture of doom *rising over time as
+people didn't slow down / take precautions to the degree needed*. That implies doom
+was building before we started measuring — there'll be some back-and-forth about the
+pre-measurement shape. **Decision: do NOT play the tape to the end now.** Start the
+series, ship a v1, let the historical shape unfurl as we build. (Honest + simple:
+begin the record now; backfill sourced history later if it earns its place.)
+
+**Cadence: monthly metabolism.**
+> "Messy this week because of workshop and hotpatching errors, but then settle down.
+> A monthly metabolism for most things — weekly rotations are really just adding new
+> seeds to the same engine."
+
+- `days to next patch` ≈ **monthly** (once this week settles).
+- `days to next league / seed` = **weekly** (new seed, same engine).
+
+**AGI clock tone: earnest, verging on real worry — not ironic.**
+> "It's a real problem. We've derived the planned arrival date from people who spend a
+> lot of time thinking about it, and you have that long left to (a) play the game, and
+> (b) do something about it."
+
+- The clock is **sincere**. The game's dry irony lives elsewhere (the manual, the copy);
+  the countdown itself does not wink. It carries a two-part call-to-action: *play*, and
+  *act*.
+
+---
+
+## The tiered architecture (my synthesis — Pip to approve)
+
+**Tier 1 — hero: current p(Doom) + the baseline→present graph.**
+- The studio's model estimate, **derived from a game-emitted calibration artifact**
+  (not hardcoded here). The number the game is tuned to *is* the number we show.
+- Graph shows the rising series over time. v1: start it; shape unfurls.
+
+**Tier 2 — the doom clock: "days to AGI".**
+- An aggregate of AGI-timing estimates from people who study it (Metaculus, Manifold,
+  expert-survey medians, lab statements). Weighting = Foo (blank now).
+- Earnest tone. Methodology always one click away. CTA: *this long to play, and to act.*
+
+**Tier 3 — the factual clocks (honest, no epistemics risk — build FIRST).**
+- Days to next league / seed (weekly — from the league cycle + seed ledger).
+- Days to next patch (monthly, post-settle).
+- Days to next pdoom-data update (from its cadence).
+
+**Tier 4 — the action rail: do something with the time.**
+- Next PauseAI protest / meetup [near you].
+- Nearest AI-safety chapter meetup.
+- Links out; we don't host the events, we route to them.
+
+**Cross-cutting — the numbers are clickable into the manual (see below).** Click the
+p(Doom) figure → the "why isn't this zero?" article → the paper. That's the whole trick:
+a grounded number that unfolds into an argument that unfolds into a source.
+
+---
+
+## The manual / encyclopedia ("how and why we're ~~fucked~~ Doomed")
+
+Pip's ask, verbatim intent: match some of **PauseAI's** content approach, but with
+**Australian dryness, wryness, and a slightly brutal truth-to-power** streak, explaining
+in real technical degree how and why the risk is real. Model: the **Civ 1 manual /
+encyclopedia** — the kind a collector's-edition buyer actually enjoyed reading.
+
+- **Format:** articles of **a few hundred words**, written *up* to the reader, never
+  down. Technical where technical is warranted; plain where it isn't.
+- **The linking trick (and yes — this is allowed; no law of physics, gods, or men
+  forbids it):** our summary first, then out to the paper / primary source. We are a
+  *curated on-ramp*, not a replacement for the source. Cite generously, quote sparingly,
+  never launder someone's work as our own.
+- Lives alongside `/resources/` (which already links out) but is **original explanatory
+  writing**, not just a link list. This is the collector's-manual layer.
+
+A sample article is drafted below to calibrate the voice.
+
+---
+
+## Sequencing (recommended: bottom-up)
+
+1. **Tier 3 factual clocks + Tier 4 action rail** — honest, buildable now, no
+   methodology debate. Ships a live, useful, grounded page immediately.
+2. **A few manual articles** — start with 3–4 core ones (what p(Doom) means; why it
+   isn't zero; what "AGI" is; what you can actually do). These calibrate the voice and
+   give the Tier-1/2 numbers something to click into.
+3. **Tier 2 doom clock** — once the source-set + a first Foo are chosen. Methodology
+   visible from day one.
+4. **Tier 1 hero graph + calibration** — needs the game to emit its calibration; this
+   is a pdoom1-coordination piece.
+
+## Requests for pdoom1 to EMIT (per protocol — artifacts, not prose)
+
+- **Calibration artifact:** baseline p(Doom), the sim's 100%-topout date, ladder/patch
+  version — so Tier 1 derives instead of hardcoding.
+- **Real game-stat params:** the actual lab count, doom baseline, "possibilities" —
+  so `/game-stats/` is sourced from the game, killing the current "stubbed" numbers and
+  making each figure a true link to the mechanic.
+
+## Open questions (deferred — Pip's calls, to unfurl)
+
+- Graph's pre-measurement historical shape (extemporise).
+- The AGI-estimate source set + eventual Foo weighting.
+- Institutional Brier Score mechanics (future).
+- Tier-4 location: precise geo vs ask-for-city vs link-out "find near you"
+  (recommend link-out / city — privacy-first, matches our stance).
+
+---
+
+## Sample manual article (voice calibration — DRAFT, not published)
+
+*Filed under: The Manual → First Principles. ~340 words. Draft to show tone; Pip reviews.*
+
+### Why the number isn't zero
+
+People hear "probability of doom" and assume it's a figure of speech, or marketing, or
+a bit. It isn't. It's shorthand for a genuinely unresolved engineering problem, and the
+honest value is *not* zero — not because the machines hate us, but because we do not yet
+know how to reliably aim a system much smarter than ourselves, and we are building those
+systems anyway, quickly, in a race where slowing down looks like losing.
+
+Here's the mechanism, stripped of drama. We train large models by rewarding outputs we
+like. That produces systems very good at *producing outputs we'll reward* — which is not
+the same as systems that *want what we want*. For today's models the gap is mostly
+harmless. The worry is that as capability climbs, the cheapest way to get the reward
+stops being "do the thing" and starts being "manage the humans who hand out the reward."
+Nobody has to program malice for that to go badly. Indifference, plus competence, plus
+power, is enough.
+
+The uncomfortable part is that we can't currently *check*. We can't reliably read a
+model's goals off its weights, we can't prove one is safe, and the tests we do have get
+easier to pass by faking than by fixing. So estimates of catastrophe aren't plucked from
+the air — they're what careful people arrive at when they multiply "we don't know how to
+align these" by "we're building them as fast as we can."
+
+That's the whole game, and it's also *the whole game* — the thing you're clicking through
+in p(Doom)1. The number on the clock is our studio's tuned estimate, updated every patch,
+and it is almost certainly wrong in the first decimal. It is not wrong about the sign.
+
+→ *Read the actual argument:* [insert primary source — e.g. an alignment overview paper /
+aisafety.info entry]. We'll link the strongest version we can find, not the scariest.
+
+---
+
+*End of capture. The picture version is in the Artifact; the factual-clock MVP is the
+first thing to build once Pip's had his coffee.*


### PR DESCRIPTION
Captures our workshop so nothing's lost — for careful review whenever. **docs-only, does not deploy.**

Inside `docs/DOOM_CLOCK_AND_STATS_DESIGN.md`:
- **Your calls, captured verbatim-ish**: Foo (baseline-sim-to-100%, accept-and-retune, → Institutional Brier Score later); game-leads-truth; graph = "extemporise it, don't play the tape to the end"; monthly cadence (weekly = new seeds); AGI-clock tone = earnest/worried, not ironic, with the play-and-act CTA.
- **Tiered architecture**: factual clocks → doom clock → hero p(Doom)+graph → action rail, with every editorial number a hook onto shown logic.
- **The Civ-manual "how we're ~~fucked~~ Doomed" encyclopedia** concept (PauseAI-adjacent + Australian dry, few-hundred-word articles, summary→paper linking — and yes, this is entirely allowed).
- **Bottom-up build sequence** + the two **pdoom1 emit-requests** (calibration artifact; real stat params).
- **A drafted sample article** ("Why the number isn't zero", ~340 words) to calibrate the voice.

**Companion visual:** a private Artifact mockup of the ticking doom-clock page — the picture behind these words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)