### PR TITLE
content(blog): DRAFT anniversary + patch-week posts — HOLD, copy revision pending

### DIFF
--- a/public/blog/2026-07-28-this-post-has-a-shelf-life.md
+++ b/public/blog/2026-07-28-this-post-has-a-shelf-life.md
@@ -1,0 +1,25 @@
+---
+title: "This post has a shelf life"
+date: "2026-07-28"
+tags: ["process", "honesty", "dev-notes"]
+summary: "This week's development cadence, reported as a dated decision (2026-07-27) rather than a forward promise - and where to check for yourself whether it held."
+commit: ""
+---
+# This post has a shelf life
+
+**Date**: 2026-07-28
+**Tags**: [process, honesty, dev-notes]
+
+Statements about what a developer is *going to do* decay in a specific and unhelpful way: the promise outlives the practice. The sentence sits on the page reading as present-tense long after it has stopped being true, and the reader has no way to date it. Nobody lies on purpose; the page just stops being checked.
+
+So, a dated observation rather than a commitment.
+
+**On Monday 2026-07-27, a cadence ruling was recorded** in the build-day log: keep adding mechanics and accept that balance breaks while they land — the log's own words are "game can break 10 times today" — patch daily through the week, hold speed until about Wednesday, then cleanup, hotpatch and playtest on Thursday, so Friday's commitments land.
+
+That is what was decided, on that day. Everything after it is the future, and the future is not something a blog post gets to assert.
+
+The falsification test is public. If the cadence held, the [commit history](https://github.com/PipFoweraker/pdoom1/commits/main) shows it; if it stopped on Tuesday, the commit history shows that instead, and this post will still say exactly what it says. The [changelog](https://github.com/PipFoweraker/pdoom1/blob/main/CHANGELOG.md) is the slower, tidier version of the same check.
+
+More relevant if you actually play: as of this post's date, the newest tagged release is v0.13.1. Work merged this week is not in any build you can download until a new tag says it is.
+
+If something breaks this week, it was priced in. If nothing gets patched, the links above will show that too.

--- a/public/blog/2026-07-30-issue-1-turns-one.md
+++ b/public/blog/2026-07-30-issue-1-turns-one.md
@@ -1,0 +1,54 @@
+---
+title: "Issue #1 turns one"
+date: "2026-07-30"
+tags: ["anniversary", "milestone", "process", "dev-notes"]
+summary: "The first issue ever filed on p(Doom)1 - 'Text overflows UI elements on several screens', 2025-07-30 - turns one. A year measured in the bug tracker rather than the trophy cabinet, ending with an audit of every promise the game's code makes."
+commit: ""
+---
+# Issue #1 turns one
+
+**Date**: 2026-07-30
+**Tags**: [anniversary, milestone, process, dev-notes]
+
+A year ago today — 2025-07-30, 12:09 UTC — the first issue was opened on the p(Doom)1 repository. In full:
+
+> Text overflows UI elements on several screens
+
+That is the founding document of a game about how civilisation might end. Not a design manifesto. Not a threat model. A label too long for its box.
+
+Anniversaries invite a list of achievements. This one gets a different measure: what the bug tracker was about at the start, and what it turned out to be about all along.
+
+## The sentence
+
+On Monday, at an AI-safety coworking session, the game got its first introduction to an actual room of people. Reconstructed verbatim afterwards:
+
+> Pdoom1 is a novel bureaucracy simulator that tries to back-trace how I get to my own personal pdoom answer and invokes time travel to make this semi-coherent.
+
+Own read on the delivery: "surprisingly confident." Which is about the honest register a year in — still slightly surprised the thing can be said in one sentence at all.
+
+## Issue #1, one abstraction layer down
+
+Also on Monday, an audit ran across the game's own code hunting for one specific thing: places where the game tells the player something happened and nothing actually happens. Roughly 140 such promises were traced from message to delivery path. Findings:
+
+- Every event message announcing a doom change fed a value the next tick overwrote. Announcements with nothing behind them.
+- Six purchasable upgrades charged real in-game money for effects with zero implementing code.
+- One action's "+political pressure" write was overwritten every tick *and* read by nothing anywhere. Doubly dead.
+- Two core actions — publishing a paper, doing safety research — were reading balance keys that did not exist and silently falling back to `0.0`. A working UI over zero-priced no-ops.
+
+That is issue #1 again, one layer down. Text overflowing its element is an interface failing to fit its own contents; you can see it, so somebody files it. A message announcing a doom change that reaches nothing is an interface failing to be *about* its contents. You cannot see that one at all. You find it by taking every promise the software makes and asking, one at a time, whether anything is on the other end.
+
+A bureaucracy simulator whose internals were quietly full of unfired promises is either the worst possible outcome or extremely on-theme, and no ruling has been made on which.
+
+## What this post is not
+
+The fixes are on `main`. Whether they are in anything you can download depends on when you are reading this: at the time of writing, the newest tagged release was v0.13.1, and Monday's work rides the next version bump. The [releases page](https://github.com/PipFoweraker/pdoom1/releases) knows; a blog post written in advance does not. If your build predates the next tag, you are playing the code as it stood before the audit — which, given the subject of this post, at least has documentary value.
+
+## Year two
+
+Asked — laughing — whether there was any appetite for being interviewed about any of this:
+
+> I'm going to try and deflect questions to lesswrong posts through the CoD death screen -- 'you died to an interpretability failure, allowing X model to escape containment, and it wasn't caught before it launched a pre-emptive HypnoDrone strike. ALL HAIL HYPNODRONE. go argue on this comment thread ->'
+
+That feature does not exist. It is a parking-lot note, filed Monday between other parking-lot notes. It is quoted here because it is the most accurate available description of the register the game is aiming at: authority deflected to a comment thread, catastrophe with a brand name, and the interface still telling you exactly what killed you.
+
+Year two opens with the tracker in roughly the condition year one opened in: full of things that do not fit. The difference is knowing which of them were lying. [Issue #1](https://github.com/PipFoweraker/pdoom1/issues/1) remains open to visitors, as does [the rest of the tracker](https://github.com/PipFoweraker/pdoom1/issues) — argue there, not here.

--- a/public/blog/atom.xml
+++ b/public/blog/atom.xml
@@ -4,8 +4,29 @@
   <link href="https://pdoom1.com/blog/" />
   <link href="https://pdoom1.com/blog/atom.xml" rel="self" />
   <id>urn:pdoom1:blog</id>
-  <updated>2026-07-15T12:00:00Z</updated>
+  <updated>2026-07-30T12:00:00Z</updated>
   <subtitle>Development notes from p(Doom)1 - a satirical strategy game about managing an AI safety lab.</subtitle>
+  <entry>
+    <title>Issue #1 turns one</title>
+    <link href="https://pdoom1.com/blog/post.html?p=2026-07-30-issue-1-turns-one.md" />
+    <id>urn:pdoom1:blog:2026-07-30-issue-1-turns-one.md</id>
+    <updated>2026-07-30T12:00:00Z</updated>
+    <summary>The first issue ever filed on p(Doom)1 - 'Text overflows UI elements on several screens', 2025-07-30 - turns one. A year measured in the bug tracker rather than the trophy cabinet, ending with an audit of every promise the game's code makes.</summary>
+    <category term="anniversary" />
+    <category term="milestone" />
+    <category term="process" />
+    <category term="dev-notes" />
+  </entry>
+  <entry>
+    <title>This post has a shelf life</title>
+    <link href="https://pdoom1.com/blog/post.html?p=2026-07-28-this-post-has-a-shelf-life.md" />
+    <id>urn:pdoom1:blog:2026-07-28-this-post-has-a-shelf-life.md</id>
+    <updated>2026-07-28T12:00:00Z</updated>
+    <summary>This week's development cadence, reported as a dated decision (2026-07-27) rather than a forward promise - and where to check for yourself whether it held.</summary>
+    <category term="process" />
+    <category term="honesty" />
+    <category term="dev-notes" />
+  </entry>
   <entry>
     <title>Where the site stands, before the refresh</title>
     <link href="https://pdoom1.com/blog/post.html?p=2026-07-15-ui-before-snapshot.md" />

--- a/public/blog/feed.xml
+++ b/public/blog/feed.xml
@@ -5,8 +5,29 @@
     <link>https://pdoom1.com/blog/</link>
     <description>Development notes from p(Doom)1 - a satirical strategy game about managing an AI safety lab.</description>
     <language>en-AU</language>
-    <lastBuildDate>Wed, 15 Jul 2026 12:00:00 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 30 Jul 2026 12:00:00 +0000</lastBuildDate>
     <atom:link href="https://pdoom1.com/blog/feed.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Issue #1 turns one</title>
+      <link>https://pdoom1.com/blog/post.html?p=2026-07-30-issue-1-turns-one.md</link>
+      <guid isPermaLink="false">pdoom1-blog-2026-07-30-issue-1-turns-one.md</guid>
+      <pubDate>Thu, 30 Jul 2026 12:00:00 +0000</pubDate>
+      <description>The first issue ever filed on p(Doom)1 - 'Text overflows UI elements on several screens', 2025-07-30 - turns one. A year measured in the bug tracker rather than the trophy cabinet, ending with an audit of every promise the game's code makes.</description>
+      <category>anniversary</category>
+      <category>milestone</category>
+      <category>process</category>
+      <category>dev-notes</category>
+    </item>
+    <item>
+      <title>This post has a shelf life</title>
+      <link>https://pdoom1.com/blog/post.html?p=2026-07-28-this-post-has-a-shelf-life.md</link>
+      <guid isPermaLink="false">pdoom1-blog-2026-07-28-this-post-has-a-shelf-life.md</guid>
+      <pubDate>Tue, 28 Jul 2026 12:00:00 +0000</pubDate>
+      <description>This week's development cadence, reported as a dated decision (2026-07-27) rather than a forward promise - and where to check for yourself whether it held.</description>
+      <category>process</category>
+      <category>honesty</category>
+      <category>dev-notes</category>
+    </item>
     <item>
       <title>Where the site stands, before the refresh</title>
       <link>https://pdoom1.com/blog/post.html?p=2026-07-15-ui-before-snapshot.md</link>

--- a/public/blog/index.json
+++ b/public/blog/index.json
@@ -1,6 +1,33 @@
 {
   "posts": [
     {
+      "filename": "2026-07-30-issue-1-turns-one.md",
+      "title": "Issue #1 turns one",
+      "date": "2026-07-30",
+      "tags": [
+        "anniversary",
+        "milestone",
+        "process",
+        "dev-notes"
+      ],
+      "summary": "The first issue ever filed on p(Doom)1 - 'Text overflows UI elements on several screens', 2025-07-30 - turns one. A year measured in the bug tracker rather than the trophy cabinet, ending with an audit of every promise the game's code makes.",
+      "commit": "",
+      "featured": false
+    },
+    {
+      "filename": "2026-07-28-this-post-has-a-shelf-life.md",
+      "title": "This post has a shelf life",
+      "date": "2026-07-28",
+      "tags": [
+        "process",
+        "honesty",
+        "dev-notes"
+      ],
+      "summary": "This week's development cadence, reported as a dated decision (2026-07-27) rather than a forward promise - and where to check for yourself whether it held.",
+      "commit": "",
+      "featured": false
+    },
+    {
       "filename": "2026-07-15-ui-before-snapshot.md",
       "title": "Where the site stands, before the refresh",
       "date": "2026-07-15",


### PR DESCRIPTION
**DO NOT MERGE YET.** Pip's ruling 2026-07-31: *publish as dated, but I need to revise copy — it can go up the pipeline so far but no further.*

Opening the PR so the work is visible and reviewable rather than sitting on an unlinked branch, but it is explicitly **held for Pip's copy pass**.

Two drafts:

- **`2026-07-30-issue-1-turns-one.md`** — the anniversary post. **Publishing as-dated 30 July was ruled** (it *was* the anniversary; a post dated the 30th appearing on the 31st is normal and honest). Opens on issue #1 being *"Text overflows UI elements on several screens"* and calls that the founding document of a game about how civilisation might end.
- **`2026-07-28-this-post-has-a-shelf-life.md`** — cadence reported as a dated decision rather than a forward promise.

**One thing to check during the copy pass**, because it will ship broken otherwise: the site's blog renderer supports **links, images, inline code, bold and italic — and nothing else**. No headings, no tables, no lists, no fenced code. Anything else renders as raw text on the live page. Both drafts use headings.

Read them rendered, with diffs, at `_review/content.html` (`python scripts/render-content-review.py`).