### PR TITLE
infra: platform-availability guard + generator asset-derivation

### DIFF
--- a/.github/workflows/content-honesty.yml
+++ b/.github/workflows/content-honesty.yml
@@ -1,0 +1,47 @@
+name: Content Honesty
+
+# Guards reader-facing claims that silently rot into lies. Today it enforces one
+# thing: no page a visitor can reach may advertise a platform that has no shipped
+# build. The source of truth is public/data/version.json -> latest_release.platforms
+# (derived from the release's actual assets by update-version-info.py), so this can
+# never drift from what actually shipped.
+#
+# Fails the PR check on violation -- that is the whole signal; it does not open
+# issues (unlike the data-contract workflow, this runs only on human-driven events,
+# so a red check is seen immediately). No secrets, read-only.
+
+on:
+  pull_request:
+    paths:
+      - 'public/**/*.html'
+      - 'public/data/version.json'
+      - 'scripts/check-platform-claims.py'
+      - 'scripts/test-download-resolution.js'
+  push:
+    branches: [main]
+    paths:
+      - 'public/**/*.html'
+      - 'public/data/version.json'
+      - 'scripts/check-platform-claims.py'
+      - 'scripts/test-download-resolution.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  honesty:
+    name: Platform-claims + download resolution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: No reachable page claims an unshipped platform
+        run: python scripts/check-platform-claims.py
+      - name: Download buttons resolve/degrade correctly
+        run: node scripts/test-download-resolution.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,21 @@ node    scripts/test-analytics-optout.js  # opt-out, DNT, no-injection regressio
 python  scripts/test_ingest_scores.py     # leaderboard read path
 python  scripts/validate_data.py          # data contracts
 python  scripts/check-stale-facts.py      # hardcoded facts that rot
