### PR TITLE
fix(league): the seed guard was firing on issue text, not a hardcoded seed

### DIFF
--- a/scripts/test-weekly-league-boundary.py
+++ b/scripts/test-weekly-league-boundary.py
@@ -394,6 +394,16 @@ for _p in list((Path(__file__).parent).glob("*.py")) + \
     # it is preventing.
     if _p.name.startswith(("test-", "test_")):
         continue
+    # Mirrors of upstream PROSE are exempt for the same reason. issues-cache.json is a
+    # verbatim copy of pdoom1's GitHub issues, so the seed appears there the moment anyone
+    # *discusses* it in an issue -- which is exactly what we want people to do before a
+    # ceremony. Failing on that would mean the guard fires because the seed was talked
+    # about correctly, and the only way to keep it green would be to stop writing issues.
+    #
+    # The rule is about a surface that SUPPLIES a seed to code or to a reader as a value,
+    # not about any file in which the characters occur. Discussion is not pinning.
+    if _p.name in ("issues-cache.json",):
+        continue
     try:
         if _probable in _p.read_text(encoding="utf-8"):
             _leaks.append(_p.name)


### PR DESCRIPTION
`main` red again — **third variant of the same false positive**, and this one is instructive.

`issues-cache.json` is a **verbatim mirror of pdoom1's GitHub issues**. The probable seed appears there the moment anyone *discusses* it in an issue — which is exactly what should happen before a ceremony. So the guard fired because the seed was talked about **correctly**, and the only way to keep it green would have been to stop writing issues about it.

The rule is about a surface that **supplies** a seed to code, or presents it to a reader as a value. **Discussion is not pinning.** Mirrors of upstream prose are now exempt alongside test fixtures.

**Worth recording the shape**, because I've now patched this guard twice in one morning: a grep over a whole directory catches everything — mirrors, tests, quoted prose — and each false positive is indistinguishable from a real leak until a human reads it. The durable fix is an **allowlist of files that can actually feed a seed**, or a check on specific *keys* rather than raw substrings. Filed rather than done, because `main` is red and this is the small change.

Verified both directions: 93/93 clean, and a planted non-test file still trips it.