### PR TITLE
fix(dashboard): a missing WebGL context could kill the entire page

### DIFF
--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -1085,34 +1085,66 @@ function compileShader(source, type) {
   const shader = gl.createShader(type);
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
+  // A shader that fails to compile used to fail SILENTLY to a black canvas.
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.warn('[dashboard] shader did not compile:', gl.getShaderInfoLog(shader));
+    return null;
+  }
   return shader;
 }
 
-const vs = compileShader(vsSource, gl.VERTEX_SHADER);
-const fs = compileShader(fsSource, gl.FRAGMENT_SHADER);
-const program = gl.createProgram();
-gl.attachShader(program, vs);
-gl.attachShader(program, fs);
-gl.linkProgram(program);
-gl.useProgram(program);
-
-const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
-const buffer = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
-
-const posLoc = gl.getAttribLocation(program, 'pos');
-gl.enableVertexAttribArray(posLoc);
-gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
-
-const resolutionLoc = gl.getUniformLocation(program, 'resolution');
-const timeLoc = gl.getUniformLocation(program, 'time');
-const pdoomLevelLoc = gl.getUniformLocation(program, 'pdoomLevel');
-
+// GUARD: everything below is BACKGROUND DECORATION, and it used to be able to kill the
+// whole page. `gl` is null whenever WebGL is unavailable -- a phone with it disabled,
+// iOS Safari shedding contexts under memory pressure, a locked-down browser, a headless
+// checker. `gl.createProgram()` on null throws a TypeError, and because the sliders, the
+// Plotly chart, the Manifold fetch and the clock all live in this SAME inline <script>,
+// that exception aborted every one of them. The visible result was not "no background"
+// but a dead page: frozen sliders, empty chart, "Loading markets..." forever.
+//
+// Decoration must never be able to take the content with it. If WebGL is missing we skip
+// the shader entirely and the page runs; the canvas simply stays the CSS background.
+// These two stay OUTSIDE the guard: currentPdoomLevel is assigned by updateAll() further
+// down, so it must exist whether or not the shader initialised.
 let startTime = Date.now();
 let currentPdoomLevel = 0.121;
 
+let shaderReady = false;
+let resolutionLoc = null, timeLoc = null, pdoomLevelLoc = null;
+
+if (gl) {
+  const vs = compileShader(vsSource, gl.VERTEX_SHADER);
+  const fs = compileShader(fsSource, gl.FRAGMENT_SHADER);
+  if (vs && fs) {
+    const program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.useProgram(program);
+
+      const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+      const buffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+      const posLoc = gl.getAttribLocation(program, 'pos');
+      gl.enableVertexAttribArray(posLoc);
+      gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+
+      resolutionLoc = gl.getUniformLocation(program, 'resolution');
+      timeLoc = gl.getUniformLocation(program, 'time');
+      pdoomLevelLoc = gl.getUniformLocation(program, 'pdoomLevel');
+      shaderReady = true;
+    } else {
+      console.warn('[dashboard] shader program did not link:', gl.getProgramInfoLog(program));
+    }
+  }
+} else {
+  console.info('[dashboard] WebGL unavailable — background shader skipped. Page is fine.');
+}
+
 function animateShader() {
+  if (!shaderReady) { return; }
   const time = (Date.now() - startTime) * 0.001;
   gl.uniform2f(resolutionLoc, shaderCanvas.width, shaderCanvas.height);
   gl.uniform1f(timeLoc, time);
@@ -1120,7 +1152,7 @@ function animateShader() {
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
   requestAnimationFrame(animateShader);
 }
-animateShader();
+if (shaderReady) { animateShader(); }
 
 /* ========== Data & Functions ========== */
 function pdoomFunc(year) {


### PR DESCRIPTION
**Reproduced, not inferred.** With `getContext('webgl')` returning null:

```
BEFORE: TypeError: Cannot read properties of null (reading 'VERTEX_SHADER')
AFTER:  [dashboard] WebGL unavailable — background shader skipped. Page is fine.
```

The shader is **background decoration**, but the sliders, the Plotly chart, the Manifold fetch and the clock all live in the **same inline `<script>`**. So that TypeError aborted every one of them. The visible result wasn't "no background" — it was a **dead page**: frozen sliders, empty chart, "Loading markets…" forever, blank timestamp.

`gl` is null whenever WebGL is unavailable: a phone with it disabled, iOS Safari shedding contexts under memory pressure, a locked-down or enterprise browser, a headless checker. `resizeShader()` already had an `if(gl)` guard — the author knew — but the rest of the block never got the same treatment.

Also closed two silent failures on the way through: `compileShader` never checked `COMPILE_STATUS`, and `linkProgram` was never checked for `LINK_STATUS`, so a shader that failed to build failed silently to a black canvas with no console trace.

> Decoration must never be able to take the content with it.

Found by the Risk Dashboard audit. Syntax-checked with `node --check`; both the WebGL and no-WebGL paths exercised against a stubbed DOM.