+python  scripts/check-platform-claims.py  # no reachable page claims an unshipped OS
+node    scripts/test-download-resolution.js # download buttons resolve/degrade right
 python  scripts/snapshot-copy.py --check  # reader-facing prose drift
 python  scripts/generate-feeds.py --check # feeds in step with the blog
 node    scripts/test-header-consistency.js
 ```
+
+**Platform availability is a *derived* fact, not prose.** The source of truth is
+`public/data/version.json` → `latest_release.platforms` ({windows,macos,linux}
+booleans), which `scripts/update-version-info.py` derives from the GitHub release's
+actual **assets** (a build is either attached or it is not). Pages must not hardcode
+"available on Windows/Mac/Linux"; say "coming soon" for anything unshipped, or read
+the field (see `about/index.html`'s `platforms-available` stat). `check-platform-claims.py`
+(also wired to CI via `content-honesty.yml`) fails if a reachable page advertises a
+platform that has no build.
 
 ## Automation notes
 - Weekly-league rollover only opens a GitHub issue **on failure**

--- a/public/data/version.json
+++ b/public/data/version.json
@@ -4,6 +4,11 @@
     "name": "P(Doom) v0.13.1",
     "published_at": "2026-07-26T00:07:25Z",
     "html_url": "https://github.com/PipFoweraker/pdoom1/releases/tag/v0.13.1",
+    "platforms": {
+      "windows": true,
+      "macos": true,
+      "linux": true
+    },
     "body": "Release v0.13.1 -- two soft-lock fixes over v0.13.0: the ledger event-orphan dialog (#883) and the staff-card ESC dead-mouse (#887). Both could strand a session; no other gameplay changes.\n\n## Platform status (honest, 2026-07-26)\n| Platform | File | Tested? |\n|---|---|---|\n| Windows | PDoom-Windows-v0.13.1.zip | Yes -- this is the supported lineage (v0.13.0 played extensively) |\n| Linux | PDoom-Linux-v0.13.1.zip | NOT extensively tested -- it should boot; early feedback wanted |\n| macOS | PDoom-macOS-v0.13.1.zip | NOT extensively tested -- it should boot; early feedback wanted |\n\nIf a build does not work on your machine, that is exactly the feedback we need: email pip@beacongcr.org with your OS version and what happened. In-game, F8 saves a bug report file and shows you its path.\n\nWindows SmartScreen: More info -> Run anyway. macOS Gatekeeper: right-click -> Open the first time. Linux: chmod +x the binary. Always EXTRACT the zip first -- running from inside the zip viewer breaks the game.\n\n## Build Information\n- **Commit:** `409535dc0215d5e7bf4ff1b83025e8da98d7b4ef`\n- **Data Hash:** `847b187267046f25f6bc860fab828ad7d0485a54ea4f285b291f825c85e97e71`\n- **Manifest Hash:** `518e43cb953d2135ce0c773c2ef89808c5b2bda712ddb91ec613bf2b87408e38`\n- **Engine:** Godot 4.5.1"
   },
   "repository_stats": {

--- a/public/index.html
+++ b/public/index.html
@@ -1582,7 +1582,7 @@ t	.hero {
 		// asset naming; on rate-limit/offline it silently keeps the working release-page href.
 		async function resolveDownloads() {
 			const platforms = {
-				'download-windows': /win/i,
+				'download-windows': /win|\.exe$/i,
 				'download-macos': /mac|osx|darwin|\.app|\.dmg/i,
 				'download-linux': /linux|x86_64|\.appimage/i
 			};

--- a/scripts/check-platform-claims.py
+++ b/scripts/check-platform-claims.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Guard: no reachable page may claim a platform is available that has no shipped build.
+
+The rot this prevents (it bit us on 2026-07-25): the site said "Windows, macOS,
+Linux" while only a Windows build existed. The single source of truth for "which
+platforms shipped" is public/data/version.json -> latest_release.platforms, which
+update-version-info.py derives from the release's actual assets (a build is either
+attached or it is not -- un-fakeable). This script cross-checks the reader-facing
+pages against that source.
+
+HEURISTIC, and deliberately biased toward flagging. For each platform the source
+marks UNavailable, it flags a reachable-page line that mentions that platform in an
+availability context -- i.e. the line lists two or more OS names together, OR uses
+an availability verb (download/available/supported/...) -- UNLESS the line also
+carries a soft qualifier (coming soon / this week / in progress / later / a dash).
+A qualified line ("macOS -- coming soon") is honest and passes; a bare list
+("Windows, macOS, Linux") is not and fails.
+
+Limits (stated, not hidden): it reads raw HTML lines, so a claim split across lines
+can slip through, and it only scans the curated reachable set below. It is a
+regression net for the specific failure mode above, not a proof of total honesty.
+
+Exit 1 on any finding (so CI blocks it). Genuine false positives go in ALLOWLIST
+with a reason, never by loosening the heuristic.
+"""
+
+import json
+import os
+import re
+import sys
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+VERSION_JSON = os.path.join(ROOT, "public", "data", "version.json")
+
+# Pages a visitor can actually walk to (the navigation.js menu + the download flow
+# and the forms reached from it). Deliberately NOT the ~2,200 generated event pages.
+REACHABLE = [
+    "public/index.html",
+    "public/press/index.html",
+    "public/about/index.html",
+    "public/game-stats/index.html",
+    "public/leaderboard/index.html",
+    "public/bug-report/index.html",
+    "public/privacy/index.html",
+    "public/cats/index.html",
+    "public/issues/index.html",
+    "public/game-changelog/index.html",
+    "public/docs/index.html",
+    "public/blog/index.html",
+    "public/resources/index.html",
+]
+
+# Word-boundary name matchers per platform key in version.json.
+PLATFORM_NAMES = {
+    "windows": re.compile(r"\bwindows\b", re.I),
+    "macos": re.compile(r"\bmac\s?os\b|\bmacos\b|\bos\s?x\b|\bosx\b", re.I),
+    "linux": re.compile(r"\blinux\b", re.I),
+}
+
+# A line that says one of these near a platform is asserting availability.
+AVAILABILITY_VERB = re.compile(
+    r"\b(download|available|supported|exported to|runs? on|native on|"
+    r"get it on|play on|ships? on|grab the)\b",
+    re.I,
+)
+
+# ...unless it is softened into a promise, not a claim of the present.
+SOFT_QUALIFIER = re.compile(
+    r"coming soon|coming|\bsoon\b|this week|in progress|\bplanned\b|not yet|"
+    r"\blater\b|roadmap|\bfuture\b|work in progress|\bwip\b|"
+    r"—|&mdash;|--",  # an em dash, as in "macOS -- coming soon"
+    re.I,
+)
+
+# (file substring, line substring) pairs that are known-honest despite tripping the
+# heuristic. Add with a comment saying WHY; do not weaken the rules to clear one.
+ALLOWLIST = [
+    # (none yet)
+]
+
+
+def strip_to_visible_text(html):
+    """Reduce HTML to what a visitor actually reads: drop <script>/<style>/comment
+    blocks and all tags (so element ids like `download-macos` and JS regexes can't
+    masquerade as prose), while preserving line numbers by replacing each removed
+    span with as many newlines as it contained."""
+    def blank(m):
+        return "\n" * m.group(0).count("\n")
+    html = re.sub(r"<script\b[^>]*>.*?</script>", blank, html, flags=re.I | re.S)
+    html = re.sub(r"<style\b[^>]*>.*?</style>", blank, html, flags=re.I | re.S)
+    html = re.sub(r"<!--.*?-->", blank, html, flags=re.S)
+    html = re.sub(r"<[^>]+>", blank, html)  # remaining tags (attrs live here) -> gone
+    return html
+
+
+def load_available_platforms():
+    with open(VERSION_JSON, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    platforms = (data.get("latest_release") or {}).get("platforms")
+    if not isinstance(platforms, dict):
+        return None
+    return platforms
+
+
+def allowlisted(path, line):
+    for f_sub, l_sub in ALLOWLIST:
+        if f_sub in path and l_sub in line:
+            return True
+    return False
+
+
+def scan():
+    platforms = load_available_platforms()
+    if platforms is None:
+        print("SKIP: version.json has no latest_release.platforms; nothing to check.")
+        print("      (An older version.json predates the platforms field.)")
+        return 0
+
+    unavailable = [p for p, ok in platforms.items() if not ok]
+    available = [p for p, ok in platforms.items() if ok]
+    print(f"version.json platforms -> available: {available or '(none)'} | "
+          f"unavailable: {unavailable or '(none)'}")
+    if not unavailable:
+        print("No unavailable platforms to guard against. OK.")
+        return 0
+
+    findings = []
+    for rel in REACHABLE:
+        path = os.path.join(ROOT, rel)
+        if not os.path.isfile(path):
+            print(f"  note: {rel} not found, skipped")
+            continue
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            visible = strip_to_visible_text(f.read())
+        for n, raw in enumerate(visible.split("\n"), 1):
+                line = raw.rstrip("\n")
+                if SOFT_QUALIFIER.search(line):
+                    continue  # a softened promise, not a present-tense claim
+                names_hit = [p for p, rx in PLATFORM_NAMES.items() if rx.search(line)]
+                unavail_hit = [p for p in names_hit if p in unavailable]
+                if not unavail_hit:
+                    continue
+                is_list = len(names_hit) >= 2
+                is_verb = bool(AVAILABILITY_VERB.search(line))
+                if (is_list or is_verb) and not allowlisted(rel, line):
+                    findings.append((rel, n, unavail_hit, line.strip()[:160]))
+
+    if not findings:
+        print(f"OK: no reachable page claims {unavailable} as available.")
+        return 0
+
+    print(f"\nFAIL: {len(findings)} line(s) claim an unshipped platform as available:\n")
+    for rel, n, hit, text in findings:
+        print(f"  {rel}:{n}  (claims: {', '.join(hit)})")
+        print(f"      {text}")
+    print("\nFix: add a soft qualifier (\"coming soon\") or remove the platform, or")
+    print("if the release now ships it, update version.json/its assets. Genuine false")
+    print("positives go in ALLOWLIST with a reason.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(scan())

--- a/scripts/test-download-resolution.js
+++ b/scripts/test-download-resolution.js
@@ -1,9 +1,14 @@
 // Extracts resolveDownloads() from public/index.html and exercises it against a
 // minimal DOM/fetch shim. Verifies the launch-day contract:
 //   - a platform WITH an asset gets a direct download href
-//   - a platform WITHOUT one says "coming soon" instead of silently pointing at a
-//     release page that has no build for it
-//   - an unreachable API degrades NOTHING (we cannot know what shipped)
+//   - a platform WITHOUT one degrades to "coming soon" instead of a dead link
+//   - an unreachable / unrecognised API degrades NOTHING -- every button keeps the
+//     release-page baseline rather than being falsely disabled.
+//
+// NOTE: all three buttons ship LIVE in the HTML (href = release page, "Download
+// for <OS>"). That is copy-pass's launch shape: v0.13.1 ships Windows, macOS AND
+// Linux builds, so every button starts live and only degrades if a future release
+// drops a platform. This mirrors makeEl() below.
 const fs = require('fs');
 const path = require('path');
 const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
@@ -13,10 +18,16 @@ if (!m) { console.error('FAIL: could not extract resolveDownloads()'); process.e
 
 const BASE = 'https://github.com/PipFoweraker/pdoom1/releases/latest';
 
+// Model the REAL initial DOM: every platform ships LIVE, pointing at the release
+// page with a "Download for <OS>" label. resolveDownloads() upgrades each to its
+// direct asset URL, or degrades it to "coming soon" only if the release actually
+// dropped that platform's build.
 function makeEl(id, label) {
   return {
-    id, dataset: { platformLabel: label }, textContent: 'Download for ' + label,
-    style: {}, _attrs: { href: BASE, target: '_blank' },
+    id, dataset: { platformLabel: label },
+    textContent: 'Download for ' + label,
+    style: {},
+    _attrs: { href: BASE, target: '_blank' },
     hasAttribute(k) { return k in this._attrs; },
     removeAttribute(k) { delete this._attrs[k]; },
     setAttribute(k, v) { this._attrs[k] = v; },
@@ -47,33 +58,42 @@ async function run(name, assets, { ok = true } = {}) {
 
   const A = (n) => ({ name: n, browser_download_url: 'https://gh/' + n });
 
-  // Scenario 1: today's intended shape -- Windows + macOS ship, Linux does not.
-
-  let els = await run('win+mac', [A('PDoom-v0.13.0-windows.zip'), A('PDoom-v0.13.0-macOS.zip')]);
-  console.log('Scenario 1: Windows + macOS assets, no Linux');
-  check(els['download-windows'].href === 'https://gh/PDoom-v0.13.0-windows.zip', 'Windows -> direct asset');
-  check(els['download-macos'].href === 'https://gh/PDoom-v0.13.0-macOS.zip', 'macOS -> direct asset');
-  check(!els['download-linux'].hasAttribute('href'), 'Linux -> href removed (not a dead link)');
-  check(/coming soon/i.test(els['download-linux'].textContent), 'Linux -> says "coming soon"');
+  // Scenario 1: TODAY's real shape (v0.13.1) -- all three builds ship.
+  let els = await run('all three', [
+    A('PDoom-Windows-v0.13.1.zip'),
+    A('PDoom-macOS-v0.13.1.zip'),
+    A('PDoom-Linux-v0.13.1.zip'),
+  ]);
+  console.log('Scenario 1: Windows + macOS + Linux assets (current v0.13.1 shape)');
+  check(els['download-windows'].href === 'https://gh/PDoom-Windows-v0.13.1.zip', 'Windows -> direct asset');
+  check(els['download-macos'].href === 'https://gh/PDoom-macOS-v0.13.1.zip', 'macOS -> direct asset');
+  check(els['download-linux'].href === 'https://gh/PDoom-Linux-v0.13.1.zip', 'Linux -> direct asset');
+  check(els['download-macos'].textContent === 'Download for macOS', 'macOS -> live label kept');
   check(els['macos-gatekeeper-note'].style.display === 'block', 'Gatekeeper note shown (mac resolved)');
 
-  // Scenario 2: Windows only -- the CURRENT v0.12.0 shape. Mac must degrade too.
-  els = await run('win only', [A('PDoom-v0.12.0-windows.zip')]);
-  console.log('Scenario 2: Windows only (current v0.12.0 shape)');
-  check(els['download-windows'].href === 'https://gh/PDoom-v0.12.0-windows.zip', 'Windows -> direct asset');
-  check(!els['download-macos'].hasAttribute('href'), 'macOS -> degraded');
+  // Scenario 2: a future release that dropped macOS + Linux, Windows only.
+  els = await run('win only', [A('PDoom-Windows-v0.13.1.zip')]);
+  console.log('Scenario 2: Windows only -> macOS/Linux degrade to "coming soon"');
+  check(els['download-windows'].href === 'https://gh/PDoom-Windows-v0.13.1.zip', 'Windows -> direct asset');
+  check(!els['download-macos'].hasAttribute('href'), 'macOS -> no href (not a dead link)');
+  check(/coming soon/i.test(els['download-macos'].textContent), 'macOS -> says "coming soon"');
+  check(!els['download-linux'].hasAttribute('href'), 'Linux -> no href (not a dead link)');
+  check(/coming soon/i.test(els['download-linux'].textContent), 'Linux -> says "coming soon"');
   check(els['macos-gatekeeper-note'].style.display === 'none', 'Gatekeeper note hidden (no mac build)');
 
-  // Scenario 3: API unreachable -- we know nothing, so change nothing.
+  // Scenario 3: API unreachable -- change nothing. Every button keeps its live
+  // release-page baseline (we cannot know what shipped, so never degrade).
   els = await run('rate limited', [], { ok: false });
-  console.log('Scenario 3: API rate-limited / offline');
+  console.log('Scenario 3: API rate-limited / offline -> all keep release-page baseline');
   check(els['download-windows'].href === BASE, 'Windows keeps release-page baseline');
-  check(els['download-linux'].href === BASE, 'Linux keeps baseline (NOT falsely "coming soon")');
+  check(els['download-macos'].href === BASE, 'macOS keeps release-page baseline');
+  check(els['download-linux'].href === BASE, 'Linux keeps release-page baseline');
 
   // Scenario 4: assets exist but none match our naming guess -> keep baseline.
   els = await run('unrecognised', [A('SomethingWeird.bin'), A('checksums.txt')]);
-  console.log('Scenario 4: release has assets, none recognised as builds');
+  console.log('Scenario 4: release has assets, none recognised as builds -> keep baseline');
   check(els['download-windows'].href === BASE, 'Windows keeps baseline');
+  check(els['download-macos'].href === BASE, 'macOS keeps baseline');
   check(els['download-linux'].href === BASE, 'Linux keeps baseline');
 
   console.log(failures ? `\n${failures} FAILURE(S)` : '\nAll checks passed.');

--- a/scripts/update-version-info.py
+++ b/scripts/update-version-info.py
@@ -7,9 +7,18 @@ Fetches latest release info and updates website data files
 import json
 import os
 import re
+import sys
 import urllib.request
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
+# Windows console is cp1252; the check marks below (U+2713) would raise
+# UnicodeEncodeError on the FIRST print, aborting before any work. Force UTF-8.
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
 
 GITHUB_API_BASE = 'https://api.github.com'
 REPO_OWNER = 'PipFoweraker'
@@ -44,6 +53,36 @@ def read_existing_version_json() -> Dict[str, Any]:
         return {}
 
 
+# Same filename heuristics resolveDownloads() uses in index.html. Keep the two in
+# step: if the button can resolve a build for a platform, this must report that
+# platform available, and vice versa.
+_PLATFORM_PATTERNS = {
+    # '\.exe$' catches a bare PDoom.exe (v0.13.1+ dropped "windows" from the name);
+    # 'win' still catches PDoom-...-windows.zip (v0.13.0 style).
+    'windows': re.compile(r'win|\.exe$', re.I),
+    'macos':   re.compile(r'mac|osx|darwin|\.app|\.dmg', re.I),
+    'linux':   re.compile(r'linux|x86_64|\.appimage', re.I),
+}
+_BUILD_SUFFIX = re.compile(r'\.(zip|dmg|appimage|x86_64|exe|tar\.gz)$', re.I)
+
+
+def derive_platforms(assets: List[Dict[str, Any]]) -> Dict[str, bool]:
+    """Which OS builds are actually attached to the release.
+
+    A platform is 'available' iff a matching downloadable build exists -- the one
+    un-fakeable source of truth (the file is either in the release or it is not).
+    Pages and the platform-claims guard read this instead of trusting hand-typed
+    prose, which is what silently rots into a lie. NOTE: this is only meaningful on
+    a FRESH asset list; an empty list from a failed fetch would read as 'nothing
+    shipped anywhere', so callers must preserve the prior value on failure rather
+    than write all-False. See get_latest_release()."""
+    names = [a.get('name', '') for a in (assets or [])]
+    return {
+        os_key: any(pat.search(n) and _BUILD_SUFFIX.search(n) for n in names)
+        for os_key, pat in _PLATFORM_PATTERNS.items()
+    }
+
+
 def get_latest_release() -> Dict[str, Any]:
     """Get latest release information"""
     data = fetch_github_data(f"/repos/{REPO_OWNER}/{REPO_NAME}/releases/latest")
@@ -54,7 +93,10 @@ def get_latest_release() -> Dict[str, Any]:
             'name': data.get('name'),
             'published_at': data.get('published_at'),
             'html_url': data.get('html_url'),
-            'body': data.get('body', '')
+            'body': data.get('body', ''),
+            # Derived from THIS release's assets. Fresh fetch, so it is safe to
+            # write; the failure branch below keeps the last known-good instead.
+            'platforms': derive_platforms(data.get('assets', [])),
         }
 
     # API failed. This function's output is written straight into version.json, which


### PR DESCRIPTION
Re-landed cleanly off current main (the original #173 merged into its orphaned stacked base when #172 was squashed, so it never reached production). No reader-facing prose — data/scripts/workflow only.

- `check-platform-claims.py` + `content-honesty.yml` — the honesty guard (the check that caught a copy agent trying to over-claim platforms), now enforced in CI.
- `update-version-info.py` — derives `platforms` from the release's actual assets (`win|\.exe$` / mac / linux matchers), preserved-on-failure like the rest.
- `version.json` — `platforms: {windows,macos,linux: true}` (all three v0.13.1 builds ship). Lights up the About "Platforms Available" stat to the true 3.
- `index.html` — windows matcher gains `\.exe$` for robustness.
- `test-download-resolution.js` — matches production's live-default buttons; all checks pass.

Known follow-up (not here): the generator still hardcodes `game_stats.frontier_labs_count: 7` (main shows 5) — a clobber that fires on the next auto-run. Deferred rather than touch the load-bearing version-sync path overnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)