### PR TITLE
docs(league): cycle handbook + drafted L3 blessing (roll ruled)

### DIFF
--- a/docs/LEAGUE_CYCLE_HANDBOOK.md
+++ b/docs/LEAGUE_CYCLE_HANDBOOK.md
@@ -1,0 +1,174 @@
+# League cycle handbook
+
+**Read this instead of asking.** Written 2026-07-31 because the same three
+questions kept needing re-explaining: what a board key is, when to *bless* versus
+*roll* a seed, and where the website fits in the game's gate ceremony.
+
+This is the *why*. For the record of which seed governs which epoch, see
+[`LEAGUE_SEED_LEDGER.md`](LEAGUE_SEED_LEDGER.md). For the mechanics of publishing,
+see [`SURFACE_REGISTER.md`](SURFACE_REGISTER.md) §2.
+
+---
+
+## 1. The board key, in one page
+
+A **board** is one leaderboard table. Every score the game submits carries a key
+saying which table it belongs on. The key has two halves:
+
+```
+(seed, ladder_epoch)
+ │      └── which RULES the score was earned under.  "L3".  Ticks when rules change.
+ └───────── which SCENARIO everyone is competing on. "weekly-2026-w31".
+```
+
+**Two scores are comparable only if both halves match.** Same puzzle, same rules.
+That is the whole idea.
+
+**The build version is NOT part of the key.** `v0.13.2` is not `L3`. A cosmetic
+patch must never fork a board — that was the entire point of the build-vs-ladder
+split. One board legitimately spans several builds, and seeing
+`builds_seen: ["v0.13.1", "v0.13.2"]` on a single board is the split working, not
+a bug.
+
+**Why this matters more than it sounds.** The score API returns `ok: true` with an
+empty list for a board that has never existed. There is no validation and no
+error. So a wrong key is **indistinguishable from nobody playing** — from the
+player's side *and* from ours. That is not hypothetical: 27 real submissions from
+6 players were stranded exactly this way, and nobody noticed for a week. They are
+now in the permanent anomaly archive and must never be re-stamped.
+
+---
+
+## 2. Bless vs roll — the decision that keeps coming up
+
+Both words are about the **seed** half of the key. Neither touches the epoch.
+
+| | **Bless in place** | **Roll** |
+|---|---|---|
+| What happens | Keep the seed the client already sends; record it as canonical | Change the client's seed const, then bless the new one |
+| Board opens | With whatever is already on it | Empty |
+| Cost | None — no re-cut | A re-cut, and a const change |
+| Use when | The existing board's contents are legitimate competition | Something on the board should not be in the competition |
+
+### The rule that decides it
+
+**Ask one question: is everything currently on that board something you are happy
+for players to compete against?**
+
+- **Yes → bless in place.** Cheaper, no re-cut, no risk.
+- **No → roll.**
+
+There is no third option, because **the website does not filter a live board.**
+Removing entries is editing standings, and a board that can be edited is no longer
+a record of what happened. If something must not be on the opening board, the
+league has to open on a *different key*.
+
+And since the epoch only moves when the *rules* change, the only half that can
+move for this purpose is the seed. **"Get those runs off the board" and "roll the
+seed" are the same sentence.**
+
+### Worked example — 2026-07-31
+
+The Gate 4 proving runs (three of Pip's own, Thursday morning) were sitting on
+`(weekly-2026-w30, L3)`. Pip ruled they should not open the league. The rules had
+not changed again, so `L3` stays. Therefore: roll the seed to `weekly-2026-w31`,
+bless that, open empty.
+
+### The trap in rolling
+
+The ledger's discipline is *bless what the client actually sends, verified*. But
+after a roll you **cannot verify by submitting a score** — that puts a run on the
+opening board, which is the thing you just ruled out.
+
+**Verify from the built artifact instead**: read the seed const out of the zip.
+That is the source of truth for what the client will send, needs no submission,
+and is stronger evidence than a round trip anyway.
+
+**Never verify by "the GET returned ok:true".** Every wrong key returns that too.
+
+### After the freeze, a const change is a re-cut
+
+Changing the seed after [Gate 2: THE FREEZE] means a re-cut, not a patch. A seed
+const is not gameplay-shaped, so the Commissioner may rule the full Gate 4
+sequence is not needed — but **record that ruling**. A silent exception is how the
+rule dies.
+
+---
+
+## 3. Where the website sits in the gate rail
+
+pdoom1 runs release weeks on six named gates. The website appears in exactly one
+of them, and it is worth knowing which.
+
+| Gate | Website involvement |
+|---|---|
+| 1 LAST POUR | none |
+| 2 THE FREEZE | none |
+| 3 PACK BLESSED | none |
+| 4 PROVEN BUILD | none |
+| **5 SEED BLESSING** | **"board-key fork verified clean" — the one gate line that spans both repos** |
+| 6 BOARD OPENS | display points at the live board |
+
+Gate 5 cannot be honestly spoken from the game side alone. The playbook's rule is
+*"saying a line you have not verified is the cardinal sin of the ceremony"*, so a
+website-side unknown is enough to fail it.
+
+**What the website has to be able to say at Gate 5:**
+
+1. The API accepts the epoch key. *(Proven by observation 2026-07-30 — real rows
+   exist on an `L3` key the API auto-created. Does not need re-proving unless the
+   epoch changes.)*
+2. The site publishes whatever board the client posts to. *(Structural — see §4.)*
+3. Earlier epochs stay preserved and read-only, never merged forward.
+
+---
+
+## 4. Why the website needs no code change on ceremony day
+
+`scripts/publish-live-board.py` **observes** the board key rather than being told
+it. It reuses the liveness probe's derivation, finds whichever board on the
+current epoch has the most recent activity, and publishes that.
+
+So: draw the seed, the client posts to it, the next probe publishes it. **No edit,
+no deploy race against the release.**
+
+This is deliberate and worth protecting. The failure it prevents is a
+website-derived seed that no client ever sends — which is exactly what happened
+before (`weekly_2026_W31_f148a5b6`, a hash the site invented and published while
+players posted somewhere else entirely).
+
+**Corollary: never hardcode a seed anywhere in `scripts/` or `public/data/`.**
+`test-weekly-league-boundary.py` fails if you do, and it gates the unattended
+rollover.
+
+---
+
+## 5. The one thing that is still a human channel
+
+The **current ladder epoch** reaches this repo by a person reading a GitHub
+comment and typing a value into `public/leaderboard/data/board-probe-targets.json`.
+pdoom1 publishes no machine-readable epoch artifact yet.
+
+Nothing in CI can notice pdoom1 forking L3 → L4. A wrong epoch returns `ok:true`
+with an empty board, so the site would keep reporting "live" against a board that
+had gone quiet.
+
+**So: at every epoch fork, update that file.** It carries a `supersede_when` field
+naming the artifact that would retire the human step. Standing ask on PR #190.
+
+---
+
+## 6. Quick reference
+
+**A board is empty on opening night.** Correct, not a fault, when the seed rolled.
+
+**Scores from before a fork do not migrate.** Different rules produced them.
+Merging them is the specific lie the ladder split exists to prevent.
+
+**The anomaly archive is immutable.** `public/leaderboard/data/preserved/`. Never
+edit, never re-stamp. It is the only surviving copy — the boards it was captured
+from have since been rewritten.
+
+**If the board looks wrong, suspect the key before suspecting the players.**
+`python scripts/check-board-liveness.py` prints every board it can find and
+whether each is DEPLOYED, archived, or a NEW ORPHAN.

--- a/docs/LEAGUE_SEED_LEDGER.md
+++ b/docs/LEAGUE_SEED_LEDGER.md
@@ -45,15 +45,68 @@ What is already known and sourced (pdoom1 on #151, 2026-07-28T23:13Z):
 - The read path is confirmed clear: `GET ?seed=…&version=L3` returns
   `ok:true` with an empty board — **and so does every wrong key**, including
   `version=L99` and `version=NOTAVERSION`. The API has no validation, so a typo
-  produces a valid-looking empty board rather than an error. Proving the key on
-  Friday needs a **positive** check (post a score, read it back), not an absence
-  of errors. POST auto-creation is **not** verified — only the read path was
-  tested, deliberately, to avoid polluting a production board.
+  produces a valid-looking empty board rather than an error. Proving the key
+  needs a **positive** check, not an absence of errors.
+- **UPDATE 2026-07-31 — the positive check now exists, and it passed.** The
+  board `(weekly-2026-w30, L3)` holds **3 real entries** posted by the shipped
+  client on 2026-07-30 (08:32, 09:10, 09:36 AEST), spanning builds `v0.13.1` and
+  `v0.13.2`. So **POST auto-creation on an `L3` key is verified by observation,
+  not inferred**: the API accepted a key that had never existed and stored real
+  rows under it. Item 1 of pdoom1-website#151 — *"the one item that would
+  actually break Friday"* — is **closed**. What remains unverified is only which
+  seed string the shipped client sends; see the roll decision below.
+
+### Roll, not bless-in-place — ruled 2026-07-31
+
+**Decision (Pip, 2026-07-31 morning): the league opens on a NEW seed, and the
+Gate 4 proving runs do not carry over.**
+
+Why this follows rather than being a preference: the board
+`(weekly-2026-w30, L3)` already holds three runs — the Thursday proving runs that
+passed [Gate 4: PROVEN BUILD]. Pip ruled those should not be on the opening
+board. **The website does not filter a live board** — removing entries is editing
+standings, and a board that can be edited is no longer a record of what happened.
+So the only honest way to exclude them is for the league to open on a *different
+board key*.
+
+The epoch half cannot move: the rules have not changed again, so it stays `L3`.
+**The only half that can move is the seed.** Hence the roll.
+
+Consequence to accept knowingly: **the board opens empty** and stays empty until
+the first real player finishes a run. That is correct, not a fault. The
+leaderboard says so honestly rather than showing a live-looking empty table.
+
+**The verification wrinkle.** This ledger's discipline is *bless what the client
+actually sends, verified*. But the new seed **must not** be verified by
+submitting a score — that would put a run on the opening board, which is the
+thing being ruled out. So:
+
+- **Verify from the artifact**: read the seed const out of the built v0.13.2 zip.
+  That is the source of truth for what the client will send, needs no submission,
+  and is stronger evidence than a round trip.
+- **Do not** verify by POST. **Do not** verify by GET-returns-`ok:true` — every
+  wrong key does that too.
+- The API's acceptance of an `L3` key is already proven (above) and does not need
+  re-proving.
+
+**Re-cut, not patch.** Changing the seed const after [Gate 2: THE FREEZE] means a
+re-cut by the standing rule. A seed const is not gameplay-shaped, so the
+Commissioner may rule that the full [Gate 4] sequence is not required — but that
+must be an **explicit ruling recorded here**, not a silent exception. "We patched
+instead of re-cutting, just this once" is how the rule dies.
+
+**Website work required: none.** `publish-live-board.py` observes whichever board
+the client posts to and publishes that. No code change, no deploy race.
 
 **Checklist for whoever blesses it (a human, on the day):**
 
 - [ ] Copy the confirmed seed string from pdoom1's #151 comment — not from any
-      website-derived value, and not from this document.
+      website-derived value, and not from this document. **The probable value is
+      `weekly-2026-w31`; treat that as UNCONFIRMED until the ceremony.**
+- [ ] **Roll-specific:** confirm the seed const in the *built artifact* matches
+      the string being blessed. Artifact beats intention.
+- [ ] **Roll-specific:** record the Commissioner's ruling on whether the re-cut
+      re-ran [Gate 4], and if not, why not.
 - [ ] Fill the L3 row above: seed, board file, blessed date, by.
 - [ ] Set `regularised_from.seed` in `public/data/ladder-epochs.json` and change
       `seed_status` to `blessed`. That is the *only* place a script reads it;
@@ -78,6 +131,7 @@ history, not a tidy final answer.
 |---|---|---|---|---|
 | 1 | 2026-07-24 ~08:00 | `league_2026-07_7d6ced29` | *waves doom staff* | **Superseded.** Blessed in good faith, but conflicted with the already-shipped client key. Corrected same day. |
 | 2 | 2026-07-25 ~09:20 | `weekly-2026-w30` | *waves doom staff* | **Canonical.** Matches the shipped v0.13 client. This is the seed the L2 board uses. |
+| 3 | 2026-07-31 ~16:45 | ⏳ *to be drawn* | *waves doom staff* | **PENDING.** Roll ruled 2026-07-31 so the Gate 4 proving runs do not open the board. Fill from pdoom1's confirmed string, not from memory. |
 
 ## Correction note (2026-07-24)
 


### PR DESCRIPTION
Two things Pip asked for this morning.

**`docs/LEAGUE_CYCLE_HANDBOOK.md`** — the *why*, written to be read cold next week without asking. Covers the board key in one page, bless vs roll, where the website sits in the six-gate rail, and why ceremony day needs no code change from us.

The bless-vs-roll rule reduces to **one question**: *is everything currently on that board something you are happy for players to compete against?* Yes → bless in place. No → roll. There is no third option, because **the website does not filter a live board** — removing entries is editing standings.

**`docs/LEAGUE_SEED_LEDGER.md`** — staged the L3 row and blessings-log entry for the ceremony to complete. Deliberately **not** pre-filled: the ledger's own rule is *do not fill this in from memory*, and this repo blessed a wrong value once already. Added the roll ruling, the verification wrinkle (verify from the built artifact, never by POST, never by `ok:true`), and two roll-specific checklist items.

Also corrected a claim that had gone stale: the ledger said POST auto-creation on `L3` was **not** verified. It is — three real client-posted rows exist on `(weekly-2026-w30, L3)`. **Item 1 of #151, the one called "the only thing that would actually break Friday", is closed.**

Docs only. `test-weekly-league-boundary.py` still passes — the probable seed appears only in `docs/`, which its no-hardcoded-seed guard correctly does not scan.