### PR TITLE
content(roadmap): re-project the pdoom1 monthly-Theme roadmap (closes #164)

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -73,8 +73,8 @@
           <span class="status synced">Auto-synced</span>
         </li>
         <li>
-          <a href="roadmap.md">Development Roadmap</a>
-          <span class="status local">Website-only</span>
+          <a href="/docs/roadmap/">Development Roadmap</a>
+          <span class="status local">Projection of game repo</span>
         </li>
         <li>
           <a href="steam-readiness.md">Steam Release Preparation</a>
@@ -165,7 +165,7 @@
       <p style="color: var(--text-muted);">New to p(Doom)1? Start here:</p>
       <ol style="color: var(--text-secondary); line-height: 1.6;">
         <li>Read the <a href="DEV_NOTES.md">Developer Notes</a> for game overview</li>
-        <li>Check the <a href="roadmap.md">Roadmap</a> for current development status</li>
+        <li>Check the <a href="/docs/roadmap/">Roadmap</a> for current development status</li>
         <li>Review <a href="pdoom1-open-issues.md">Open Issues</a> for ways to contribute</li>
         <li>Visit the <a href="https://github.com/PipFoweraker/pdoom1">main repository</a> to download and play</li>
       </ol>

--- a/public/docs/roadmap.md
+++ b/public/docs/roadmap.md
@@ -1,41 +1,100 @@
 # Roadmap
 
-Where P(Doom)1 is headed. This page is the player-facing projection of the
-game repo's [docs/ROADMAP.md](https://github.com/PipFoweraker/pdoom1/blob/main/docs/ROADMAP.md)
-(the source of truth); day-to-day execution lives on the
+Where P(Doom)1 is headed, and how firm each part of it is.
+
+This page is a projection. The source of truth is the game repo:
+[docs/ROADMAP.md](https://github.com/PipFoweraker/pdoom1/blob/main/docs/ROADMAP.md)
+and [docs/RELEASE_NOMENCLATURE.md](https://github.com/PipFoweraker/pdoom1/blob/main/docs/RELEASE_NOMENCLATURE.md).
+Nothing on this page is a commitment the game repo has not already made; where
+the two disagree, the game repo is right. Day-to-day execution lives on the
 [GitHub milestones](https://github.com/PipFoweraker/pdoom1/milestones).
-Website work has its own page: [Website roadmap](website-roadmap.md).
+Website work has its own page: [Website roadmap](/docs/website-roadmap.md).
+
+## How the game evolves
+
+Since 25 July 2026 the game moves on a **monthly rhythm**:
+
+- **Each month is a Theme.** One named direction -- a new mechanic, plus
+  quality-of-life and balance work -- shipped on the first Friday of the month
+  as a minor version bump.
+- **A Theme forks the leaderboard.** Because the rules change, a new epoch
+  starts and scores begin fresh. Older runs stay in the archive; they simply
+  stop being comparable to new ones.
+- **Every Friday brings a new seed.** A fresh board on unchanged rules -- new
+  puzzle, same game, same epoch.
+- **Small fixes ship any time**, as patches, and never fork the board.
+
+Quarterly planning has been retired. It was slowing the real pace down, and a
+version number now means "which month's Theme is this", not "which quarter".
+
+Above that rhythm sit two **Big Milestones**. Each spans several monthly Themes
+and completes when it is done rather than on a fixed date. They exist to make
+the shape of the project legible without pretending a solo developer can
+date-lock a quarter.
+
+## The two big milestones
+
+**First Contact** -- targeting the end of Q3 2026. Everything the game needs
+before the doors open properly: first-launch help and onboarding, the share loop
+(copy your result and your seed so somebody can try to beat it), the remote
+leaderboard switched on and hardened, and the monthly league running for real.
+
+**Rivals & News** -- targeting the end of Q4 2026. Rival labs stop being
+background numbers and become a surface you play against: an intel panel, a
+visible capability race, poaching, and a News channel that reports the world
+back to you.
+
+Both are named arcs, not release dates.
+
+## Month by month
+
+Theme names beyond the shipped one are **provisional** -- the game repo marks
+them so, and two of the six months are not named at all yet.
+
+| Ships | Version | Theme | What it adds | How firm |
+|---|---|---|---|---|
+| Jul 2026 | v0.13 | Launch epoch | hiring pipeline, narrative cold-open, office visuals, the league live, a legibility and stability pass | **Shipped** |
+| 7 Aug 2026 | v0.14 | "Per-tick & People" *(provisional name)* | per-tick resolution; people and money cohere -- roles, salary, managers, payroll | Grounded in design that already exists |
+| 4 Sep 2026 | v0.15 | *not yet named* | onboarding as a mechanic rather than a tutorial; public-alpha hardening -- leaderboard, install ping, bug reporter, test builds | Grounded in design that already exists |
+| 2 Oct 2026 | v0.16 | "Sightings" *(provisional name)* | rivals begin to appear -- procedural presence and developments; a wider event pool drawn from the open data set | Direction to steer, not a commitment |
+| 6 Nov 2026 | v0.17 | "The World Shoots Back" *(provisional name)* | the News feedline, plus rival pressure in the midgame: poaching, litigation, funding attacks | Direction to steer, not a commitment |
+| 4 Dec 2026 | v0.18 | *not yet named* | rivals confront you directly; News v1; a voice pass over generic event text | Direction to steer, not a commitment |
+
+The "how firm" column is the game repo's own confidence note, not a softening we
+added: the next two months rest on design that already exists, and everything
+from October onward is expected to be reshaped by design workshops before it is
+built. The dates follow the first-Friday rule, so they move when a month moves.
+
+## Further out -- wanted, not scheduled
+
+Carried forward with no dates attached, deliberately: a player-facing Liability
+Ledger; a content-pool ladder and a monthly world-update metabolism that feeds
+real-world AI events into the game; a damper-economy beat; and then the beta and
+Steam "coming soon" beat -- store page and wishlists, press kit, character
+creation, and a full balance calibration pass.
 
 ## The release ladder
 
-1. **Private alpha (v0.11) -- we are here.** Friends-and-family Windows build
-   with the full core loop, hiring pipeline, honest defeat screens, and the
-   world leaderboard.
-2. **Public alpha -- free.** First-contact polish, onboarding, and the share
-   loop, then the doors open. (How it will be distributed -- direct download,
-   a storefront page, or a playable web build -- is still being decided.)
-3. **Beta -- Steam "coming soon" page.** Wishlists start compounding while
-   the mid and late game get built in.
+1. **Alpha -- we are here.** The game is free and you can download it from this
+   site today. The game repo still calls this the *private*
+   (friends-and-family) alpha, because what makes the alpha "public" is
+   readiness rather than availability: onboarding that works without somebody
+   sitting next to you, a hardened leaderboard, and a distribution channel
+   chosen. That readiness work is the First Contact milestone.
+2. **Public alpha -- free.** How it will be distributed is genuinely not
+   decided: a direct download from this site, a storefront page, or a playable
+   web build. That decision is owed before the public alpha ships. Anyone who
+   tells you it is settled is ahead of the facts.
+3. **Beta -- a Steam "coming soon" page.** Wishlists start compounding while the
+   mid and late game get built in.
 4. **1.0.**
 
-## Quarterly outlook
+This page does not restate which build is current, so that it cannot go stale --
+the download buttons on the [home page](/) always point at the latest release.
 
-| Quarter | Version | Theme |
-|---|---|---|
-| Q3 2026 | v0.12 | **First Contact** -- public alpha, onboarding and first-launch help, shareable runs ("beat my seed"), world leaderboard switched on |
-| Q4 2026 | v0.13 | **Rivals and News** -- rival labs become a visible strategic surface: intel panel, capability race, a News feed with detail you earn |
-| Q1 2027 | v0.14 | **The World Shoots Back** -- rivals fight back past a threshold; the Liability Ledger becomes fully player-facing; monthly world-updates begin flowing from real-world AI events |
-| Q2 2027 | v0.15 | **Beta / Steam Coming Soon** -- Steam page and wishlists, press kit, character creation, a full balance pass |
+## What all of this is sized to
 
-v0.12 is committed; v0.13 is planned; the 2027 pins are honest intentions,
-sized to a solo developer working roughly one to two focused days per week --
-they exist to be steered, not to be marketing.
-
-## Cadence
-
-Leagues, content updates, and releases run **monthly**: a point release, a
-curated world-update, balance adjustments, and a refreshed challenge board
-each league month. The quarterly versions above are theme milestones, not
-the release cadence. Weekly output is limited to lightweight generated
-artifacts (challenge seeds). Runs are deterministic per seed, so every
-board compares fairly.
+One developer at roughly one to two focused days a week, plus agent-assisted
+increments. Every date above is sized to that cadence, not to burst weeks. They
+exist to be steered, and to make the shape of the work legible -- not as
+marketing.

--- a/public/docs/roadmap/index.html
+++ b/public/docs/roadmap/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en-AU">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Roadmap — p(Doom)1</title>
+	<meta name="description" content="Where p(Doom)1 is headed and how firm each part of it is — the monthly Theme rhythm, the two big milestones, and what is still only a direction.">
+	<link rel="canonical" href="https://pdoom1.com/docs/roadmap/" />
+	<!-- Plausible Analytics - Privacy-first, self-hosted -->
+	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
+	<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+	<style>
+		:root{
+			--bg-primary:#12100f; --bg-secondary:#1c1917; --bg-tertiary:#262220;
+			--text-primary:#ffffff; --text-secondary:#cfc7bb; --text-muted:#a79e92;
+			--accent-primary:#f6a800; --accent-secondary:#2fd4c2;
+			--border-color:#3a342e; --radius-lg:10px;
+			--mono:ui-monospace,"SFMono-Regular",Menlo,"Courier New",monospace;
+		}
+		*{margin:0;padding:0;box-sizing:border-box}
+		html{color-scheme:dark}
+		body{
+			background:var(--bg-primary); color:var(--text-primary);
+			font-family:var(--mono); line-height:1.65;
+			-webkit-font-smoothing:antialiased;
+		}
+		main{max-width:min(860px,92vw); margin:0 auto; padding:2rem 0 4rem}
+		.crumb{font-size:.8rem; color:var(--text-muted); margin-bottom:1.2rem}
+		.crumb a{color:var(--accent-primary); text-decoration:none}
+		.crumb a:hover{text-decoration:underline}
+
+		/* Derived, never typed: filled from /data/version.json at runtime. */
+		.shipped{
+			background:var(--bg-secondary); border:1px solid var(--border-color);
+			border-radius:var(--radius-lg); padding:.9rem 1.1rem; margin-bottom:1.8rem;
+			font-size:.86rem; color:var(--text-secondary);
+		}
+		.shipped .k{font-size:.68rem; letter-spacing:.14em; text-transform:uppercase; color:var(--text-muted); display:block; margin-bottom:.25rem}
+		.shipped a{color:var(--accent-primary); text-decoration:none}
+		.shipped a:hover{text-decoration:underline}
+
+		#doc h1{font-size:clamp(1.7rem,5vw,2.4rem); margin:0 0 .9rem; letter-spacing:.01em; text-wrap:balance}
+		#doc h2{font-size:1.15rem; margin:2.2rem 0 .7rem; color:var(--accent-primary); letter-spacing:.02em}
+		#doc h3{font-size:1rem; margin:1.4rem 0 .5rem; color:var(--accent-secondary)}
+		#doc p{margin:.75rem 0; color:var(--text-secondary); text-wrap:pretty}
+		#doc ul,#doc ol{margin:.75rem 0 .75rem 1.4rem; color:var(--text-secondary)}
+		#doc li{margin:.4rem 0}
+		#doc strong{color:var(--text-primary)}
+		#doc em{color:var(--text-muted); font-style:italic}
+		#doc code{background:var(--bg-tertiary); padding:.1rem .35rem; border-radius:4px; font-size:.9em}
+		#doc a{color:var(--accent-primary); text-decoration:none}
+		#doc a:hover{text-decoration:underline}
+
+		/* Wide tables must scroll inside their own box, never the page body. */
+		.tablewrap{overflow-x:auto; margin:1.1rem 0; border:1px solid var(--border-color); border-radius:var(--radius-lg)}
+		#doc table{border-collapse:collapse; width:100%; min-width:640px; font-size:.83rem}
+		#doc th,#doc td{padding:.6rem .8rem; text-align:left; vertical-align:top; border-bottom:1px solid var(--border-color)}
+		#doc th{background:var(--bg-tertiary); color:var(--text-primary); font-size:.7rem; letter-spacing:.1em; text-transform:uppercase; white-space:nowrap}
+		#doc td{color:var(--text-secondary)}
+		#doc tr:last-child td{border-bottom:0}
+
+		.fallback{background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:var(--radius-lg); padding:1.2rem}
+		.fallback a{color:var(--accent-primary)}
+		.src{margin-top:2.5rem; padding-top:1.2rem; border-top:1px solid var(--border-color); font-size:.78rem; color:var(--text-muted)}
+		.src a{color:var(--accent-primary); text-decoration:none}
+	</style>
+</head>
+<body>
+	<!-- navigation.js injects the shared header here (see CLAUDE.md). -->
+	<header></header>
+
+	<main role="main" id="main-content">
+		<p class="crumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / Roadmap</p>
+
+		<div class="shipped" id="shipped" hidden>
+			<span class="k">Currently shipped</span>
+			<span id="shipped-body"></span>
+		</div>
+
+		<div id="doc">
+			<div class="fallback" id="loading">Loading the roadmap&hellip;</div>
+		</div>
+
+		<p class="src">
+			This page renders <a href="/docs/roadmap.md">/docs/roadmap.md</a> directly &mdash; it holds no
+			copy of its own, so the two cannot drift apart. That file is itself a projection of the game
+			repo's <a href="https://github.com/PipFoweraker/pdoom1/blob/main/docs/ROADMAP.md">ROADMAP.md</a>,
+			which is the source of truth.
+		</p>
+	</main>
+
+	<script>
+	(function () {
+		'use strict';
+
+		function esc(s) {
+			return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+		}
+
+		// Inline spans, applied AFTER escaping so the source can never inject markup.
+		function inline(s) {
+			return esc(s)
+				.replace(/`([^`]+)`/g, '<code>$1</code>')
+				.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, function (m, text, href) {
+					// Same-origin or http(s) only; anything else renders as plain text.
+					if (!/^(https?:\/\/|\/|#)/.test(href)) { return m; }
+					var ext = /^https?:\/\//.test(href) ? ' target="_blank" rel="noopener"' : '';
+					return '<a href="' + href + '"' + ext + '>' + text + '</a>';
+				})
+				.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+				.replace(/\*([^*]+)\*/g, '<em>$1</em>')
+				// The markdown keeps ASCII "--" (repo convention); a reader should see
+				// a dash, not a typo. Presentation only -- the wording is untouched.
+				.replace(/(^|\s)--(\s|$)/g, '$1&mdash;$2');
+		}
+
+		function cells(row) {
+			return row.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|').map(function (c) {
+				return c.trim();
+			});
+		}
+
+		// Deliberately a SUBSET: headings, paragraphs, lists, tables, and the inline
+		// spans above. That is everything roadmap.md uses. Anything else would render
+		// as literal text, which is visible and therefore fixable -- unlike silence.
+		function render(md) {
+			var lines = md.replace(/\r\n/g, '\n').split('\n');
+			var out = [];
+			var i = 0;
+
+			while (i < lines.length) {
+				var line = lines[i];
+
+				if (!line.trim()) { i++; continue; }
+
+				var h = /^(#{1,3})\s+(.*)$/.exec(line);
+				if (h) {
+					var lvl = h[1].length;
+					out.push('<h' + lvl + '>' + inline(h[2]) + '</h' + lvl + '>');
+					i++;
+					continue;
+				}
+
+				// Table: a header row followed by a |---|---| separator.
+				if (/^\s*\|/.test(line) && i + 1 < lines.length && /^\s*\|[\s:|-]+\|\s*$/.test(lines[i + 1])) {
+					var head = cells(line);
+					i += 2;
+					var body = [];
+					while (i < lines.length && /^\s*\|/.test(lines[i])) {
+						body.push(cells(lines[i]));
+						i++;
+					}
+					var t = '<div class="tablewrap"><table><thead><tr>';
+					head.forEach(function (c) { t += '<th>' + inline(c) + '</th>'; });
+					t += '</tr></thead><tbody>';
+					body.forEach(function (r) {
+						t += '<tr>';
+						r.forEach(function (c) { t += '<td>' + inline(c) + '</td>'; });
+						t += '</tr>';
+					});
+					out.push(t + '</tbody></table></div>');
+					continue;
+				}
+
+				// Lists. A continuation line is any indented, non-blank, non-marker line.
+				var ulm = /^[-*]\s+/, olm = /^\d+\.\s+/;
+				if (ulm.test(line) || olm.test(line)) {
+					var ordered = olm.test(line);
+					var marker = ordered ? olm : ulm;
+					var items = [];
+					while (i < lines.length && lines[i].trim() && (marker.test(lines[i]) || /^\s+\S/.test(lines[i]))) {
+						if (marker.test(lines[i])) {
+							items.push(lines[i].replace(marker, ''));
+						} else if (items.length) {
+							items[items.length - 1] += ' ' + lines[i].trim();
+						}
+						i++;
+					}
+					var tag = ordered ? 'ol' : 'ul';
+					out.push('<' + tag + '>' + items.map(function (it) {
+						return '<li>' + inline(it) + '</li>';
+					}).join('') + '</' + tag + '>');
+					continue;
+				}
+
+				// Paragraph: run to the next blank line or block marker.
+				var para = [];
+				while (i < lines.length && lines[i].trim() &&
+				       !/^(#{1,3})\s/.test(lines[i]) && !/^\s*\|/.test(lines[i]) &&
+				       !ulm.test(lines[i]) && !olm.test(lines[i])) {
+					para.push(lines[i].trim());
+					i++;
+				}
+				if (para.length) { out.push('<p>' + inline(para.join(' ')) + '</p>'); }
+			}
+
+			return out.join('\n');
+		}
+
+		// Expose for the node test; harmless in the browser.
+		if (typeof module !== 'undefined' && module.exports) { module.exports = { render: render }; }
+
+		if (typeof document === 'undefined') { return; }
+
+		fetch('/docs/roadmap.md', { cache: 'no-cache' })
+			.then(function (r) {
+				if (!r.ok) { throw new Error('HTTP ' + r.status); }
+				return r.text();
+			})
+			.then(function (md) {
+				document.getElementById('doc').innerHTML = render(md);
+			})
+			.catch(function () {
+				// Fail loudly and usefully rather than showing a stale or invented roadmap.
+				document.getElementById('doc').innerHTML =
+					'<div class="fallback"><p>The roadmap could not be loaded just now. ' +
+					'It is readable at <a href="/docs/roadmap.md">/docs/roadmap.md</a>, and the ' +
+					'source of truth is the game repo\'s ' +
+					'<a href="https://github.com/PipFoweraker/pdoom1/blob/main/docs/ROADMAP.md" target="_blank" rel="noopener">ROADMAP.md</a>.</p></div>';
+			});
+
+		// The shipped version is DERIVED, never typed into this page. If the lookup
+		// fails the strip stays hidden -- no fallback literal to go stale.
+		fetch('/data/version.json', { cache: 'no-cache' })
+			.then(function (r) { return r.ok ? r.json() : null; })
+			.then(function (data) {
+				var rel = data && data.latest_release;
+				if (!rel || !rel.version) { return; }
+				var url = rel.html_url || 'https://github.com/PipFoweraker/pdoom1/releases/latest';
+				var body = document.getElementById('shipped-body');
+				var a = document.createElement('a');
+				a.href = url;
+				a.target = '_blank';
+				a.rel = 'noopener';
+				a.textContent = rel.version;
+				body.appendChild(a);
+				body.appendChild(document.createTextNode(' — free, and downloadable from the '));
+				var home = document.createElement('a');
+				home.href = '/';
+				home.textContent = 'home page';
+				body.appendChild(home);
+				body.appendChild(document.createTextNode('.'));
+				document.getElementById('shipped').hidden = false;
+			})
+			.catch(function () { /* strip stays hidden */ });
+	})();
+	</script>
+
+	<script src="/assets/js/navigation.js"></script>
+</body>
+</html>

--- a/public/docs/website-roadmap.md
+++ b/public/docs/website-roadmap.md
@@ -2,7 +2,7 @@
 
 This roadmap is a living document. It summarizes major goals for the **website** and feeds the GitHub Issues backlog for execution. It is organized by status rather than version number to avoid confusion.
 
-> **Versioning note:** The *game* (`PipFoweraker/pdoom1`) is the source of truth for gameplay and releases — its current release is **v0.11.0**. This site tracks that release automatically via `public/data/version.json`. The milestones below describe *website* work and are independent of the game's version.
+> **Versioning note:** The *game* (`PipFoweraker/pdoom1`) is the source of truth for gameplay and releases. This site tracks its current release automatically via `public/data/version.json`, so no version number is written down here to go stale — see the [game roadmap](/docs/roadmap/) for where the game is headed. The milestones below describe *website* work and are independent of the game's version.
 
 ## Shipped
 - **Weekly League system** — deterministic seeding, standings UI, archives, and automated weekly rollover.
@@ -28,4 +28,4 @@ This roadmap is a living document. It summarizes major goals for the **website**
 ## Notes
 - The source of truth for game code and the design system is the `PipFoweraker/pdoom1` repo. This site links there for downloads until the Steam launch.
 
-- Forward cadence note (2026-07-21): league/content operations move to a MONTHLY cycle; weekly output is limited to generated challenge seeds. See the game roadmap.
+- Forward cadence note (2026-07-21, re-cast 2026-07-25): the game ships one named Theme a month, and league/content operations run on that same monthly cycle; weekly output is limited to generated challenge seeds. See the [game roadmap](/docs/roadmap/).

--- a/public/index.html
+++ b/public/index.html
@@ -1168,16 +1168,16 @@ t	.hero {
 
 		<section class="section" id="roadmap">
 			<h2>Roadmap</h2>
-			<p style="margin-bottom: 0.6rem;">High-level milestones for the website and game. <a href="/docs/roadmap.md" style="color: var(--accent-primary);">View full roadmap →</a></p>
+			<p style="margin-bottom: 0.6rem;">High-level milestones for the website and game. <a href="/docs/roadmap/" style="color: var(--accent-primary);">View full roadmap →</a></p>
 			<div class="grid">
-				<a href="/docs/roadmap.md" class="card roadmap-card" style="text-decoration: none; color: inherit;">
+				<a href="/docs/roadmap/" class="card roadmap-card" style="text-decoration: none; color: inherit;">
 					<h3>Short term (weeks) 📅</h3>
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
 						<li>Regular feature updates</li>
 						<li>Social media automation</li>
 					</ul>
 				</a>
-				<a href="/docs/roadmap.md" class="card roadmap-card" style="text-decoration: none; color: inherit;">
+				<a href="/docs/roadmap/" class="card roadmap-card" style="text-decoration: none; color: inherit;">
 					<h3>Mid term (months) 🚀</h3>
 					<ul style="margin: 0.8rem 0; padding-left: 1.2rem;">
 						<li>Steam &mdash; eventually, no date</li>

--- a/scripts/test-roadmap-render.js
+++ b/scripts/test-roadmap-render.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Guard: /docs/roadmap/ renders /docs/roadmap.md, and holds no copy of its own.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * DreamHost serves a .md file as a DOWNLOAD, so /docs/roadmap.md is not a page a
+ * visitor can read (TECH_DEBT B8). The rendering surface exists to fix that. The
+ * trap it must not fall into is becoming a SECOND copy of the roadmap prose,
+ * which would then drift from the markdown, which is itself a projection of the
+ * game repo's ROADMAP.md. So the page fetches the markdown at runtime and renders
+ * it with a deliberately small parser -- and this test pins that parser against
+ * the actual file, because a silently-mangled table is exactly the kind of thing
+ * nobody notices until a funder reads it.
+ *
+ * It also asserts the two honesty properties the roadmap depends on:
+ *   1. the HTML page contains no hardcoded game version (it derives one, or shows
+ *      nothing), and
+ *   2. every forward-looking Theme row is marked provisional or unnamed.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const PAGE = path.join(ROOT, 'public', 'docs', 'roadmap', 'index.html');
+const DOC = path.join(ROOT, 'public', 'docs', 'roadmap.md');
+
+let failures = 0;
+function check(name, ok, detail) {
+	if (ok) {
+		console.log('  PASS  ' + name);
+	} else {
+		failures++;
+		console.log('  FAIL  ' + name + (detail ? ' -- ' + detail : ''));
+	}
+}
+
+const html = fs.readFileSync(PAGE, 'utf8');
+const md = fs.readFileSync(DOC, 'utf8');
+
+// --- Pull the renderer out of the page and run it here, with no DOM. ---------
+const scripts = html.match(/<script>([\s\S]*?)<\/script>/g) || [];
+const rendererTag = scripts.find((s) => s.includes('function render'));
+if (!rendererTag) {
+	console.log('  FAIL  page still contains an inline renderer script');
+	process.exit(1);
+}
+const code = rendererTag.replace(/^<script>/, '').replace(/<\/script>$/, '');
+
+const fakeModule = { exports: {} };
+// `document` is genuinely undefined here, so the page's own guard short-circuits
+// the fetch calls and only the pure function is exercised.
+new Function('module', 'exports', code)(fakeModule, fakeModule.exports);
+
+check('renderer is exported for testing', typeof fakeModule.exports.render === 'function');
+if (typeof fakeModule.exports.render !== 'function') { process.exit(1); }
+
+const out = fakeModule.exports.render(md);
+
+// --- The page must not carry its own copy of the roadmap. -------------------
+const bodyOnly = html.replace(/<script>[\s\S]*?<\/script>/g, '').replace(/<style>[\s\S]*?<\/style>/g, '');
+check('page holds no copy of the roadmap prose',
+	!/monthly rhythm|First Contact|Rivals & News|Per-tick/i.test(bodyOnly),
+	'found roadmap wording inline in the page');
+
+// --- No hardcoded game version anywhere in the page. ------------------------
+// A literal here would ship precisely when the version.json lookup failed.
+const versionLiteral = bodyOnly.match(/\bv?0\.\d+\.\d+\b/);
+check('page hardcodes no game version', !versionLiteral,
+	versionLiteral ? 'found ' + versionLiteral[0] : '');
+
+// --- Structure survived the parser. -----------------------------------------
+check('renders an h1', /<h1>Roadmap<\/h1>/.test(out));
+check('renders the month-by-month table', /<table>/.test(out));
+
+const rowCount = (out.match(/<tbody>([\s\S]*?)<\/tbody>/) || ['', ''])[1].split('<tr>').length - 1;
+const mdRows = md.split('\n').filter((l) => /^\|/.test(l)).length - 2; // minus header + separator
+check('every markdown table row rendered', rowCount === mdRows && rowCount > 0,
+	'rendered ' + rowCount + ' of ' + mdRows);
+
+check('no raw pipe characters leaked into prose', !/<p>[^<]*\|/.test(out));
+check('ordered list (the release ladder) rendered', /<ol>/.test(out));
+check('links rendered', /<a href="https:\/\/github\.com\/PipFoweraker\/pdoom1\/blob/.test(out));
+check('external links open safely', !/target="_blank"(?![^>]*rel="noopener")/.test(out));
+check('bold survived', /<strong>/.test(out));
+// A relative markdown link silently fails to linkify (the href guard rejects it),
+// which is how "[Website roadmap](website-roadmap.md)" once shipped as raw text.
+check('every markdown link linkified', !/\]\(/.test(out),
+	(out.match(/\[[^\]]*\]\([^)]*\)/) || [''])[0]);
+check('ASCII double-dash rendered as a dash', !/\s--\s/.test(out));
+
+// --- Escaping: the parser escapes before it inserts markup. -----------------
+const nasty = fakeModule.exports.render('<img src=x onerror=alert(1)>\n\n[ok](javascript:alert(1))');
+check('html in the source is escaped', !/<img/.test(nasty), nasty);
+check('javascript: links are not linkified', !/href="javascript:/.test(nasty), nasty);
+
+// --- The honesty property this whole page exists to protect. ----------------
+// Every future Theme row must be marked provisional or explicitly unnamed.
+const themeRows = md.split('\n').filter((l) => /^\|\s*\d+ \w+ 20\d\d/.test(l));
+check('there are future Theme rows to check', themeRows.length > 0);
+const unmarked = themeRows.filter((r) => !/provisional|not yet named/i.test(r));
+check('every future Theme is marked provisional or unnamed', unmarked.length === 0,
+	unmarked.join(' // '));
+
+// A forward row must not read as committed.
+check('no future row claims to be committed',
+	!themeRows.some((r) => /\bcommitted\b/i.test(r)));
+
+console.log('');
+if (failures) {
+	console.log(failures + ' check(s) failed.');
+	process.exit(1);
+}
+console.log('All roadmap render checks passed.');


### PR DESCRIPTION
Closes #164. **Do not merge yet** — Pip should review the copy and rule on two contradictions found along the way.

`pdoom1` re-cast its `ROADMAP.md` to the monthly-Theme model on 2026-07-25. This PR pulls that source and re-projects it audience-shaped. `pdoom1` remains the source of truth; every claim below traces to `pdoom1/docs/ROADMAP.md` or `pdoom1/docs/RELEASE_NOMENCLATURE.md` at `origin/main`.

> Note on sources: the local `D:/Local_Code/pdoom1` checkout was ~230 commits stale and still held the **old quarterly** ROADMAP. `RELEASE_NOMENCLATURE.md`, `ROADMAP_RECAST_PROPOSAL.html` and `docs/copy/README.md` did not exist locally at all. Everything here was read from `origin/main` after a fetch. The working tree was not disturbed.

## What was re-projected

| Retired | Replaced with |
|---|---|
| Quarterly table, version == theme, Q3 2026 through Q2 2027 | Monthly Theme spine: one named Theme a month, first Friday, minor bump, forking epoch |
| v0.12 "First Contact" and v0.13 "Rivals and News" as *versions* | First Contact and Rivals + News as the two **Big Milestones** — named arcs spanning several Themes, "complete when done, not date-locked" |
| "Private alpha (v0.11) — we are here. Friends-and-family **Windows** build" | Version literal removed; three builds ship now, so the Windows-only claim was false too |
| Nothing explained the fork | Players are told a Theme forks the leaderboard and starts a fresh epoch, and that a new seed lands every Friday on unchanged rules |

Also translated, not transcribed: internal handles (DQ-22, ADR-0016, "aggro midgame", ladder L2–L7) are dropped in favour of what the player sees. Ladder numbers are deliberately **not** published — see contradiction 2.

## Every place something is marked provisional

1. Section preamble: "Theme names beyond the shipped one are **provisional** … two of the six months are not named at all yet."
2. Table `How firm` column, per row — v0.14 and v0.15 "Grounded in design that already exists"; v0.16, v0.17, v0.18 "Direction to steer, not a commitment".
3. Theme names v0.14 "Per-tick & People", v0.16 "Sightings", v0.17 "The World Shoots Back" each carry an inline *(provisional name)*.
4. v0.15 and v0.18 render as *not yet named* rather than being given a name we would have had to invent.
5. Under the table: the firmness column is the game repo's own confidence note, "everything from October onward is expected to be reshaped by design workshops before it is built", and "the dates follow the first-Friday rule, so they move when a month moves".
6. Big Milestones: "targeting the end of Q3/Q4 2026", "Both are named arcs, not release dates."
7. Further-out list carries "Carried forward with no dates attached, deliberately".
8. Release ladder step 2: distribution channel "genuinely not decided … Anyone who tells you it is settled is ahead of the facts."

`scripts/test-roadmap-render.js` **enforces** items 1–4: it fails if any future Theme row loses its provisional/unnamed marker, or if a future row starts claiming to be committed. That is the honesty property most likely to be quietly edited away later.

## No hardcoded current version

`public/docs/roadmap.md` never states the shipped version. The rendered page derives it from `public/data/version.json` at runtime and, if that lookup fails, **shows nothing** rather than a fallback literal. The test asserts the HTML contains no `v0.x.y` literal. `check-stale-facts.py` findings: **174 before, 174 after** — zero added.

## Is the roadmap reachable by a visitor today?

**It was not, and now it half is.** DreamHost serves `.md` as a download (TECH_DEBT B8), so clicking "Roadmap" downloaded a file. This adds `public/docs/roadmap/` (`/docs/roadmap/`), which fetches `/docs/roadmap.md` and renders it — it holds **no copy** of the prose, so the two cannot drift, and the markdown stays the single pull artefact.

**Needs the navigation owner to finish the job.** I did not touch `navigation.js` or `public/includes/navigation.html`, as instructed:

- `public/assets/js/navigation.js:39` — Roadmap still points at `/docs/roadmap.md`. **Ask: repoint to `/docs/roadmap/`.** That closes TECH_DEBT B8 for this route.
- `public/index.html:874` — the homepage's own inline `<nav>` has the same `.md` link. Left alone because it sits inside the nav markup that agent is reworking. **Ask: repoint.**
- `public/includes/navigation.html:31` — same link, and that file hardcodes `v0.11.0`. Wired into zero pages, so harmless today, but it is a stale literal waiting to be adopted.
- `public/sitemap.xml` has no `/docs/roadmap/` entry; `scripts/generate-sitemap.js` is off-limits so it was not regenerated.

The **content** links I did repoint (not navigation): `public/index.html` roadmap section x3, `public/docs/index.html` x2.

## Contradictions found between the pdoom1 source and this site

**1. "Private alpha" vs three public download buttons.** `pdoom1/docs/ROADMAP.md` says *"Private alpha (friends and family, v0.13 — HERE)"* and puts public alpha ahead of us. The homepage hands anyone Windows, macOS and Linux downloads from a public GitHub release, with no friends-and-family framing anywhere. Writing "private alpha, we are here" would have contradicted the site's own front page. Resolved in copy the only honest way available — the alpha is described as free and downloadable today, with the *public* alpha beat characterised as **readiness, not availability** (onboarding, hardened leaderboard, chosen channel), which is what the source's "public alpha readiness" milestone and v0.15 "public-alpha hardening" row actually describe. **Pip should rule on whether the game repo's ladder wording is now behind reality.**

**2. Leaderboard board key disagrees across repos.** `RELEASE_NOMENCLATURE.md` (CANONICAL, 2026-07-25): "Board key = `(seed, ladder_version)`". This repo's `CLAUDE.md`, citing pdoom1 PR #679: "the board key is `(seed, game_version)`". Under the monthly model minor and ladder move together, so they agree *by coincidence* every month — until a mid-month fork or a patch-only month, when they do not. Per CLAUDE.md a key mismatch means scores land nowhere **with no error shown to the player**. Not touched here; the roadmap deliberately does not publish ladder numbers until this is settled. Worth a cross-repo issue.

**3. `check-platform-claims.py` is currently a no-op.** It skipped: *"version.json has no latest_release.platforms; nothing to check."* CLAUDE.md documents that field as the source of truth for platform honesty. The guard that exists precisely to stop us advertising unshipped platforms is not running. Out of scope, but it should not stay quiet.

**4. `check-stale-facts.py` does not scan `.md`.** `SCAN_GLOBS` covers `public/**/*.{html,json,js}` only. That is why `website-roadmap.md` could carry *"its current release is **v0.11.0**"* — false since v0.12 — indefinitely. Fixed by deleting the literal rather than updating it. The blind spot itself remains.

## Test suite

Passing: `test-design-notes.py` (26/26), `test-analytics-optout.js` (17/17), `validate_data.py` (0 fail 0 warn), `check-platform-claims.py` (skips, see above), `test-download-resolution.js`, `generate-feeds.py --check`, and the new `test-roadmap-render.js` (18/18).

Known-failing, unchanged by this PR: `test_ingest_scores.py`, `check-stale-facts.py` (174 to 174), `test-header-consistency.js` (does not scan the new page).

`snapshot-copy.py --check`: **16 pages changed to 16** (no new page joins the drifted set) and **19 added to 20** (the new `/docs/roadmap/`). Prose lines I touched, for review:

- `public/docs/index.html` — one line: "Development Roadmap **Website-only**" to "Development Roadmap **Projection of game repo**". It is pulled from pdoom1, not website-only. (This page was already drifted; the baseline said "Auto-synced", which was also wrong — the pull is agent-manual per `pdoom1/docs/copy/README.md`.)
- `public/docs/website-roadmap.md` — versioning note and cadence note. Not HTML, so invisible to the snapshot; listed here so it is reviewed anyway.
- `public/index.html` — **no prose change**, three `href` values only.

## Suggested follow-up (not done here)

Add `node scripts/test-roadmap-render.js` to the local suite list in `CLAUDE.md`. Not edited, since CLAUDE.md is yours to change.