### PR TITLE
fix(macos): our Gatekeeper instructions were deleted by Apple in Sequoia

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -910,11 +910,25 @@ t	.hero {
 			<!-- Shown by resolveDownloads() only when a macOS build actually resolved.
 			     An unsigned/un-notarised Godot .app is refused by Gatekeeper on first
 			     open with "the developer cannot be verified", which reads as a broken
-			     download; most testers bounce silently rather than report it. -->
+			     download; most testers bounce silently rather than report it.
+
+			     CORRECTED 2026-07-29. This note used to say "right-click and choose
+			     Open". Apple REMOVED that bypass in macOS Sequoia (15.x): on current
+			     macOS the context menu offers only Cancel / Move to Trash, so the old
+			     instruction failed in exactly the way it was written to prevent. It
+			     cost us a real playtest -- the first backer of the Manifund round
+			     followed it on 15.5, hit the dead end, and gave up. Verify against
+			     Apple's developer note before editing again; do not restore the
+			     Control-click wording as the primary path.
+			     The real fix is notarisation (Apple Developer Program), which is a
+			     budget line, not a copy change. -->
 			<p id="macos-gatekeeper-note" style="display: none; text-align: center; margin: 0 auto 0.6rem; max-width: 46rem; font-size: 0.8rem; color: var(--text-secondary); line-height: 1.5;">
 				<strong>On macOS:</strong> the first launch is blocked because the build isn't
-				Apple-notarised yet. Right-click (or Control-click) the app and choose
-				<strong>Open</strong>, then confirm — you only need to do this once.
+				Apple-notarised yet. On macOS&nbsp;15 (Sequoia) and later, open
+				<strong>System&nbsp;Settings → Privacy&nbsp;&amp;&nbsp;Security</strong>, scroll to
+				<strong>Security</strong>, and choose <strong>Open&nbsp;Anyway</strong> — you may need your
+				admin password. On macOS&nbsp;14 and earlier, right-click (or Control-click) the app
+				and choose <strong>Open</strong>. Either way you only need to do it once.
 			</p>
 
 			<div style="text-align: center; margin-bottom: 0.8rem;">


### PR DESCRIPTION
**A visitor-facing instruction that does not work on current macOS, found the hard way.**

## What happened
The homepage told macOS users to *"right-click (or Control-click) the app and choose **Open**, then confirm."*

Apple **removed that bypass in macOS Sequoia (15.x)**. On current macOS the context menu offers only **Cancel / Move to Trash**.

Today the first backer of the Manifund funding round followed that instruction on macOS 15.5, hit the dead end, and gave up — publicly:

> "I wasn't actually able to demo the game myself -- I'm on Mac, Sequoia 15.5, and 'right click => open' only gave me 'cancel' and 'move to trash' as options... it was enough of a roadblock for me to give up."

He backed the project **without being able to play it.** The note existed specifically to stop testers bouncing silently, and instead it caused the bounce.

## The fix
Both paths, correctly ordered:
- **macOS 15 (Sequoia) and later** — System Settings → Privacy & Security → Security → **Open Anyway** (admin password may be required)
- **macOS 14 and earlier** — right-click / Control-click → **Open**

First launch only, either way.

A comment above the block records why, so the old wording is not restored by someone who remembers the pre-Sequoia flow.

## What this does NOT fix
**Notarisation.** The correct fix is signing + notarising the build via the Apple Developer Program — a budget line, not a copy change. Until then every macOS visitor hits a scary dialog, and an unknown number bounce without telling us. Worth tracking as tech debt and as a funded line item.

Also worth considering, from the same feedback: a **Godot web export** would remove the download barrier entirely — which is the exact barrier that just stopped a funder from playing.

## Verification
```
check-platform-claims.py     PASS
test-download-resolution.js  PASS
check-stale-facts.py         unchanged from baseline
```
Reader-facing prose changed on one page; justified as "this was false, now it is true" per the copy-baseline rule. Pip reviews.