### PR TITLE
feat(cats): honest cat-submission path (#159, first increment)

### DIFF
--- a/public/cats/index.html
+++ b/public/cats/index.html
@@ -221,6 +221,13 @@
 			<p style="color: var(--text-muted); font-size: 0.9rem;">Want to become a custodian? Check out the <a href="/about/#contributors" style="color: var(--accent-primary);">contributors page</a> to learn how to earn rewards.</p>
 		</section>
 
+		<section class="info-section">
+			<h2>Submit your cat</h2>
+			<p style="margin-bottom: 1rem;">We can now turn a photo of a real cat into a pixel office companion &mdash; so we're actually asking: send us your cat. If it makes the cut, it joins the custodians above.</p>
+			<p style="margin-bottom: 1rem;">There's no upload widget here yet. The honest path is our <a href="/bug-report/" style="color: var(--accent-primary);">reporting form</a>: choose <strong>Feature</strong>, title it &ldquo;Cat submission&rdquo;, attach the photo (up to 500&nbsp;KB), and it comes straight through to the team.</p>
+			<p style="color: var(--text-muted); font-size: 0.9rem;">The consent bit, plainly: a photo of your cat is something you're choosing to send us, and the cat may appear publicly in the game. The form's &ldquo;name for credit&rdquo; is opt-in &mdash; fill it in to be credited (you or the cat!), leave it blank to stay anonymous. Your email is used only to reply.</p>
+		</section>
+
 		<div class="cat-gallery">
 			<div class="cat-card">
 				<img src="/assets/cats-gallery/web-doom-cat.jpg" alt="Doom Cat - The original AI Safety guardian" class="cat-image" loading="lazy">


### PR DESCRIPTION
Closes the #159 gap — the page solicited cats but asked for nothing. Now that the game has a photo→pixel pipeline (pdoom1 #815) and the bug form actually forwards attachments (PR #162, verified live), this adds a **Submit your cat** section that routes to the working attachment path with explicit consent + opt-in credit framing. New reader-facing prose, so it's a PR for your eyeball rather than a direct push. A dedicated embedded form can be a later increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)