### PR TITLE
fix(league): stop a test fixture being able to abort the rollover

### DIFF
--- a/scripts/test-publish-live-board.py
+++ b/scripts/test-publish-live-board.py
@@ -187,22 +187,22 @@ with Sandbox(boards={}):
 print("\n4. Cross-epoch: a BUSIER old-epoch board must never be published")
 with Sandbox(epoch="L3", boards={
         ("weekly-2026-w30", "L2"): {"rows": ROWS * 50, "last_entry": "2026-07-29T23:59:59"},
-        ("weekly-2026-w31", "L3"): {"rows": ROWS * 2, "last_entry": "2026-07-30T10:00:00"}}):
+        ("weekly-fixture-later", "L3"): {"rows": ROWS * 2, "last_entry": "2026-07-30T10:00:00"}}):
     code, _ = run()
     d = board_on_disk()
     check(code == 0, "publishes the current-epoch board")
     check(d["meta"]["board_key"]["ladder_epoch"] == "L3", "published epoch is L3")
-    check(d["meta"]["board_key"]["seed"] == "weekly-2026-w31",
+    check(d["meta"]["board_key"]["seed"] == "weekly-fixture-later",
           "chose the L3 board, NOT the 50-entry L2 one -- epochs are never merged")
     check(len(d["entries"]) == 2, f"published 2 entries, not 50 (got {len(d['entries'])})")
 
 print("\n5. Several live boards on the epoch -> most recently active wins")
 with Sandbox(epoch="L3", boards={
         ("weekly-2026-w30", "L3"): {"rows": ROWS * 9, "last_entry": "2026-07-30T08:00:00"},
-        ("weekly-2026-w31", "L3"): {"rows": ROWS * 1, "last_entry": "2026-07-30T11:00:00"}}):
+        ("weekly-fixture-later", "L3"): {"rows": ROWS * 1, "last_entry": "2026-07-30T11:00:00"}}):
     code, _ = run()
     d = board_on_disk()
-    check(d["seed"] == "weekly-2026-w31",
+    check(d["seed"] == "weekly-fixture-later",
           "recency beats volume -- a fresh league board outranks a busy stale one")
 
 print("\n6. Happy path -> both artifacts, honest metadata, no invented fields")

--- a/scripts/test-weekly-league-boundary.py
+++ b/scripts/test-weekly-league-boundary.py
@@ -381,6 +381,19 @@ for _p in list((Path(__file__).parent).glob("*.py")) + \
         list((Path(__file__).parent.parent / "public" / "data").glob("*.json")):
     if _p.name == Path(__file__).name:
         continue
+    # Test files are exempt, and the reason matters. What this rule protects against is a
+    # PRODUCTION surface pinning a seed the ceremony has not blessed -- a script that
+    # writes data, or published JSON a visitor can fetch. A fixture inside a test is
+    # neither: it never reaches a board and never reaches a reader.
+    #
+    # Without this exemption the rule is actively dangerous, because this test is the
+    # FIRST STEP of weekly-league-reset.yml and gates the unattended Friday rollover. On
+    # 2026-07-31 a sibling test's fixture tripped it and turned main red; had it landed a
+    # few hours earlier it would have aborted a live rollover over a string in a test.
+    # A guard that can stop the league to complain about test data is worse than the leak
+    # it is preventing.
+    if _p.name.startswith(("test-", "test_")):
+        continue
     try:
         if _probable in _p.read_text(encoding="utf-8"):
             _leaks.append(_p.name)


### PR DESCRIPTION
`main` was red, and **this one had teeth.**

`test-weekly-league-boundary.py` is the **first step of `weekly-league-reset.yml`** and gates the unattended Friday rollover. Its no-hardcoded-seed rule globs every `scripts/*.py` — so a *sibling test's fixture* could halt the league to complain about a string in a test.

The coverage audit predicted this exact failure before it happened. I then merged #207 with the live candidate seed in its fixture and walked straight into it.

**Fixed both ends:**

1. **The fixture never needed the real seed** — it only needed a second, later-sorting key. Now `weekly-fixture-later`, unmistakably synthetic. Using the live candidate was careless; the ledger rules nothing may pin it before the ceremony.
2. **The guard now exempts `test-*`/`test_*`**, with the reasoning recorded. What the rule protects against is a *production* surface pinning an unblessed seed — a script that writes data, or published JSON a visitor can fetch. A fixture is neither. **A guard that can halt the league over test data is worse than the leak it prevents.**

**Verified both directions:** 93/93 with the fixture renamed, and a planted non-test file still trips it.