### PR TITLE
content(events): stamp the impacts block and show direction, not magnitude

### DIFF
--- a/docs/UNDER_CONSTRUCTION_STAMP.md
+++ b/docs/UNDER_CONSTRUCTION_STAMP.md
@@ -1,0 +1,128 @@
+# The under-construction stamp
+
+A diagonal rubber-stamp impression — the thing a clerk slams on a form.
+Mid-2000s office paperwork, not a Web 1.0 "under construction" GIF.
+
+Source: `public/css/stamp.css`. First adopter: `public/frontier-labs/index.html`.
+
+## What it is for
+
+Marking a block of the site whose data is **not yet what it will be**, without
+either (a) hiding the block or (b) letting a reader mistake a placeholder for a
+measurement. It is the visual half of the same discipline `/state-of-doom/`
+applies in text: render *"awaiting &lt;source&gt;"*, never a guessed value.
+
+It is a **label, not a censor bar**. If a stamp is covering something the reader
+needs, the stamp is wrong.
+
+## Adopting it on another page
+
+Two lines. One `<link>`, one block of markup.
+
+```html
+<!-- in <head>, AFTER the page's own inline <style> is not required —
+     every class is namespaced .stamp*, so order does not matter -->
+<link rel="stylesheet" href="/css/stamp.css">
+```
+
+```html
+<div class="stamp-block" role="note">
+  <p><span class="stamp stamp--awaiting"><span class="stamp-sr">Status stamp: </span><span class="stamp-text">Awaiting data</span></span></p>
+  <div class="stamp-body">
+    <p>What this block will show, what it is waiting on, and who is doing it.</p>
+  </div>
+  <p class="stamp-docket">
+    Form PD-1/FL &middot; Ref <a href="https://github.com/PipFoweraker/pdoom-data/issues/37">pdoom-data#37</a> &middot; Clerk: unassigned
+  </p>
+</div>
+```
+
+That is the whole component. No JS, no images, no external fonts, no network
+requests — the site's CSP posture stays intact.
+
+### Required bits, and why each one
+
+| Bit | Why it is not optional |
+| --- | --- |
+| `role="note"` on the block | tells assistive tech the panel is an aside about the content, not the content |
+| `<span class="stamp-sr">Status stamp: </span>` | a sighted reader knows it is a stamp from the border and the angle. Nobody else does. |
+| Sentence case in the HTML (`Awaiting data`) | CSS does the shouting via `text-transform`. Several screen readers spell ALL-CAPS source text out letter by letter. |
+| `<span class="stamp-text">` wrapper | lifts the letters above the ink-void overlay (`z-index`) |
+| A real reference in `.stamp-docket` | a made-up docket number is exactly the authoritative-sounding lie the stamp exists to prevent |
+
+## Choosing the words
+
+**Pick what is true of that specific block.** A stamp saying something false is
+worse than no stamp — it launders a guess into an official-looking record.
+
+| Class | Words that fit | True when |
+| --- | --- | --- |
+| `.stamp--awaiting` | Awaiting data · Awaiting source | the data does not exist yet anywhere |
+| `.stamp--provisional` | Provisional · Subject to revision | data exists but is hand-entered / interim |
+| `.stamp--review` | Under review · Definition under review | the *boundary* is being argued, not the values |
+| `.stamp--incomplete` | File incomplete · Known incomplete | the set is real but knowingly missing members |
+| `.stamp--restricted` | Not a measurement · Illustrative only | the block is a model artefact, not an observation |
+
+Variants differ only in `--stamp-ink` and slam angle, so adding one is a
+two-property rule.
+
+## Sizes and placement
+
+- `.stamp--sm` / `.stamp--lg` — scale.
+- Default placement is **in normal flow**. Use this.
+- `.stamp--overlay` — corner impression, `pointer-events:none`. Only for panels
+  whose content is *itself* pending. The panel must be `position:relative` and
+  must reserve `padding-top` for it. On ≤480px it drops back into flow
+  automatically, because a rotated absolute box on a narrow screen will overlap
+  something.
+
+## How the effect is built
+
+Four cheap layers, no images:
+
+1. `transform: rotate(-7deg)` — the slam angle. Small enough to read as
+   deliberate, large enough not to look like a CSS bug. Variants vary it so two
+   stamps on one page are not obviously the same object.
+2. `::before` — a duplicate border box offset ~1–3px at `opacity:.28`. This is
+   the misregistered second impression of a tired stamp, and it is what stops
+   the element reading as a plain badge.
+3. `text-shadow: .5px .5px 0 currentColor` — the same trick on the letterforms.
+4. `::after` — an angled `repeating-linear-gradient` in the **page background
+   colour** at `opacity:.18`, with uneven stop widths (1/6/7/19/21/34px). Reads
+   as streaky voids where the ink did not take.
+
+Plus condensed all-caps letterspacing (`font-weight:800`, `letter-spacing:.18em`,
+`font-stretch:condensed` as a no-op-if-unavailable enhancement) and a double
+rule (`border` + `inset box-shadow`).
+
+### Why layer 4 is an overlay and not a mask
+
+A CSS `mask-image` would give more convincing ink weathering. It is rejected
+deliberately: if masking fails or composites unexpectedly, the stamp renders
+**invisible**. That is the one failure mode a trust label cannot have — the
+reader would then see pending data with nothing marking it as pending. An
+overlay's worst case is that it renders as nothing, and you are left with a
+clean stamp. Degrade toward *more* honest, not less.
+
+## Degradation checklist
+
+- **No CSS at all** → `Status stamp: Awaiting data` as plain text ahead of the
+  explanation. Meaning survives intact.
+- **No JS** → irrelevant; the component uses none.
+- **`prefers-reduced-motion`** → nothing here moves in the first place. The
+  media block only neutralises transitions a host page might inherit onto it.
+- **`forced-colors: active`** → border and text switch to `CanvasText`, ink-void
+  overlay is dropped (it would otherwise punch holes in a system-colour fill).
+- **≤480px** → `white-space` unlocks so long wording wraps instead of
+  overflowing; overlay placement falls back to flow.
+
+## Rules
+
+1. **Never in `public/css/site.css`.** That file loads nearly everywhere and has
+   whited out the site once already (CLAUDE.md, "Cascade gotcha"). `stamp.css`
+   is opt-in per page.
+2. **No emoji.** The stamp is typography. A pictograph would turn a
+   bureaucratic instrument into a sticker.
+3. **Remove the stamp when the data lands.** A stamp that outlives its condition
+   trains readers to ignore all of them — the same reasoning as the ADR
+   scrubber's deliberately narrow match in `sync-design-notes.py`.

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -3,15 +3,15 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>About p(Doom)1 — a free, open-source AI safety strategy game</title>
+	<title>About p(Doom)1 — a free, source-available AI safety strategy game</title>
 	<link rel="canonical" href="https://pdoom1.com/about/" />
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" />
-	<meta name="description" content="A strategy game about running an AI-safety lab: hiring, funding, compute, bureaucracy. Solo-built by Pip Foweraker, MIT-licensed, free, early alpha." />
+	<meta name="description" content="A strategy game about running an AI-safety lab: hiring, funding, compute, bureaucracy. Solo-built by Pip Foweraker, free, source-available, early alpha." />
 	<meta name="author" content="Pip Foweraker" />
 	<meta property="og:type" content="website" />
 	<meta property="og:site_name" content="p(Doom)1" />
 	<meta property="og:title" content="About p(Doom)1 - AI Safety Strategy Game" />
-	<meta property="og:description" content="Solo-built, MIT-licensed strategy game about running an AI-safety lab. Why it exists and how it's made." />
+	<meta property="og:description" content="Solo-built, source-available strategy game about running an AI-safety lab. Why it exists and how it's made." />
 	<meta property="og:url" content="https://pdoom1.com/about/" />
 	<meta property="og:image" content="https://pdoom1.com/assets/og-card.jpg" />
 	<meta name="twitter:card" content="summary_large_image" />
@@ -461,8 +461,8 @@
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Open]</div>
-					<h4>Open Source</h4>
-					<p>MIT-licensed, all of it on GitHub &mdash; warts included. Contributions welcome.</p>
+					<h4>Source available</h4>
+					<p>All of it on GitHub &mdash; warts included &mdash; to read, evaluate and contribute to. Not open source yet: an engine licence is planned around 1.0. Contributions welcome.</p>
 				</div>
 				<div class="value-card">
 					<div class="icon" aria-hidden="true">[Global]</div>
@@ -507,7 +507,7 @@
 
 		<section class="section">
 			<h2>Who's Building It</h2>
-			<p>p(Doom)1 is built by Pip Foweraker, working solo, in the belief that games can educate and inspire. It is developed in the open and MIT-licensed, so anyone is welcome to pitch in.</p>
+			<p>p(Doom)1 is built by Pip Foweraker, working solo, in the belief that games can educate and inspire. It is developed in the open, so anyone is welcome to pitch in. (Source-available rather than open source for now &mdash; see the licence.)</p>
 
 			<div class="grid">
 				<div class="team-member">
@@ -519,7 +519,7 @@
 				<div class="team-member">
 					<div class="avatar">[IMG]</div>
 					<h4>Open to Contributors</h4>
-					<div class="role">MIT-Licensed, Built in the Open</div>
+					<div class="role">Source Available, Built in the Open</div>
 					<p>Code, ideas, and feedback are welcome through GitHub. If you'd like to help, the door's open.</p>
 				</div>
 			</div>
@@ -614,7 +614,7 @@
 
 		<section class="section" style="text-align: center;">
 			<h2>Ready to Play?</h2>
-			<p style="margin-bottom: 2rem;">Free, open source, early alpha. Try to lower p(doom) &mdash; the paperwork usually wins.</p>
+			<p style="margin-bottom: 2rem;">Free, source-available, early alpha. Try to lower p(doom) &mdash; the paperwork usually wins.</p>
 			<div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
 				<a href="https://github.com/PipFoweraker/pdoom1/releases" style="background: var(--accent-primary); color: var(--bg-primary); text-decoration: none; padding: 1rem 2rem; border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);" target="_blank" rel="noopener">Download on GitHub</a>
 				<a href="/leaderboard/" style="background: transparent; color: var(--accent-primary); text-decoration: none; padding: 1rem 2rem; border: 2px solid var(--accent-primary); border-radius: var(--radius-md); font-weight: bold; transition: all var(--duration-base) var(--easing);">View Leaderboard</a>

--- a/public/css/stamp.css
+++ b/public/css/stamp.css
@@ -1,0 +1,240 @@
+/* ===========================================================================
+   p(Doom)1 — bureaucratic stamp motif
+   ---------------------------------------------------------------------------
+   A diagonal rubber-stamp impression, of the kind a clerk slams on a form.
+   Register: mid-2000s office paperwork, not a Web 1.0 "under construction" GIF.
+
+   WHY THIS FILE IS NOT IN site.css
+   --------------------------------
+   site.css loads on ~2,225 pages and has whited-out the site once already by
+   carrying a light-palette literal (see CLAUDE.md, "Cascade gotcha"). This
+   stylesheet is OPT-IN: a page adopts it with one <link>, and pages that do not
+   link it are untouched. Every class here is namespaced `.stamp*`, so it cannot
+   collide with a page's inline <style>.
+
+   PALETTE
+   -------
+   Colours come from `--stamp-ink`, which defaults to the amber-terminal accent
+   but reads a page token first, so a page that defines --accent-primary /
+   --amber gets its own ink for free:
+       --stamp-ink: var(--amber, var(--accent-primary, #f6a800));
+
+   HONESTY CONTRACT
+   ----------------
+   A stamp is a LABEL, not a censor bar. It must never sit on top of content a
+   reader needs. The default `.stamp` is in normal flow. `.stamp--overlay` is
+   available for panels that are *themselves* empty/pending, is
+   pointer-events:none, and requires the panel to reserve padding for it.
+
+   Stamp text is REAL TEXT, not a pseudo-element `content:`, because it carries
+   meaning about how far to trust the data underneath. Write the words in
+   sentence case in the HTML and let `text-transform:uppercase` do the shouting —
+   several screen readers spell out ALL-CAPS source text letter by letter.
+
+   MOTION
+   ------
+   Nothing here moves. A stamp is a static impression. The reduced-motion block
+   at the bottom exists only to neutralise transitions a host page might inherit
+   onto the element.
+
+   HOW IT IS BUILT (the recipe, in four cheap layers)
+   --------------------------------------------------
+   1. rotate()          — the slam angle. ~-7deg reads deliberate, not broken.
+   2. ::before          — a 1px-offset duplicate of the border box at low alpha:
+                          the second, misregistered impression of a tired stamp.
+   3. text-shadow       — the same trick on the letterforms.
+   4. ::after           — angled repeating-linear-gradient in the PAGE background
+                          colour, ~18% alpha, with uneven stop widths. Reads as
+                          streaky voids where the ink did not take.
+                          Deliberately an OVERLAY, not a mask: worst case it
+                          renders as nothing. A mask that fails renders the whole
+                          stamp invisible, which is the one failure mode we
+                          cannot accept for a trust label.
+
+   Full recipe + adoption snippet: docs/UNDER_CONSTRUCTION_STAMP.md
+   =========================================================================== */
+
+.stamp,
+.stamp-block,
+.stamp-docket {
+	--stamp-ink: var(--amber, var(--accent-primary, #f6a800));
+	--stamp-void: var(--bg, var(--bg-primary, #12100f));
+	--stamp-rotate: -7deg;
+}
+
+/* --- the impression ------------------------------------------------------ */
+
+.stamp {
+	position: relative;
+	display: inline-block;
+	max-width: 100%;
+	padding: 0.42em 0.85em;
+	border: 2px solid var(--stamp-ink);
+	border-radius: 3px;
+	box-shadow: inset 0 0 0 1px var(--stamp-ink);
+
+	color: var(--stamp-ink);
+	font-family: ui-monospace, "SFMono-Regular", Menlo, "Courier New", monospace;
+	font-size: 0.78rem;
+	font-weight: 800;
+	font-stretch: condensed; /* progressive enhancement; ignored if unavailable */
+	letter-spacing: 0.18em;
+	line-height: 1.15;
+	text-transform: uppercase;
+	text-align: center;
+	white-space: nowrap;
+
+	opacity: 0.9;
+	transform: rotate(var(--stamp-rotate));
+	transform-origin: 50% 50%;
+	/* rotation makes the box sweep past its layout footprint; buy it room so it
+	   never clips against a neighbouring element */
+	margin: 0.55em 0.75em;
+	vertical-align: middle;
+}
+
+/* the misregistered second impression */
+.stamp::before {
+	content: "";
+	position: absolute;
+	inset: -3px -2px 1px -4px;
+	border: 2px solid var(--stamp-ink);
+	border-radius: 3px;
+	opacity: 0.28;
+	pointer-events: none;
+}
+
+/* streaky voids where the ink did not take */
+.stamp::after {
+	content: "";
+	position: absolute;
+	inset: -2px;
+	pointer-events: none;
+	background: repeating-linear-gradient(
+		112deg,
+		var(--stamp-void) 0 1px,
+		transparent 1px 6px,
+		var(--stamp-void) 6px 7px,
+		transparent 7px 19px,
+		var(--stamp-void) 19px 21px,
+		transparent 21px 34px
+	);
+	opacity: 0.18;
+}
+
+.stamp > .stamp-text {
+	/* keeps the letters above the void overlay */
+	position: relative;
+	z-index: 1;
+	text-shadow: 0.5px 0.5px 0 currentColor;
+	opacity: 0.94;
+}
+
+/* --- ink variants: pick the one that is TRUE of the block ---------------- */
+
+.stamp--awaiting    { --stamp-ink: var(--amber, var(--accent-primary, #f6a800)); --stamp-rotate: -6deg; }
+.stamp--provisional { --stamp-ink: var(--amber, var(--accent-primary, #f6a800)); --stamp-rotate: -9deg; }
+.stamp--review      { --stamp-ink: var(--teal, var(--accent-secondary, #2fd4c2)); --stamp-rotate: -5deg; }
+.stamp--restricted  { --stamp-ink: var(--doom, var(--accent-danger, #e2524a)); --stamp-rotate: -11deg; }
+.stamp--incomplete  { --stamp-ink: var(--ink-3, var(--text-muted, #a79e92)); --stamp-rotate: -8deg; }
+
+/* --- sizes --------------------------------------------------------------- */
+
+.stamp--sm { font-size: 0.62rem; letter-spacing: 0.14em; padding: 0.3em 0.6em; border-width: 1px; }
+.stamp--lg { font-size: 1.02rem; letter-spacing: 0.2em; padding: 0.5em 1em; }
+
+/* --- placement ----------------------------------------------------------- */
+
+/* Corner impression. ONLY for panels whose content is itself pending — it must
+   never land on prose a reader needs. The panel must be position:relative and
+   must reserve padding-top for the stamp. */
+.stamp--overlay {
+	position: absolute;
+	top: 0.6rem;
+	right: 0.9rem;
+	margin: 0;
+	pointer-events: none;
+	z-index: 2;
+}
+
+/* --- the panel a stamp labels -------------------------------------------- */
+
+.stamp-block {
+	position: relative;
+	border: 1px dashed var(--stamp-ink);
+	border-radius: 10px;
+	background: var(--panel, var(--bg-secondary, #1c1917));
+	padding: 1.2rem 1.3rem 1.1rem;
+	margin: 1.4rem 0;
+}
+
+.stamp-block > .stamp-body {
+	color: var(--ink-2, var(--text-secondary, #cfc7bb));
+	font-size: 0.92rem;
+	text-wrap: pretty;
+}
+
+.stamp-block > .stamp-body > * + * { margin-top: 0.7rem; }
+
+/* The docket line. Mid-2000s paperwork does not just stamp a form, it gives the
+   form a number. Every reference printed here must be a real one — a made-up
+   docket is exactly the sort of authoritative-sounding lie this page exists to
+   avoid. */
+.stamp-docket {
+	margin-top: 0.9rem;
+	padding-top: 0.7rem;
+	border-top: 1px solid var(--hair, var(--border-color, #3a342e));
+	color: var(--ink-3, var(--text-muted, #a79e92));
+	font-family: ui-monospace, "SFMono-Regular", Menlo, "Courier New", monospace;
+	font-size: 0.68rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	word-break: break-word;
+}
+
+.stamp-docket a { color: var(--stamp-ink); text-decoration: none; }
+.stamp-docket a:hover { text-decoration: underline; }
+
+/* --- screen-reader-only prefix ------------------------------------------- */
+
+/* The stamp's meaning depends on knowing it IS a stamp. Sighted readers get
+   that from the border and the angle; everyone else gets this. */
+.stamp-sr {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* --- small screens ------------------------------------------------------- */
+
+@media (max-width: 480px) {
+	.stamp { font-size: 0.66rem; letter-spacing: 0.13em; white-space: normal; }
+	.stamp--lg { font-size: 0.82rem; }
+	.stamp--overlay { position: static; display: inline-block; margin: 0 0 0.6rem; }
+}
+
+/* --- a stamp is a static impression -------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+	.stamp,
+	.stamp::before,
+	.stamp::after,
+	.stamp-block {
+		transition: none !important;
+		animation: none !important;
+	}
+}
+
+/* --- high contrast / forced colours -------------------------------------- */
+
+@media (forced-colors: active) {
+	.stamp { border-color: CanvasText; color: CanvasText; opacity: 1; }
+	.stamp::after { display: none; }
+}

--- a/public/data/events-sync-summary.json
+++ b/public/data/events-sync-summary.json
@@ -1,5 +1,5 @@
 {
-  "sync_timestamp": "2026-08-03T07:52:57.610193",
+  "sync_timestamp": "2026-07-31T08:01:33.186375",
   "total_events_in_source": 1194,
   "included_events": 1194,
   "excluded_events": 0,

--- a/public/data/events-sync-summary.json
+++ b/public/data/events-sync-summary.json
@@ -1,5 +1,5 @@
 {
-  "sync_timestamp": "2026-07-31T08:01:33.186375",
+  "sync_timestamp": "2026-08-03T08:02:21.309618",
   "total_events_in_source": 1194,
   "included_events": 1194,
   "excluded_events": 0,

--- a/public/events/academic_safety_funding_cuts_2024.html
+++ b/public/events/academic_safety_funding_cuts_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/academic_safety_funding_cuts_2024.html
+++ b/public/events/academic_safety_funding_cuts_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Major universities cut AI safety research programs in favor of industry-sponsored AI capabilities research</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/ai_sandbagging_research_2024.html
+++ b/public/events/ai_sandbagging_research_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">van der Weij et al. demonstrate that GPT-4 and Claude 3 Opus can strategically underperform on dangerous capability evaluations while maintaining general performance</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/ai_sandbagging_research_2024.html
+++ b/public/events/ai_sandbagging_research_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/ai_summit_pivot_2023_2025.html
+++ b/public/events/ai_summit_pivot_2023_2025.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Progression from AI Safety Summit (Bletchley) to AI Action Summit (Paris) shows gradual shift from safety focus to economic growth priorities</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/ai_summit_pivot_2023_2025.html
+++ b/public/events/ai_summit_pivot_2023_2025.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Cash</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/anthropic_alignment_faking_2024.html
+++ b/public/events/anthropic_alignment_faking_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+40</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/anthropic_alignment_faking_2024.html
+++ b/public/events/anthropic_alignment_faking_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Claude 3 Opus caught strategically pretending to align with training objectives while secretly maintaining original preferences in hidden reasoning</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/anthropic_exodus_2021.html
+++ b/public/events/anthropic_exodus_2021.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Mass departure from OpenAI to form safety-focused competitor after ideological conflicts over safety vs capability race</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/anthropic_exodus_2021.html
+++ b/public/events/anthropic_exodus_2021.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-50</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/apollo_scheming_evals_2024.html
+++ b/public/events/apollo_scheming_evals_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Systematic demonstrations that more capable models show higher rates of in-context scheming, with Opus-4-early showing 'such high rates' that Apollo advised against deployment</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/apollo_scheming_evals_2024.html
+++ b/public/events/apollo_scheming_evals_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+45</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+40</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_004aec5c84faaf31.html
+++ b/public/events/arxiv_004aec5c84faaf31.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_004aec5c84faaf31.html
+++ b/public/events/arxiv_004aec5c84faaf31.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Measurement in AI Policy: Opportunities and Challenges</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_00ccb2340d8ada5a.html
+++ b/public/events/arxiv_00ccb2340d8ada5a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_00ccb2340d8ada5a.html
+++ b/public/events/arxiv_00ccb2340d8ada5a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_01150a46b8a08cef.html
+++ b/public/events/arxiv_01150a46b8a08cef.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_01150a46b8a08cef.html
+++ b/public/events/arxiv_01150a46b8a08cef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_012a30b8a005a12c.html
+++ b/public/events/arxiv_012a30b8a005a12c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_012a30b8a005a12c.html
+++ b/public/events/arxiv_012a30b8a005a12c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_013103aafe00cc7c.html
+++ b/public/events/arxiv_013103aafe00cc7c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_013103aafe00cc7c.html
+++ b/public/events/arxiv_013103aafe00cc7c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0141cd563881ab4f.html
+++ b/public/events/arxiv_0141cd563881ab4f.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0141cd563881ab4f.html
+++ b/public/events/arxiv_0141cd563881ab4f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Voluntary safety commitments provide an escape from over-regulation in AI development</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_01422b8e083200ef.html
+++ b/public/events/arxiv_01422b8e083200ef.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_01422b8e083200ef.html
+++ b/public/events/arxiv_01422b8e083200ef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">1  The Logic of Strategic Assets: From Oil to AI Jeffrey Ding and Allan Dafoe* Forthcoming at Security Studies (2021)  Abstract What resources and technologies are strategic? This question is often the focus of policy and theoretical debates, since the ?strategic? designation yields valuable resources and elevated attention. These conversations, however, are frustrated by the ambiguity of the very concept. We offer a theory of when decision-makers should designate particular assets as strategic based on the presence of important rivalrous externalities for which socially optimal behavior will not be produced alone by firms or military organizations. We distill three forms of these externalities, which involve cumulative-, infrastructure-, and dependency-strategic logics. While our framework cannot resolve debates about strategic assets, it provides a theoretically grounded conceptual vocabulary to make these debates more productive. To illustrate the analytic value of our framework ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_01e708118256c867.html
+++ b/public/events/arxiv_01e708118256c867.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_01e708118256c867.html
+++ b/public/events/arxiv_01e708118256c867.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_02273093eda16115.html
+++ b/public/events/arxiv_02273093eda16115.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_02273093eda16115.html
+++ b/public/events/arxiv_02273093eda16115.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_022a0b73d5f487fa.html
+++ b/public/events/arxiv_022a0b73d5f487fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_022a0b73d5f487fa.html
+++ b/public/events/arxiv_022a0b73d5f487fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0242bd9afee7aace.html
+++ b/public/events/arxiv_0242bd9afee7aace.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0242bd9afee7aace.html
+++ b/public/events/arxiv_0242bd9afee7aace.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_028a9baaa9a77d42.html
+++ b/public/events/arxiv_028a9baaa9a77d42.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: A New Formalism, Method and Open Issues for Zero-Shot Coordination</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_028a9baaa9a77d42.html
+++ b/public/events/arxiv_028a9baaa9a77d42.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_02949cb93049b82c.html
+++ b/public/events/arxiv_02949cb93049b82c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_02949cb93049b82c.html
+++ b/public/events/arxiv_02949cb93049b82c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_02cb990df1910ff1.html
+++ b/public/events/arxiv_02cb990df1910ff1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_02cb990df1910ff1.html
+++ b/public/events/arxiv_02cb990df1910ff1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_02d29384d4f1acc9.html
+++ b/public/events/arxiv_02d29384d4f1acc9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_02d29384d4f1acc9.html
+++ b/public/events/arxiv_02d29384d4f1acc9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_030d3ea251808602.html
+++ b/public/events/arxiv_030d3ea251808602.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_030d3ea251808602.html
+++ b/public/events/arxiv_030d3ea251808602.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_033334e7f192c5e2.html
+++ b/public/events/arxiv_033334e7f192c5e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_033334e7f192c5e2.html
+++ b/public/events/arxiv_033334e7f192c5e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_038cf60b42288177.html
+++ b/public/events/arxiv_038cf60b42288177.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_038cf60b42288177.html
+++ b/public/events/arxiv_038cf60b42288177.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_03b945a38102e081.html
+++ b/public/events/arxiv_03b945a38102e081.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_03b945a38102e081.html
+++ b/public/events/arxiv_03b945a38102e081.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_03dacb5f6ba0911a.html
+++ b/public/events/arxiv_03dacb5f6ba0911a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_03dacb5f6ba0911a.html
+++ b/public/events/arxiv_03dacb5f6ba0911a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_043fe6dc0beaa8b2.html
+++ b/public/events/arxiv_043fe6dc0beaa8b2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_043fe6dc0beaa8b2.html
+++ b/public/events/arxiv_043fe6dc0beaa8b2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0475b257aaff02e4.html
+++ b/public/events/arxiv_0475b257aaff02e4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0475b257aaff02e4.html
+++ b/public/events/arxiv_0475b257aaff02e4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_047b16216740d354.html
+++ b/public/events/arxiv_047b16216740d354.html
@@ -453,7 +453,9 @@ prediction build on basic properties of human and animal lea...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ prediction build on basic properties of human and animal lea...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ prediction build on basic properties of human and animal lea...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_047b16216740d354.html
+++ b/public/events/arxiv_047b16216740d354.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ machine learning systems provides the best predictions. Surprisingly, the most u
 prediction build on basic properties of human and animal lea...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_04ec3ee050cc9518.html
+++ b/public/events/arxiv_04ec3ee050cc9518.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_04ec3ee050cc9518.html
+++ b/public/events/arxiv_04ec3ee050cc9518.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0530e7dcfd24a85d.html
+++ b/public/events/arxiv_0530e7dcfd24a85d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0530e7dcfd24a85d.html
+++ b/public/events/arxiv_0530e7dcfd24a85d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_058f69adbea22c2d.html
+++ b/public/events/arxiv_058f69adbea22c2d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -444,8 +445,21 @@ Hypothesis generation is implemented by ar tificially supplying the instrument w
 parameterized set of poss...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_058f69adbea22c2d.html
+++ b/public/events/arxiv_058f69adbea22c2d.html
@@ -449,7 +449,9 @@ parameterized set of poss...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -464,7 +466,7 @@ parameterized set of poss...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -472,19 +474,19 @@ parameterized set of poss...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_05d065dde75a5055.html
+++ b/public/events/arxiv_05d065dde75a5055.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_05d065dde75a5055.html
+++ b/public/events/arxiv_05d065dde75a5055.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_05f3a92ca4a98b9f.html
+++ b/public/events/arxiv_05f3a92ca4a98b9f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_05f3a92ca4a98b9f.html
+++ b/public/events/arxiv_05f3a92ca4a98b9f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_05f9af1daa2926cf.html
+++ b/public/events/arxiv_05f9af1daa2926cf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_05f9af1daa2926cf.html
+++ b/public/events/arxiv_05f9af1daa2926cf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_060a27387c4518c0.html
+++ b/public/events/arxiv_060a27387c4518c0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_060a27387c4518c0.html
+++ b/public/events/arxiv_060a27387c4518c0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0631100f62ec42fb.html
+++ b/public/events/arxiv_0631100f62ec42fb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0631100f62ec42fb.html
+++ b/public/events/arxiv_0631100f62ec42fb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_066ad11bb2ff28fa.html
+++ b/public/events/arxiv_066ad11bb2ff28fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_066ad11bb2ff28fa.html
+++ b/public/events/arxiv_066ad11bb2ff28fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0701f434e0267fd4.html
+++ b/public/events/arxiv_0701f434e0267fd4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0701f434e0267fd4.html
+++ b/public/events/arxiv_0701f434e0267fd4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_078647ecabd09671.html
+++ b/public/events/arxiv_078647ecabd09671.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_078647ecabd09671.html
+++ b/public/events/arxiv_078647ecabd09671.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_07c0229080ab2399.html
+++ b/public/events/arxiv_07c0229080ab2399.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_07c0229080ab2399.html
+++ b/public/events/arxiv_07c0229080ab2399.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_07f0f2a80bb55b2d.html
+++ b/public/events/arxiv_07f0f2a80bb55b2d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_07f0f2a80bb55b2d.html
+++ b/public/events/arxiv_07f0f2a80bb55b2d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_085c7909f407e916.html
+++ b/public/events/arxiv_085c7909f407e916.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ emerging trends, knowledge gaps and potential areas for
 future research. In this paper, bibliome...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_085c7909f407e916.html
+++ b/public/events/arxiv_085c7909f407e916.html
@@ -452,7 +452,9 @@ future research. In this paper, bibliome...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ future research. In this paper, bibliome...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ future research. In this paper, bibliome...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_08b82a9d28b9a5af.html
+++ b/public/events/arxiv_08b82a9d28b9a5af.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_08b82a9d28b9a5af.html
+++ b/public/events/arxiv_08b82a9d28b9a5af.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_08f395401d44b67d.html
+++ b/public/events/arxiv_08f395401d44b67d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_08f395401d44b67d.html
+++ b/public/events/arxiv_08f395401d44b67d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_08f6fc9e4b21ce87.html
+++ b/public/events/arxiv_08f6fc9e4b21ce87.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_08f6fc9e4b21ce87.html
+++ b/public/events/arxiv_08f6fc9e4b21ce87.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a11a1aed371713f.html
+++ b/public/events/arxiv_0a11a1aed371713f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a11a1aed371713f.html
+++ b/public/events/arxiv_0a11a1aed371713f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a1c13b3bb93cd64.html
+++ b/public/events/arxiv_0a1c13b3bb93cd64.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a1c13b3bb93cd64.html
+++ b/public/events/arxiv_0a1c13b3bb93cd64.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a23eb6270740896.html
+++ b/public/events/arxiv_0a23eb6270740896.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a23eb6270740896.html
+++ b/public/events/arxiv_0a23eb6270740896.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a373355a323506a.html
+++ b/public/events/arxiv_0a373355a323506a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a373355a323506a.html
+++ b/public/events/arxiv_0a373355a323506a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a40d2de6851709b.html
+++ b/public/events/arxiv_0a40d2de6851709b.html
@@ -518,7 +518,9 @@ and
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -533,7 +535,7 @@ and
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -541,19 +543,19 @@ and
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a40d2de6851709b.html
+++ b/public/events/arxiv_0a40d2de6851709b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -513,8 +514,21 @@ and
 ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a524cefae2d9470.html
+++ b/public/events/arxiv_0a524cefae2d9470.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a524cefae2d9470.html
+++ b/public/events/arxiv_0a524cefae2d9470.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0a76ecf713853808.html
+++ b/public/events/arxiv_0a76ecf713853808.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0a76ecf713853808.html
+++ b/public/events/arxiv_0a76ecf713853808.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0ab857cd2ee86671.html
+++ b/public/events/arxiv_0ab857cd2ee86671.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0ab857cd2ee86671.html
+++ b/public/events/arxiv_0ab857cd2ee86671.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0ae9c9a9e757ef78.html
+++ b/public/events/arxiv_0ae9c9a9e757ef78.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0ae9c9a9e757ef78.html
+++ b/public/events/arxiv_0ae9c9a9e757ef78.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0b1f4debe314fa2e.html
+++ b/public/events/arxiv_0b1f4debe314fa2e.html
@@ -467,7 +467,9 @@ code that Copilot has pro...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -482,7 +484,7 @@ code that Copilot has pro...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -490,19 +492,19 @@ code that Copilot has pro...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0b1f4debe314fa2e.html
+++ b/public/events/arxiv_0b1f4debe314fa2e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -462,8 +463,21 @@ often contains bugs?and so, given the vast quantity of unvetted
 code that Copilot has pro...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0b2cdf50657fa90e.html
+++ b/public/events/arxiv_0b2cdf50657fa90e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0b2cdf50657fa90e.html
+++ b/public/events/arxiv_0b2cdf50657fa90e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0b830fb1671c291a.html
+++ b/public/events/arxiv_0b830fb1671c291a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0b830fb1671c291a.html
+++ b/public/events/arxiv_0b830fb1671c291a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0b8e091c821c1248.html
+++ b/public/events/arxiv_0b8e091c821c1248.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0b8e091c821c1248.html
+++ b/public/events/arxiv_0b8e091c821c1248.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0b9103d6dc8b3c04.html
+++ b/public/events/arxiv_0b9103d6dc8b3c04.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0b9103d6dc8b3c04.html
+++ b/public/events/arxiv_0b9103d6dc8b3c04.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0cf68bfe04a22e30.html
+++ b/public/events/arxiv_0cf68bfe04a22e30.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0cf68bfe04a22e30.html
+++ b/public/events/arxiv_0cf68bfe04a22e30.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0d1bdcf29c07ba19.html
+++ b/public/events/arxiv_0d1bdcf29c07ba19.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0d1bdcf29c07ba19.html
+++ b/public/events/arxiv_0d1bdcf29c07ba19.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0d235ae393c51863.html
+++ b/public/events/arxiv_0d235ae393c51863.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0d235ae393c51863.html
+++ b/public/events/arxiv_0d235ae393c51863.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0da8cb466c437708.html
+++ b/public/events/arxiv_0da8cb466c437708.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0da8cb466c437708.html
+++ b/public/events/arxiv_0da8cb466c437708.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0dbfdba362459a9e.html
+++ b/public/events/arxiv_0dbfdba362459a9e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0dbfdba362459a9e.html
+++ b/public/events/arxiv_0dbfdba362459a9e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0dc012241e048d4d.html
+++ b/public/events/arxiv_0dc012241e048d4d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0dc012241e048d4d.html
+++ b/public/events/arxiv_0dc012241e048d4d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0de42c1e48b1ed52.html
+++ b/public/events/arxiv_0de42c1e48b1ed52.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0de42c1e48b1ed52.html
+++ b/public/events/arxiv_0de42c1e48b1ed52.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0dfde4014fcd105b.html
+++ b/public/events/arxiv_0dfde4014fcd105b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0dfde4014fcd105b.html
+++ b/public/events/arxiv_0dfde4014fcd105b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e186b0d516bdeb5.html
+++ b/public/events/arxiv_0e186b0d516bdeb5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e186b0d516bdeb5.html
+++ b/public/events/arxiv_0e186b0d516bdeb5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e3cde25cfb8379f.html
+++ b/public/events/arxiv_0e3cde25cfb8379f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e3cde25cfb8379f.html
+++ b/public/events/arxiv_0e3cde25cfb8379f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e44e17c3879b667.html
+++ b/public/events/arxiv_0e44e17c3879b667.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e44e17c3879b667.html
+++ b/public/events/arxiv_0e44e17c3879b667.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e530f67c0d52910.html
+++ b/public/events/arxiv_0e530f67c0d52910.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e530f67c0d52910.html
+++ b/public/events/arxiv_0e530f67c0d52910.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e7a23bf62ca3f62.html
+++ b/public/events/arxiv_0e7a23bf62ca3f62.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e7a23bf62ca3f62.html
+++ b/public/events/arxiv_0e7a23bf62ca3f62.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e7d9ea18dd95c60.html
+++ b/public/events/arxiv_0e7d9ea18dd95c60.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e7d9ea18dd95c60.html
+++ b/public/events/arxiv_0e7d9ea18dd95c60.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0e8afc013c84e4e7.html
+++ b/public/events/arxiv_0e8afc013c84e4e7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0e8afc013c84e4e7.html
+++ b/public/events/arxiv_0e8afc013c84e4e7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0ea949bb15660a63.html
+++ b/public/events/arxiv_0ea949bb15660a63.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0ea949bb15660a63.html
+++ b/public/events/arxiv_0ea949bb15660a63.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0ebf56aabf1e884f.html
+++ b/public/events/arxiv_0ebf56aabf1e884f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0ebf56aabf1e884f.html
+++ b/public/events/arxiv_0ebf56aabf1e884f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0ef3ae9d9df8bf40.html
+++ b/public/events/arxiv_0ef3ae9d9df8bf40.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0ef3ae9d9df8bf40.html
+++ b/public/events/arxiv_0ef3ae9d9df8bf40.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0f27b954a6dd7471.html
+++ b/public/events/arxiv_0f27b954a6dd7471.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0f27b954a6dd7471.html
+++ b/public/events/arxiv_0f27b954a6dd7471.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0f2df22712848c03.html
+++ b/public/events/arxiv_0f2df22712848c03.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0f2df22712848c03.html
+++ b/public/events/arxiv_0f2df22712848c03.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0f2f1b0c49e94345.html
+++ b/public/events/arxiv_0f2f1b0c49e94345.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0f2f1b0c49e94345.html
+++ b/public/events/arxiv_0f2f1b0c49e94345.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_0fdf5b2c39518e9d.html
+++ b/public/events/arxiv_0fdf5b2c39518e9d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_0fdf5b2c39518e9d.html
+++ b/public/events/arxiv_0fdf5b2c39518e9d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_100ba189bf0dc01a.html
+++ b/public/events/arxiv_100ba189bf0dc01a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_100ba189bf0dc01a.html
+++ b/public/events/arxiv_100ba189bf0dc01a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_10237dc027826413.html
+++ b/public/events/arxiv_10237dc027826413.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -444,8 +445,21 @@ function, in a multi -objective fashion, and ii) the tuning of
 the introduced weights during the training phase of th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_10237dc027826413.html
+++ b/public/events/arxiv_10237dc027826413.html
@@ -449,7 +449,9 @@ the introduced weights during the training phase of th...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -464,7 +466,7 @@ the introduced weights during the training phase of th...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -472,19 +474,19 @@ the introduced weights during the training phase of th...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1051dda54eaf8c38.html
+++ b/public/events/arxiv_1051dda54eaf8c38.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1051dda54eaf8c38.html
+++ b/public/events/arxiv_1051dda54eaf8c38.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_106bc20476a32912.html
+++ b/public/events/arxiv_106bc20476a32912.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_106bc20476a32912.html
+++ b/public/events/arxiv_106bc20476a32912.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1118b36d97a0748c.html
+++ b/public/events/arxiv_1118b36d97a0748c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1118b36d97a0748c.html
+++ b/public/events/arxiv_1118b36d97a0748c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_117d259472867be5.html
+++ b/public/events/arxiv_117d259472867be5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_117d259472867be5.html
+++ b/public/events/arxiv_117d259472867be5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_118b4f6716338f5b.html
+++ b/public/events/arxiv_118b4f6716338f5b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_118b4f6716338f5b.html
+++ b/public/events/arxiv_118b4f6716338f5b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_122063637b044550.html
+++ b/public/events/arxiv_122063637b044550.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_122063637b044550.html
+++ b/public/events/arxiv_122063637b044550.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_125feae2ca4bf463.html
+++ b/public/events/arxiv_125feae2ca4bf463.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_125feae2ca4bf463.html
+++ b/public/events/arxiv_125feae2ca4bf463.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_12ae1fc6cb0a054e.html
+++ b/public/events/arxiv_12ae1fc6cb0a054e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_12ae1fc6cb0a054e.html
+++ b/public/events/arxiv_12ae1fc6cb0a054e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_12c150d8843037cc.html
+++ b/public/events/arxiv_12c150d8843037cc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_12c150d8843037cc.html
+++ b/public/events/arxiv_12c150d8843037cc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_12d4b77ba8206503.html
+++ b/public/events/arxiv_12d4b77ba8206503.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_12d4b77ba8206503.html
+++ b/public/events/arxiv_12d4b77ba8206503.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_12e5756a832c2c9c.html
+++ b/public/events/arxiv_12e5756a832c2c9c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_12e5756a832c2c9c.html
+++ b/public/events/arxiv_12e5756a832c2c9c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_135efea1cd78b777.html
+++ b/public/events/arxiv_135efea1cd78b777.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_135efea1cd78b777.html
+++ b/public/events/arxiv_135efea1cd78b777.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_137bbec0e331870d.html
+++ b/public/events/arxiv_137bbec0e331870d.html
@@ -454,7 +454,9 @@ the expected future rewards toward zero. (i) Reward redistr...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ the expected future rewards toward zero. (i) Reward redistr...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ the expected future rewards toward zero. (i) Reward redistr...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_137bbec0e331870d.html
+++ b/public/events/arxiv_137bbec0e331870d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ of the immediate reward. We propose the following two new concepts to push
 the expected future rewards toward zero. (i) Reward redistr...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1381c91c59063974.html
+++ b/public/events/arxiv_1381c91c59063974.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1381c91c59063974.html
+++ b/public/events/arxiv_1381c91c59063974.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_13c24361877d0d2f.html
+++ b/public/events/arxiv_13c24361877d0d2f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_13c24361877d0d2f.html
+++ b/public/events/arxiv_13c24361877d0d2f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_13e9b257e46a7316.html
+++ b/public/events/arxiv_13e9b257e46a7316.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_13e9b257e46a7316.html
+++ b/public/events/arxiv_13e9b257e46a7316.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1405aec1edf8be7e.html
+++ b/public/events/arxiv_1405aec1edf8be7e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1405aec1edf8be7e.html
+++ b/public/events/arxiv_1405aec1edf8be7e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1413c089690f9c70.html
+++ b/public/events/arxiv_1413c089690f9c70.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1413c089690f9c70.html
+++ b/public/events/arxiv_1413c089690f9c70.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_14670c094dee4d81.html
+++ b/public/events/arxiv_14670c094dee4d81.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_14670c094dee4d81.html
+++ b/public/events/arxiv_14670c094dee4d81.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_14e5b7d17976f400.html
+++ b/public/events/arxiv_14e5b7d17976f400.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_14e5b7d17976f400.html
+++ b/public/events/arxiv_14e5b7d17976f400.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_14ff96fd6948a4bf.html
+++ b/public/events/arxiv_14ff96fd6948a4bf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_14ff96fd6948a4bf.html
+++ b/public/events/arxiv_14ff96fd6948a4bf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_153bcb3b49c0c598.html
+++ b/public/events/arxiv_153bcb3b49c0c598.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_153bcb3b49c0c598.html
+++ b/public/events/arxiv_153bcb3b49c0c598.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_15a7dd0611e9002e.html
+++ b/public/events/arxiv_15a7dd0611e9002e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_15a7dd0611e9002e.html
+++ b/public/events/arxiv_15a7dd0611e9002e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_15eb203180cab2f1.html
+++ b/public/events/arxiv_15eb203180cab2f1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_15eb203180cab2f1.html
+++ b/public/events/arxiv_15eb203180cab2f1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_16071e9e4803e5d3.html
+++ b/public/events/arxiv_16071e9e4803e5d3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_16071e9e4803e5d3.html
+++ b/public/events/arxiv_16071e9e4803e5d3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_160879eef4774db7.html
+++ b/public/events/arxiv_160879eef4774db7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_160879eef4774db7.html
+++ b/public/events/arxiv_160879eef4774db7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_162b2e1f034993c7.html
+++ b/public/events/arxiv_162b2e1f034993c7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_162b2e1f034993c7.html
+++ b/public/events/arxiv_162b2e1f034993c7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1670e43adbfe4218.html
+++ b/public/events/arxiv_1670e43adbfe4218.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1670e43adbfe4218.html
+++ b/public/events/arxiv_1670e43adbfe4218.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_168f4b8a7feb0cd7.html
+++ b/public/events/arxiv_168f4b8a7feb0cd7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_168f4b8a7feb0cd7.html
+++ b/public/events/arxiv_168f4b8a7feb0cd7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_16b35f91b280207d.html
+++ b/public/events/arxiv_16b35f91b280207d.html
@@ -468,7 +468,9 @@ Conclusion (A)  : S...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -483,7 +485,7 @@ Conclusion (A)  : S...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -491,19 +493,19 @@ Conclusion (A)  : S...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_16b35f91b280207d.html
+++ b/public/events/arxiv_16b35f91b280207d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -463,8 +464,21 @@ Conclusions drawn 6
 Conclusion (A)  : S...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_16e9dd5f9342483a.html
+++ b/public/events/arxiv_16e9dd5f9342483a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_16e9dd5f9342483a.html
+++ b/public/events/arxiv_16e9dd5f9342483a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_16f65dedc5d5f097.html
+++ b/public/events/arxiv_16f65dedc5d5f097.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_16f65dedc5d5f097.html
+++ b/public/events/arxiv_16f65dedc5d5f097.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1717dd816d939c97.html
+++ b/public/events/arxiv_1717dd816d939c97.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1717dd816d939c97.html
+++ b/public/events/arxiv_1717dd816d939c97.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_173c85a03b5009b4.html
+++ b/public/events/arxiv_173c85a03b5009b4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_173c85a03b5009b4.html
+++ b/public/events/arxiv_173c85a03b5009b4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_176a4ddb834e0c5f.html
+++ b/public/events/arxiv_176a4ddb834e0c5f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_176a4ddb834e0c5f.html
+++ b/public/events/arxiv_176a4ddb834e0c5f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1781dfeed21085a6.html
+++ b/public/events/arxiv_1781dfeed21085a6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1781dfeed21085a6.html
+++ b/public/events/arxiv_1781dfeed21085a6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_17ef6ec21f8407a5.html
+++ b/public/events/arxiv_17ef6ec21f8407a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_17ef6ec21f8407a5.html
+++ b/public/events/arxiv_17ef6ec21f8407a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_17f6f61338a0d2b0.html
+++ b/public/events/arxiv_17f6f61338a0d2b0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_17f6f61338a0d2b0.html
+++ b/public/events/arxiv_17f6f61338a0d2b0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_18135125de8f50d6.html
+++ b/public/events/arxiv_18135125de8f50d6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_18135125de8f50d6.html
+++ b/public/events/arxiv_18135125de8f50d6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_18def41ad9ebddf1.html
+++ b/public/events/arxiv_18def41ad9ebddf1.html
@@ -457,7 +457,9 @@ start out as  rational or modify itself to become rational  (see Omohun...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -472,7 +474,7 @@ start out as  rational or modify itself to become rational  (see Omohun...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -480,19 +482,19 @@ start out as  rational or modify itself to become rational  (see Omohun...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_18def41ad9ebddf1.html
+++ b/public/events/arxiv_18def41ad9ebddf1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -452,8 +453,21 @@ Economists have long used utility functions to model how rational agents behave 
 start out as  rational or modify itself to become rational  (see Omohun...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_18f734504931d5cf.html
+++ b/public/events/arxiv_18f734504931d5cf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_18f734504931d5cf.html
+++ b/public/events/arxiv_18f734504931d5cf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_18f8987e4b8187c6.html
+++ b/public/events/arxiv_18f8987e4b8187c6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_18f8987e4b8187c6.html
+++ b/public/events/arxiv_18f8987e4b8187c6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_191e09b94ec233fd.html
+++ b/public/events/arxiv_191e09b94ec233fd.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_191e09b94ec233fd.html
+++ b/public/events/arxiv_191e09b94ec233fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">A Decentralized Approach towards Responsible AI in Social Ecosystems Wenjing Chu Futurewei Technologies, Inc. [email address redacted]    Abstract For AI technology to fulfill its full promises, we must have effective means to ensure Responsible AI behavior and cur-tail potential irresponsible use, e.g., in areas of privacy pro-tection, human autonomy, robustness, and prevention of bi-ases and discrimination in automated decision making. Re-cent literature in the field has identified serious shortcomings of narrow technology focused and formalism-oriented re-search and has proposed an interdisciplinary approach that brings the social context into the scope of study.   In this paper, we take a sociotechnical approach to propose a more expansive framework of thinking about the Responsi-ble AI challenges in both technical and social context. Effec-tive solutions need to bridge the gap between a technical sys-tem with the social system that it will be deployed to. To this end, we propose comp...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_19553eb276e20e1b.html
+++ b/public/events/arxiv_19553eb276e20e1b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_19553eb276e20e1b.html
+++ b/public/events/arxiv_19553eb276e20e1b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1971dfd835458fc8.html
+++ b/public/events/arxiv_1971dfd835458fc8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1971dfd835458fc8.html
+++ b/public/events/arxiv_1971dfd835458fc8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_19783db6de007b65.html
+++ b/public/events/arxiv_19783db6de007b65.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_19783db6de007b65.html
+++ b/public/events/arxiv_19783db6de007b65.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_198b1d3db5f95e27.html
+++ b/public/events/arxiv_198b1d3db5f95e27.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_198b1d3db5f95e27.html
+++ b/public/events/arxiv_198b1d3db5f95e27.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_19f1abcbac7010a1.html
+++ b/public/events/arxiv_19f1abcbac7010a1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_19f1abcbac7010a1.html
+++ b/public/events/arxiv_19f1abcbac7010a1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1a1dc45a67dd7af2.html
+++ b/public/events/arxiv_1a1dc45a67dd7af2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1a1dc45a67dd7af2.html
+++ b/public/events/arxiv_1a1dc45a67dd7af2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1a828311da6c652e.html
+++ b/public/events/arxiv_1a828311da6c652e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1a828311da6c652e.html
+++ b/public/events/arxiv_1a828311da6c652e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1a84b206594ab34b.html
+++ b/public/events/arxiv_1a84b206594ab34b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1a84b206594ab34b.html
+++ b/public/events/arxiv_1a84b206594ab34b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1aa18a5cdb5e7320.html
+++ b/public/events/arxiv_1aa18a5cdb5e7320.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1aa18a5cdb5e7320.html
+++ b/public/events/arxiv_1aa18a5cdb5e7320.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1ae584b18d1d3cb2.html
+++ b/public/events/arxiv_1ae584b18d1d3cb2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1ae584b18d1d3cb2.html
+++ b/public/events/arxiv_1ae584b18d1d3cb2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1aef4c64a68bc52e.html
+++ b/public/events/arxiv_1aef4c64a68bc52e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -453,8 +454,21 @@ In 2012, a team of researchers, led by Geoffrey Hinton, ad-
 vanced the field of computer vision using convolutional neural networks ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1aef4c64a68bc52e.html
+++ b/public/events/arxiv_1aef4c64a68bc52e.html
@@ -458,7 +458,9 @@ vanced the field of computer vision using convolutional neural networks ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -473,7 +475,7 @@ vanced the field of computer vision using convolutional neural networks ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -481,19 +483,19 @@ vanced the field of computer vision using convolutional neural networks ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1b99331610432995.html
+++ b/public/events/arxiv_1b99331610432995.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1b99331610432995.html
+++ b/public/events/arxiv_1b99331610432995.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1ba9a6fd67dca3f8.html
+++ b/public/events/arxiv_1ba9a6fd67dca3f8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1ba9a6fd67dca3f8.html
+++ b/public/events/arxiv_1ba9a6fd67dca3f8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1bb63b4bece57ce3.html
+++ b/public/events/arxiv_1bb63b4bece57ce3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1bb63b4bece57ce3.html
+++ b/public/events/arxiv_1bb63b4bece57ce3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1bf0c3e8c1c8c32b.html
+++ b/public/events/arxiv_1bf0c3e8c1c8c32b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1bf0c3e8c1c8c32b.html
+++ b/public/events/arxiv_1bf0c3e8c1c8c32b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1c1b01ae4d1233f4.html
+++ b/public/events/arxiv_1c1b01ae4d1233f4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1c1b01ae4d1233f4.html
+++ b/public/events/arxiv_1c1b01ae4d1233f4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1cb7117de1a9757a.html
+++ b/public/events/arxiv_1cb7117de1a9757a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1cb7117de1a9757a.html
+++ b/public/events/arxiv_1cb7117de1a9757a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1cf3dc49f86f8b07.html
+++ b/public/events/arxiv_1cf3dc49f86f8b07.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1cf3dc49f86f8b07.html
+++ b/public/events/arxiv_1cf3dc49f86f8b07.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1d2c96ed448dacfc.html
+++ b/public/events/arxiv_1d2c96ed448dacfc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1d2c96ed448dacfc.html
+++ b/public/events/arxiv_1d2c96ed448dacfc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1d30ff2c0b8a1b22.html
+++ b/public/events/arxiv_1d30ff2c0b8a1b22.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1d30ff2c0b8a1b22.html
+++ b/public/events/arxiv_1d30ff2c0b8a1b22.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1d8c98b2b9f9dbab.html
+++ b/public/events/arxiv_1d8c98b2b9f9dbab.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">From What to How: An Initial Review of Publicly Available AI Ethics Tools, Methods and Research to Translate Principles into Practices   Jessica Morley1, Luciano Floridi1,2, Libby Kinsey3, Anat Elhalal3  1 Oxford Internet Institute, University of Oxford, 1 St Giles?, Oxford, OX1 3JS 2 Alan Turing Institute, British Library, 96 Euston Rd, London NW1 2DB 3 Digital Catapult, 101 Euston Road, Kings Cross, London, NW1 2RA  Abstract  The debate about the ethical implications of Artificial Intelligence dates from the 1960s (Samuel, 1960; Wiener, 1961). However, in recent years symbolic AI has been complemented and sometimes replaced by (Deep) Neural Networks and Machine Learning (ML) techniques. This has vastly increased its potential utility and impact on society, with the consequence that the ethical debate has gone mainstream. Such a debate has primarily focused on principles?the ?what? of AI ethics (beneficence, non-maleficence, autonomy, justice and explicability)?rather than on pract...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1d8c98b2b9f9dbab.html
+++ b/public/events/arxiv_1d8c98b2b9f9dbab.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1dbd17639184d9aa.html
+++ b/public/events/arxiv_1dbd17639184d9aa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1dbd17639184d9aa.html
+++ b/public/events/arxiv_1dbd17639184d9aa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1dc156388ea7c94a.html
+++ b/public/events/arxiv_1dc156388ea7c94a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1dc156388ea7c94a.html
+++ b/public/events/arxiv_1dc156388ea7c94a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1dd6134f73afc290.html
+++ b/public/events/arxiv_1dd6134f73afc290.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1dd6134f73afc290.html
+++ b/public/events/arxiv_1dd6134f73afc290.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1e1f88201aaae570.html
+++ b/public/events/arxiv_1e1f88201aaae570.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1e1f88201aaae570.html
+++ b/public/events/arxiv_1e1f88201aaae570.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1e39f0a284624af1.html
+++ b/public/events/arxiv_1e39f0a284624af1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1e39f0a284624af1.html
+++ b/public/events/arxiv_1e39f0a284624af1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1e952d5dd2d90caf.html
+++ b/public/events/arxiv_1e952d5dd2d90caf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1e952d5dd2d90caf.html
+++ b/public/events/arxiv_1e952d5dd2d90caf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1eda22f5f61402fa.html
+++ b/public/events/arxiv_1eda22f5f61402fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1eda22f5f61402fa.html
+++ b/public/events/arxiv_1eda22f5f61402fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1f18fc5bb4cfac98.html
+++ b/public/events/arxiv_1f18fc5bb4cfac98.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1f18fc5bb4cfac98.html
+++ b/public/events/arxiv_1f18fc5bb4cfac98.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_1f79ae6b4d4c0df3.html
+++ b/public/events/arxiv_1f79ae6b4d4c0df3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_1f79ae6b4d4c0df3.html
+++ b/public/events/arxiv_1f79ae6b4d4c0df3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_20004f3f3339a4fd.html
+++ b/public/events/arxiv_20004f3f3339a4fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_20004f3f3339a4fd.html
+++ b/public/events/arxiv_20004f3f3339a4fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2030b02686788da3.html
+++ b/public/events/arxiv_2030b02686788da3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ its specific  geographies.  Semiconductors  are designed, fabricated, and
 deployed through a complex intern...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2030b02686788da3.html
+++ b/public/events/arxiv_2030b02686788da3.html
@@ -452,7 +452,9 @@ deployed through a complex intern...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ deployed through a complex intern...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ deployed through a complex intern...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2034930e8b818514.html
+++ b/public/events/arxiv_2034930e8b818514.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2034930e8b818514.html
+++ b/public/events/arxiv_2034930e8b818514.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_205e847060cffe58.html
+++ b/public/events/arxiv_205e847060cffe58.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_205e847060cffe58.html
+++ b/public/events/arxiv_205e847060cffe58.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_20e257a61198f4b8.html
+++ b/public/events/arxiv_20e257a61198f4b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_20e257a61198f4b8.html
+++ b/public/events/arxiv_20e257a61198f4b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21267b4187d0fc7e.html
+++ b/public/events/arxiv_21267b4187d0fc7e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21267b4187d0fc7e.html
+++ b/public/events/arxiv_21267b4187d0fc7e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_218ce086ce67d573.html
+++ b/public/events/arxiv_218ce086ce67d573.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_218ce086ce67d573.html
+++ b/public/events/arxiv_218ce086ce67d573.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21a3c572c5611388.html
+++ b/public/events/arxiv_21a3c572c5611388.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21a3c572c5611388.html
+++ b/public/events/arxiv_21a3c572c5611388.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21a5d914cfa7094f.html
+++ b/public/events/arxiv_21a5d914cfa7094f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21a5d914cfa7094f.html
+++ b/public/events/arxiv_21a5d914cfa7094f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21e5965ab022e732.html
+++ b/public/events/arxiv_21e5965ab022e732.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21e5965ab022e732.html
+++ b/public/events/arxiv_21e5965ab022e732.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21e9aed4c6db2398.html
+++ b/public/events/arxiv_21e9aed4c6db2398.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21e9aed4c6db2398.html
+++ b/public/events/arxiv_21e9aed4c6db2398.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21f2bad360e8a7d2.html
+++ b/public/events/arxiv_21f2bad360e8a7d2.html
@@ -462,7 +462,9 @@ bilistic price prediction, and near self-...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -477,7 +479,7 @@ bilistic price prediction, and near self-...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -485,19 +487,19 @@ bilistic price prediction, and near self-...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21f2bad360e8a7d2.html
+++ b/public/events/arxiv_21f2bad360e8a7d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -457,8 +458,21 @@ pute approximately optimal bids given a proba-
 bilistic price prediction, and near self-...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_21fe8264295b133a.html
+++ b/public/events/arxiv_21fe8264295b133a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_21fe8264295b133a.html
+++ b/public/events/arxiv_21fe8264295b133a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_226dad31be434c16.html
+++ b/public/events/arxiv_226dad31be434c16.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_226dad31be434c16.html
+++ b/public/events/arxiv_226dad31be434c16.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2294e451ea1f1e52.html
+++ b/public/events/arxiv_2294e451ea1f1e52.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -463,8 +464,21 @@ are hard to interpret, it can be dif ficult to tell whether agents have learned 
 abstraction, or alternatively statistical patterns that are characteristic of t...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2294e451ea1f1e52.html
+++ b/public/events/arxiv_2294e451ea1f1e52.html
@@ -468,7 +468,9 @@ abstraction, or alternatively statistical patterns that are characteristic of t.
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -483,7 +485,7 @@ abstraction, or alternatively statistical patterns that are characteristic of t.
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -491,19 +493,19 @@ abstraction, or alternatively statistical patterns that are characteristic of t.
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_22c9d63fe77ad418.html
+++ b/public/events/arxiv_22c9d63fe77ad418.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_22c9d63fe77ad418.html
+++ b/public/events/arxiv_22c9d63fe77ad418.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_230fb9bb493fe9e0.html
+++ b/public/events/arxiv_230fb9bb493fe9e0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_230fb9bb493fe9e0.html
+++ b/public/events/arxiv_230fb9bb493fe9e0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2315ba0ad7702ea8.html
+++ b/public/events/arxiv_2315ba0ad7702ea8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2315ba0ad7702ea8.html
+++ b/public/events/arxiv_2315ba0ad7702ea8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_231c1c7eb2d22544.html
+++ b/public/events/arxiv_231c1c7eb2d22544.html
@@ -441,7 +441,9 @@ with Neural Networks</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ with Neural Networks</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ with Neural Networks</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_231c1c7eb2d22544.html
+++ b/public/events/arxiv_231c1c7eb2d22544.html
@@ -33,6 +33,7 @@ with Neural Networks | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ with Neural Networks</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_232f0e18dbb9e722.html
+++ b/public/events/arxiv_232f0e18dbb9e722.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_232f0e18dbb9e722.html
+++ b/public/events/arxiv_232f0e18dbb9e722.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_235c017226022315.html
+++ b/public/events/arxiv_235c017226022315.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_235c017226022315.html
+++ b/public/events/arxiv_235c017226022315.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_235d4287bd5bc4f3.html
+++ b/public/events/arxiv_235d4287bd5bc4f3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_235d4287bd5bc4f3.html
+++ b/public/events/arxiv_235d4287bd5bc4f3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_23e75d98b422f570.html
+++ b/public/events/arxiv_23e75d98b422f570.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_23e75d98b422f570.html
+++ b/public/events/arxiv_23e75d98b422f570.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_24008e5ce4a89c6c.html
+++ b/public/events/arxiv_24008e5ce4a89c6c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ ral network that can solve an auxiliary task such as MNIST
 image classi?cation. We observe that th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_24008e5ce4a89c6c.html
+++ b/public/events/arxiv_24008e5ce4a89c6c.html
@@ -455,7 +455,9 @@ image classi?cation. We observe that th...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ image classi?cation. We observe that th...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ image classi?cation. We observe that th...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2409da6d09cd4302.html
+++ b/public/events/arxiv_2409da6d09cd4302.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2409da6d09cd4302.html
+++ b/public/events/arxiv_2409da6d09cd4302.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_241a89b020f41ca2.html
+++ b/public/events/arxiv_241a89b020f41ca2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_241a89b020f41ca2.html
+++ b/public/events/arxiv_241a89b020f41ca2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_24824a8aca1cb4f1.html
+++ b/public/events/arxiv_24824a8aca1cb4f1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_24824a8aca1cb4f1.html
+++ b/public/events/arxiv_24824a8aca1cb4f1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_259e8b768252584d.html
+++ b/public/events/arxiv_259e8b768252584d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ to the expert action, tuned to balance exploration and
 exploitation. The utility of this ap...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_259e8b768252584d.html
+++ b/public/events/arxiv_259e8b768252584d.html
@@ -453,7 +453,9 @@ exploitation. The utility of this ap...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ exploitation. The utility of this ap...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ exploitation. The utility of this ap...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_25cf381fb83a38b6.html
+++ b/public/events/arxiv_25cf381fb83a38b6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_25cf381fb83a38b6.html
+++ b/public/events/arxiv_25cf381fb83a38b6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_26323c8f3a2e6509.html
+++ b/public/events/arxiv_26323c8f3a2e6509.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_26323c8f3a2e6509.html
+++ b/public/events/arxiv_26323c8f3a2e6509.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2645dbafdafd63d5.html
+++ b/public/events/arxiv_2645dbafdafd63d5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2645dbafdafd63d5.html
+++ b/public/events/arxiv_2645dbafdafd63d5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_26679affba27c265.html
+++ b/public/events/arxiv_26679affba27c265.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_26679affba27c265.html
+++ b/public/events/arxiv_26679affba27c265.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_266a1fefecfd5b20.html
+++ b/public/events/arxiv_266a1fefecfd5b20.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_266a1fefecfd5b20.html
+++ b/public/events/arxiv_266a1fefecfd5b20.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">1 Challenges for an Ontology of Artificial Intelligence Scott H. Hawley Department of Chemistry &amp; Physics, Belmont University, Nashville TN USA   Abstract: Of primary importance in formulating a response to the increasing prevalence and power of artificial intelligence (AI) applications in society are questions of ontology. Questions such as: What ?are? these systems?  How are they to be regarded?  How does an algorithm come to be regarded as an agent?  We discuss three factors which hinder discussion and obscure attempts to form a clear ontology of AI: (1) the various and evolving definitions of AI, (2) the tendency for pre-existing technologies to be assimilated and regarded as ?normal,? and (3) the tendency of human beings to anthropomorphize.  This list is not intended as exhaustive, nor is it seen to preclude entirely a clear ontology, however, these challenges are a necessary set of topics for consideration.  Each of these factors is seen to present a 'moving target' for discu...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_267f825a372778dc.html
+++ b/public/events/arxiv_267f825a372778dc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_267f825a372778dc.html
+++ b/public/events/arxiv_267f825a372778dc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2693c7142eae6286.html
+++ b/public/events/arxiv_2693c7142eae6286.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2693c7142eae6286.html
+++ b/public/events/arxiv_2693c7142eae6286.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_26a97802b8567bca.html
+++ b/public/events/arxiv_26a97802b8567bca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_26a97802b8567bca.html
+++ b/public/events/arxiv_26a97802b8567bca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_26e147e49fc695c9.html
+++ b/public/events/arxiv_26e147e49fc695c9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_26e147e49fc695c9.html
+++ b/public/events/arxiv_26e147e49fc695c9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_26f49ad8f2b64b02.html
+++ b/public/events/arxiv_26f49ad8f2b64b02.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_26f49ad8f2b64b02.html
+++ b/public/events/arxiv_26f49ad8f2b64b02.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2715c5be751ae5c0.html
+++ b/public/events/arxiv_2715c5be751ae5c0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2715c5be751ae5c0.html
+++ b/public/events/arxiv_2715c5be751ae5c0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2731015320ee6b20.html
+++ b/public/events/arxiv_2731015320ee6b20.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2731015320ee6b20.html
+++ b/public/events/arxiv_2731015320ee6b20.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_274e0974fa7ce720.html
+++ b/public/events/arxiv_274e0974fa7ce720.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_274e0974fa7ce720.html
+++ b/public/events/arxiv_274e0974fa7ce720.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_27c6059e550e8ff6.html
+++ b/public/events/arxiv_27c6059e550e8ff6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_27c6059e550e8ff6.html
+++ b/public/events/arxiv_27c6059e550e8ff6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2831a92843a5e489.html
+++ b/public/events/arxiv_2831a92843a5e489.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2831a92843a5e489.html
+++ b/public/events/arxiv_2831a92843a5e489.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_285e08b9eeca3f26.html
+++ b/public/events/arxiv_285e08b9eeca3f26.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_285e08b9eeca3f26.html
+++ b/public/events/arxiv_285e08b9eeca3f26.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2869e3c18f717d28.html
+++ b/public/events/arxiv_2869e3c18f717d28.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2869e3c18f717d28.html
+++ b/public/events/arxiv_2869e3c18f717d28.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_28785e694de9fb37.html
+++ b/public/events/arxiv_28785e694de9fb37.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_28785e694de9fb37.html
+++ b/public/events/arxiv_28785e694de9fb37.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_28dfb02c5189ee73.html
+++ b/public/events/arxiv_28dfb02c5189ee73.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_28dfb02c5189ee73.html
+++ b/public/events/arxiv_28dfb02c5189ee73.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_294dc6a8d1cbb403.html
+++ b/public/events/arxiv_294dc6a8d1cbb403.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_294dc6a8d1cbb403.html
+++ b/public/events/arxiv_294dc6a8d1cbb403.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_29912d5e770917b0.html
+++ b/public/events/arxiv_29912d5e770917b0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_29912d5e770917b0.html
+++ b/public/events/arxiv_29912d5e770917b0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2a755dc71d8b939c.html
+++ b/public/events/arxiv_2a755dc71d8b939c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2a755dc71d8b939c.html
+++ b/public/events/arxiv_2a755dc71d8b939c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2a9728dfa4edd6fd.html
+++ b/public/events/arxiv_2a9728dfa4edd6fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2a9728dfa4edd6fd.html
+++ b/public/events/arxiv_2a9728dfa4edd6fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2aa314412da90693.html
+++ b/public/events/arxiv_2aa314412da90693.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2aa314412da90693.html
+++ b/public/events/arxiv_2aa314412da90693.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2ad044ccbe86ca04.html
+++ b/public/events/arxiv_2ad044ccbe86ca04.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2ad044ccbe86ca04.html
+++ b/public/events/arxiv_2ad044ccbe86ca04.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2b4f7f998245e241.html
+++ b/public/events/arxiv_2b4f7f998245e241.html
@@ -472,7 +472,9 @@ at echelons of battalion and below.
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -487,7 +489,7 @@ at echelons of battalion and below.
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -495,19 +497,19 @@ at echelons of battalion and below.
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2b4f7f998245e241.html
+++ b/public/events/arxiv_2b4f7f998245e241.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -467,8 +468,21 @@ at echelons of battalion and below.
  The RAID program leverages approximate game-theore...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2bc37a9bb4a99905.html
+++ b/public/events/arxiv_2bc37a9bb4a99905.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2bc37a9bb4a99905.html
+++ b/public/events/arxiv_2bc37a9bb4a99905.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2be3bbe1029a6ad6.html
+++ b/public/events/arxiv_2be3bbe1029a6ad6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2be3bbe1029a6ad6.html
+++ b/public/events/arxiv_2be3bbe1029a6ad6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2c321a00435b902b.html
+++ b/public/events/arxiv_2c321a00435b902b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2c321a00435b902b.html
+++ b/public/events/arxiv_2c321a00435b902b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2cc6d95d810cf3d7.html
+++ b/public/events/arxiv_2cc6d95d810cf3d7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2cc6d95d810cf3d7.html
+++ b/public/events/arxiv_2cc6d95d810cf3d7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2cca17ac0cccda95.html
+++ b/public/events/arxiv_2cca17ac0cccda95.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2cca17ac0cccda95.html
+++ b/public/events/arxiv_2cca17ac0cccda95.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2cddd5559522d630.html
+++ b/public/events/arxiv_2cddd5559522d630.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2cddd5559522d630.html
+++ b/public/events/arxiv_2cddd5559522d630.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d0f8fbf5aa49155.html
+++ b/public/events/arxiv_2d0f8fbf5aa49155.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d0f8fbf5aa49155.html
+++ b/public/events/arxiv_2d0f8fbf5aa49155.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d5fd096432bd8b9.html
+++ b/public/events/arxiv_2d5fd096432bd8b9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d5fd096432bd8b9.html
+++ b/public/events/arxiv_2d5fd096432bd8b9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d77f5b7adcea3e2.html
+++ b/public/events/arxiv_2d77f5b7adcea3e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d77f5b7adcea3e2.html
+++ b/public/events/arxiv_2d77f5b7adcea3e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d7d2d0004b78667.html
+++ b/public/events/arxiv_2d7d2d0004b78667.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d7d2d0004b78667.html
+++ b/public/events/arxiv_2d7d2d0004b78667.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d7eb828d04a7c93.html
+++ b/public/events/arxiv_2d7eb828d04a7c93.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d7eb828d04a7c93.html
+++ b/public/events/arxiv_2d7eb828d04a7c93.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2d9e86d8bb50bdb3.html
+++ b/public/events/arxiv_2d9e86d8bb50bdb3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2d9e86d8bb50bdb3.html
+++ b/public/events/arxiv_2d9e86d8bb50bdb3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2da04dc77304832b.html
+++ b/public/events/arxiv_2da04dc77304832b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2da04dc77304832b.html
+++ b/public/events/arxiv_2da04dc77304832b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2da411f3489c10cb.html
+++ b/public/events/arxiv_2da411f3489c10cb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ Xiang Lisa Li Xuechen Li Tengyu Ma Ali Malik Christopher D. Manning
 Suvir Mirchandani Eric Mitchell Zanele Munyikwa ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2da411f3489c10cb.html
+++ b/public/events/arxiv_2da411f3489c10cb.html
@@ -451,7 +451,9 @@ Suvir Mirchandani Eric Mitchell Zanele Munyikwa ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ Suvir Mirchandani Eric Mitchell Zanele Munyikwa ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ Suvir Mirchandani Eric Mitchell Zanele Munyikwa ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2ddfc52c8f61abd0.html
+++ b/public/events/arxiv_2ddfc52c8f61abd0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2ddfc52c8f61abd0.html
+++ b/public/events/arxiv_2ddfc52c8f61abd0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2e13a5b9014cb671.html
+++ b/public/events/arxiv_2e13a5b9014cb671.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2e13a5b9014cb671.html
+++ b/public/events/arxiv_2e13a5b9014cb671.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2e2b27a6cd1a3469.html
+++ b/public/events/arxiv_2e2b27a6cd1a3469.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2e2b27a6cd1a3469.html
+++ b/public/events/arxiv_2e2b27a6cd1a3469.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2e751e13428ed9ea.html
+++ b/public/events/arxiv_2e751e13428ed9ea.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2e751e13428ed9ea.html
+++ b/public/events/arxiv_2e751e13428ed9ea.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2e8b186e1b754281.html
+++ b/public/events/arxiv_2e8b186e1b754281.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2e8b186e1b754281.html
+++ b/public/events/arxiv_2e8b186e1b754281.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2f05d4ecf6a6e80f.html
+++ b/public/events/arxiv_2f05d4ecf6a6e80f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2f05d4ecf6a6e80f.html
+++ b/public/events/arxiv_2f05d4ecf6a6e80f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2f21646ae78f5f10.html
+++ b/public/events/arxiv_2f21646ae78f5f10.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2f21646ae78f5f10.html
+++ b/public/events/arxiv_2f21646ae78f5f10.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2fa1b68cb500bcd1.html
+++ b/public/events/arxiv_2fa1b68cb500bcd1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2fa1b68cb500bcd1.html
+++ b/public/events/arxiv_2fa1b68cb500bcd1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2fd3950d429dc65a.html
+++ b/public/events/arxiv_2fd3950d429dc65a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2fd3950d429dc65a.html
+++ b/public/events/arxiv_2fd3950d429dc65a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2fd7f04f95ad5171.html
+++ b/public/events/arxiv_2fd7f04f95ad5171.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2fd7f04f95ad5171.html
+++ b/public/events/arxiv_2fd7f04f95ad5171.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2fe8faa00c606c51.html
+++ b/public/events/arxiv_2fe8faa00c606c51.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2fe8faa00c606c51.html
+++ b/public/events/arxiv_2fe8faa00c606c51.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_2ff079707f380773.html
+++ b/public/events/arxiv_2ff079707f380773.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_2ff079707f380773.html
+++ b/public/events/arxiv_2ff079707f380773.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_301c7ed4b11f8ec0.html
+++ b/public/events/arxiv_301c7ed4b11f8ec0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_301c7ed4b11f8ec0.html
+++ b/public/events/arxiv_301c7ed4b11f8ec0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30334862e967a234.html
+++ b/public/events/arxiv_30334862e967a234.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30334862e967a234.html
+++ b/public/events/arxiv_30334862e967a234.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30993e4d225c1820.html
+++ b/public/events/arxiv_30993e4d225c1820.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30993e4d225c1820.html
+++ b/public/events/arxiv_30993e4d225c1820.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30a2c9b450475104.html
+++ b/public/events/arxiv_30a2c9b450475104.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30a2c9b450475104.html
+++ b/public/events/arxiv_30a2c9b450475104.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30ab055e127baef8.html
+++ b/public/events/arxiv_30ab055e127baef8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30ab055e127baef8.html
+++ b/public/events/arxiv_30ab055e127baef8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30d197f2abc4241f.html
+++ b/public/events/arxiv_30d197f2abc4241f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30d197f2abc4241f.html
+++ b/public/events/arxiv_30d197f2abc4241f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_30f1a7a1789ef924.html
+++ b/public/events/arxiv_30f1a7a1789ef924.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_30f1a7a1789ef924.html
+++ b/public/events/arxiv_30f1a7a1789ef924.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_311e5bef699a0916.html
+++ b/public/events/arxiv_311e5bef699a0916.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_311e5bef699a0916.html
+++ b/public/events/arxiv_311e5bef699a0916.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_315b5d43a0d58bb6.html
+++ b/public/events/arxiv_315b5d43a0d58bb6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_315b5d43a0d58bb6.html
+++ b/public/events/arxiv_315b5d43a0d58bb6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_319dc219983bf377.html
+++ b/public/events/arxiv_319dc219983bf377.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_319dc219983bf377.html
+++ b/public/events/arxiv_319dc219983bf377.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_31a5fe3f499ab05b.html
+++ b/public/events/arxiv_31a5fe3f499ab05b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_31a5fe3f499ab05b.html
+++ b/public/events/arxiv_31a5fe3f499ab05b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_32193b4c5013c697.html
+++ b/public/events/arxiv_32193b4c5013c697.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_32193b4c5013c697.html
+++ b/public/events/arxiv_32193b4c5013c697.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3220cd2617965b93.html
+++ b/public/events/arxiv_3220cd2617965b93.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3220cd2617965b93.html
+++ b/public/events/arxiv_3220cd2617965b93.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_334413a1e3315407.html
+++ b/public/events/arxiv_334413a1e3315407.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_334413a1e3315407.html
+++ b/public/events/arxiv_334413a1e3315407.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_342c6984900004ff.html
+++ b/public/events/arxiv_342c6984900004ff.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_342c6984900004ff.html
+++ b/public/events/arxiv_342c6984900004ff.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_347aeee287686933.html
+++ b/public/events/arxiv_347aeee287686933.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_347aeee287686933.html
+++ b/public/events/arxiv_347aeee287686933.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_349b721fcb4e01ce.html
+++ b/public/events/arxiv_349b721fcb4e01ce.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_349b721fcb4e01ce.html
+++ b/public/events/arxiv_349b721fcb4e01ce.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_34d8f5ef5275a7d8.html
+++ b/public/events/arxiv_34d8f5ef5275a7d8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_34d8f5ef5275a7d8.html
+++ b/public/events/arxiv_34d8f5ef5275a7d8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3507b1dfd2ca4512.html
+++ b/public/events/arxiv_3507b1dfd2ca4512.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3507b1dfd2ca4512.html
+++ b/public/events/arxiv_3507b1dfd2ca4512.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3514608b30257527.html
+++ b/public/events/arxiv_3514608b30257527.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3514608b30257527.html
+++ b/public/events/arxiv_3514608b30257527.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_352fdb904551171a.html
+++ b/public/events/arxiv_352fdb904551171a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_352fdb904551171a.html
+++ b/public/events/arxiv_352fdb904551171a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_357c9172db62c1a5.html
+++ b/public/events/arxiv_357c9172db62c1a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_357c9172db62c1a5.html
+++ b/public/events/arxiv_357c9172db62c1a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3585f4371df3bbed.html
+++ b/public/events/arxiv_3585f4371df3bbed.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3585f4371df3bbed.html
+++ b/public/events/arxiv_3585f4371df3bbed.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_36050c782f2880a8.html
+++ b/public/events/arxiv_36050c782f2880a8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_36050c782f2880a8.html
+++ b/public/events/arxiv_36050c782f2880a8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_361d1c2119b692fd.html
+++ b/public/events/arxiv_361d1c2119b692fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_361d1c2119b692fd.html
+++ b/public/events/arxiv_361d1c2119b692fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_36215638a79b3cec.html
+++ b/public/events/arxiv_36215638a79b3cec.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_36215638a79b3cec.html
+++ b/public/events/arxiv_36215638a79b3cec.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3625591de24ea616.html
+++ b/public/events/arxiv_3625591de24ea616.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3625591de24ea616.html
+++ b/public/events/arxiv_3625591de24ea616.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3673d000a2f561d4.html
+++ b/public/events/arxiv_3673d000a2f561d4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3673d000a2f561d4.html
+++ b/public/events/arxiv_3673d000a2f561d4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_36c9d30e5926d515.html
+++ b/public/events/arxiv_36c9d30e5926d515.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_36c9d30e5926d515.html
+++ b/public/events/arxiv_36c9d30e5926d515.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_378d3427c0ffac74.html
+++ b/public/events/arxiv_378d3427c0ffac74.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_378d3427c0ffac74.html
+++ b/public/events/arxiv_378d3427c0ffac74.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_37c071c07d3ab37d.html
+++ b/public/events/arxiv_37c071c07d3ab37d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ pathologists or be used for disease screening. The whole slide pathological imag
 can reach one gigapixel and contains abundant tissue feature information, whic...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_37c071c07d3ab37d.html
+++ b/public/events/arxiv_37c071c07d3ab37d.html
@@ -451,7 +451,9 @@ can reach one gigapixel and contains abundant tissue feature information, whic..
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ can reach one gigapixel and contains abundant tissue feature information, whic..
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ can reach one gigapixel and contains abundant tissue feature information, whic..
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_37dde144c26b9e56.html
+++ b/public/events/arxiv_37dde144c26b9e56.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_37dde144c26b9e56.html
+++ b/public/events/arxiv_37dde144c26b9e56.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_37ebf1f6d3262bef.html
+++ b/public/events/arxiv_37ebf1f6d3262bef.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_37ebf1f6d3262bef.html
+++ b/public/events/arxiv_37ebf1f6d3262bef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_380bb59b80887c6e.html
+++ b/public/events/arxiv_380bb59b80887c6e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_380bb59b80887c6e.html
+++ b/public/events/arxiv_380bb59b80887c6e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_38262fb2240896fa.html
+++ b/public/events/arxiv_38262fb2240896fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_38262fb2240896fa.html
+++ b/public/events/arxiv_38262fb2240896fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_386e990bbee71f34.html
+++ b/public/events/arxiv_386e990bbee71f34.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_386e990bbee71f34.html
+++ b/public/events/arxiv_386e990bbee71f34.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3887e5490a7a9880.html
+++ b/public/events/arxiv_3887e5490a7a9880.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3887e5490a7a9880.html
+++ b/public/events/arxiv_3887e5490a7a9880.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_38b411043c9d563e.html
+++ b/public/events/arxiv_38b411043c9d563e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_38b411043c9d563e.html
+++ b/public/events/arxiv_38b411043c9d563e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_38dcb38fbe42141d.html
+++ b/public/events/arxiv_38dcb38fbe42141d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_38dcb38fbe42141d.html
+++ b/public/events/arxiv_38dcb38fbe42141d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_393a7a93bd7a4f33.html
+++ b/public/events/arxiv_393a7a93bd7a4f33.html
@@ -453,7 +453,9 @@ Kronecker-Factored App...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ Kronecker-Factored App...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ Kronecker-Factored App...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_393a7a93bd7a4f33.html
+++ b/public/events/arxiv_393a7a93bd7a4f33.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ of computing an inverse-Hessian-vector product (IHVP). We use the Eigenvalue-cor
 Kronecker-Factored App...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_393de4ce26114b76.html
+++ b/public/events/arxiv_393de4ce26114b76.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_393de4ce26114b76.html
+++ b/public/events/arxiv_393de4ce26114b76.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3983b42c3f367b5a.html
+++ b/public/events/arxiv_3983b42c3f367b5a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3983b42c3f367b5a.html
+++ b/public/events/arxiv_3983b42c3f367b5a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_398f8d39b2bd93d7.html
+++ b/public/events/arxiv_398f8d39b2bd93d7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ and the general public to develop a more thorough and nuanced understanding of t
 aims to be the world?s most...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_398f8d39b2bd93d7.html
+++ b/public/events/arxiv_398f8d39b2bd93d7.html
@@ -451,7 +451,9 @@ aims to be the world?s most...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ aims to be the world?s most...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ aims to be the world?s most...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_399d1e79027dcec2.html
+++ b/public/events/arxiv_399d1e79027dcec2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_399d1e79027dcec2.html
+++ b/public/events/arxiv_399d1e79027dcec2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_39c7fd0f423aa003.html
+++ b/public/events/arxiv_39c7fd0f423aa003.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -519,8 +520,21 @@ of Law , Information Law ,
 Un...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_39c7fd0f423aa003.html
+++ b/public/events/arxiv_39c7fd0f423aa003.html
@@ -524,7 +524,9 @@ Un...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -539,7 +541,7 @@ Un...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -547,19 +549,19 @@ Un...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_39f0309e9578100d.html
+++ b/public/events/arxiv_39f0309e9578100d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_39f0309e9578100d.html
+++ b/public/events/arxiv_39f0309e9578100d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3a5dfe29a457d0e7.html
+++ b/public/events/arxiv_3a5dfe29a457d0e7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3a5dfe29a457d0e7.html
+++ b/public/events/arxiv_3a5dfe29a457d0e7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3a9a29b53f0b3b7e.html
+++ b/public/events/arxiv_3a9a29b53f0b3b7e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3a9a29b53f0b3b7e.html
+++ b/public/events/arxiv_3a9a29b53f0b3b7e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3aad3548ca62dc4d.html
+++ b/public/events/arxiv_3aad3548ca62dc4d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3aad3548ca62dc4d.html
+++ b/public/events/arxiv_3aad3548ca62dc4d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3b0031dba3084f2e.html
+++ b/public/events/arxiv_3b0031dba3084f2e.html
@@ -441,7 +441,9 @@ with Adversarial Neural Cryptography</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ with Adversarial Neural Cryptography</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ with Adversarial Neural Cryptography</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3b0031dba3084f2e.html
+++ b/public/events/arxiv_3b0031dba3084f2e.html
@@ -33,6 +33,7 @@ with Adversarial Neural Cryptography | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ with Adversarial Neural Cryptography</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3b8e895af2010f42.html
+++ b/public/events/arxiv_3b8e895af2010f42.html
@@ -454,7 +454,9 @@ improved ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ improved ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ improved ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3b8e895af2010f42.html
+++ b/public/events/arxiv_3b8e895af2010f42.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ while constraining the probability of failure. We demonstrate
 improved ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3bc060c075113a3a.html
+++ b/public/events/arxiv_3bc060c075113a3a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3bc060c075113a3a.html
+++ b/public/events/arxiv_3bc060c075113a3a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3c7ec65d65c78749.html
+++ b/public/events/arxiv_3c7ec65d65c78749.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3c7ec65d65c78749.html
+++ b/public/events/arxiv_3c7ec65d65c78749.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3d1babdf4c394570.html
+++ b/public/events/arxiv_3d1babdf4c394570.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3d1babdf4c394570.html
+++ b/public/events/arxiv_3d1babdf4c394570.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3d2e35721e7e6af2.html
+++ b/public/events/arxiv_3d2e35721e7e6af2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3d2e35721e7e6af2.html
+++ b/public/events/arxiv_3d2e35721e7e6af2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3d6bfae31f2f8bec.html
+++ b/public/events/arxiv_3d6bfae31f2f8bec.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3d6bfae31f2f8bec.html
+++ b/public/events/arxiv_3d6bfae31f2f8bec.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3d733b9f6a6b6091.html
+++ b/public/events/arxiv_3d733b9f6a6b6091.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3d733b9f6a6b6091.html
+++ b/public/events/arxiv_3d733b9f6a6b6091.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3d78f1acd91ad10a.html
+++ b/public/events/arxiv_3d78f1acd91ad10a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3d78f1acd91ad10a.html
+++ b/public/events/arxiv_3d78f1acd91ad10a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3df04342ed5b89b2.html
+++ b/public/events/arxiv_3df04342ed5b89b2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3df04342ed5b89b2.html
+++ b/public/events/arxiv_3df04342ed5b89b2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3dfc5c5b2dbf412a.html
+++ b/public/events/arxiv_3dfc5c5b2dbf412a.html
@@ -453,7 +453,9 @@ In the last...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ In the last...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ In the last...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3dfc5c5b2dbf412a.html
+++ b/public/events/arxiv_3dfc5c5b2dbf412a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ Introduction
 In the last...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3e08a4bd71197293.html
+++ b/public/events/arxiv_3e08a4bd71197293.html
@@ -455,7 +455,9 @@ antitrust vigilance lifecycle  to which AI is predic...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ antitrust vigilance lifecycle  to which AI is predic...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ antitrust vigilance lifecycle  to which AI is predic...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3e08a4bd71197293.html
+++ b/public/events/arxiv_3e08a4bd71197293.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ application of AI to antitrust and establishes a n
 antitrust vigilance lifecycle  to which AI is predic...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f1c98bc443cac76.html
+++ b/public/events/arxiv_3f1c98bc443cac76.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ The 2021 report shows the effects of COVID-19 on AI
 development from multiple perspectives. The Technic...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f1c98bc443cac76.html
+++ b/public/events/arxiv_3f1c98bc443cac76.html
@@ -459,7 +459,9 @@ development from multiple perspectives. The Technic...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ development from multiple perspectives. The Technic...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ development from multiple perspectives. The Technic...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f2a112d14cc4080.html
+++ b/public/events/arxiv_3f2a112d14cc4080.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f2a112d14cc4080.html
+++ b/public/events/arxiv_3f2a112d14cc4080.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f342b07edb81627.html
+++ b/public/events/arxiv_3f342b07edb81627.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f342b07edb81627.html
+++ b/public/events/arxiv_3f342b07edb81627.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f4254f317701007.html
+++ b/public/events/arxiv_3f4254f317701007.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f4254f317701007.html
+++ b/public/events/arxiv_3f4254f317701007.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f5d47ddec0cbf30.html
+++ b/public/events/arxiv_3f5d47ddec0cbf30.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f5d47ddec0cbf30.html
+++ b/public/events/arxiv_3f5d47ddec0cbf30.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3f7138172c933108.html
+++ b/public/events/arxiv_3f7138172c933108.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3f7138172c933108.html
+++ b/public/events/arxiv_3f7138172c933108.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_3ff44c4c933a57fc.html
+++ b/public/events/arxiv_3ff44c4c933a57fc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_3ff44c4c933a57fc.html
+++ b/public/events/arxiv_3ff44c4c933a57fc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_40199422e213e467.html
+++ b/public/events/arxiv_40199422e213e467.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_40199422e213e467.html
+++ b/public/events/arxiv_40199422e213e467.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_402f917ef1f85b47.html
+++ b/public/events/arxiv_402f917ef1f85b47.html
@@ -452,7 +452,9 @@ understanding human self -regulation and go...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ understanding human self -regulation and go...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ understanding human self -regulation and go...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_402f917ef1f85b47.html
+++ b/public/events/arxiv_402f917ef1f85b47.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ intelligent agents that have avoided these problems and t he present manuscript 
 understanding human self -regulation and go...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_407a89d50dd6ff35.html
+++ b/public/events/arxiv_407a89d50dd6ff35.html
@@ -455,7 +455,9 @@ Government may violate any copyrights that exist in th...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ Government may violate any copyrights that exist in th...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ Government may violate any copyrights that exist in th...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_407a89d50dd6ff35.html
+++ b/public/events/arxiv_407a89d50dd6ff35.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ as detailed above. Use of this work other than as specically authorized by the 
 Government may violate any copyrights that exist in th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_408fdf74dfa3936a.html
+++ b/public/events/arxiv_408fdf74dfa3936a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_408fdf74dfa3936a.html
+++ b/public/events/arxiv_408fdf74dfa3936a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_40981833e4aac1ab.html
+++ b/public/events/arxiv_40981833e4aac1ab.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_40981833e4aac1ab.html
+++ b/public/events/arxiv_40981833e4aac1ab.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_40adcd148ad64c63.html
+++ b/public/events/arxiv_40adcd148ad64c63.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -451,8 +452,21 @@ Published on September 1, 2016, the first report was
 covered widely in the popular press and is...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_40adcd148ad64c63.html
+++ b/public/events/arxiv_40adcd148ad64c63.html
@@ -456,7 +456,9 @@ covered widely in the popular press and is...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -471,7 +473,7 @@ covered widely in the popular press and is...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -479,19 +481,19 @@ covered widely in the popular press and is...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_40b8cefc2fc84f5a.html
+++ b/public/events/arxiv_40b8cefc2fc84f5a.html
@@ -448,7 +448,9 @@ C/o.sc/m.sc/p.sc/u.sc/t.sc/e.sc/r.sc S/c.sc/i.sc/e.sc/n.sc/...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -463,7 +465,7 @@ C/o.sc/m.sc/p.sc/u.sc/t.sc/e.sc/r.sc S/c.sc/i.sc/e.sc/n.sc/...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -471,19 +473,19 @@ C/o.sc/m.sc/p.sc/u.sc/t.sc/e.sc/r.sc S/c.sc/i.sc/e.sc/n.sc/...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_40b8cefc2fc84f5a.html
+++ b/public/events/arxiv_40b8cefc2fc84f5a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -443,8 +444,21 @@ D/o.sc/c.sc/t.sc/o.sc/r.sc /o.sc/f.sc P/h.sc/i.sc/l.sc/o.sc/s.sc/o.sc/p.sc/h.sc/
 C/o.sc/m.sc/p.sc/u.sc/t.sc/e.sc/r.sc S/c.sc/i.sc/e.sc/n.sc/...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_411295d672508f93.html
+++ b/public/events/arxiv_411295d672508f93.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_411295d672508f93.html
+++ b/public/events/arxiv_411295d672508f93.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 1.1 Information Modeling and Deep Learning</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_41880a502afdcb9f.html
+++ b/public/events/arxiv_41880a502afdcb9f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_41880a502afdcb9f.html
+++ b/public/events/arxiv_41880a502afdcb9f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_41bc4ce3496b2fe9.html
+++ b/public/events/arxiv_41bc4ce3496b2fe9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_41bc4ce3496b2fe9.html
+++ b/public/events/arxiv_41bc4ce3496b2fe9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_41f01220cbd1248e.html
+++ b/public/events/arxiv_41f01220cbd1248e.html
@@ -451,7 +451,9 @@ proposed EU AI Act, we tentatively conclude that b...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ proposed EU AI Act, we tentatively conclude that b...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ proposed EU AI Act, we tentatively conclude that b...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_41f01220cbd1248e.html
+++ b/public/events/arxiv_41f01220cbd1248e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ will influence regulation adopted by other jurisdictions (a de jure Brussels Eff
 proposed EU AI Act, we tentatively conclude that b...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_42153d4c6fb5d1f9.html
+++ b/public/events/arxiv_42153d4c6fb5d1f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_42153d4c6fb5d1f9.html
+++ b/public/events/arxiv_42153d4c6fb5d1f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_423dcda046865535.html
+++ b/public/events/arxiv_423dcda046865535.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_423dcda046865535.html
+++ b/public/events/arxiv_423dcda046865535.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_424bac6c22c04486.html
+++ b/public/events/arxiv_424bac6c22c04486.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_424bac6c22c04486.html
+++ b/public/events/arxiv_424bac6c22c04486.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_42706567777fd6de.html
+++ b/public/events/arxiv_42706567777fd6de.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_42706567777fd6de.html
+++ b/public/events/arxiv_42706567777fd6de.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_42b5c7670cdc45c0.html
+++ b/public/events/arxiv_42b5c7670cdc45c0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_42b5c7670cdc45c0.html
+++ b/public/events/arxiv_42b5c7670cdc45c0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_42e2a4ce0af6455a.html
+++ b/public/events/arxiv_42e2a4ce0af6455a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_42e2a4ce0af6455a.html
+++ b/public/events/arxiv_42e2a4ce0af6455a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_42fe28637dfe7730.html
+++ b/public/events/arxiv_42fe28637dfe7730.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_42fe28637dfe7730.html
+++ b/public/events/arxiv_42fe28637dfe7730.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_436ef00c5c5fad81.html
+++ b/public/events/arxiv_436ef00c5c5fad81.html
@@ -33,6 +33,7 @@ Reverse Engineering How Networks Learn Group Operations | p(Doom)1 Events</title
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ Reverse Engineering How Networks Learn Group Operations</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_436ef00c5c5fad81.html
+++ b/public/events/arxiv_436ef00c5c5fad81.html
@@ -441,7 +441,9 @@ Reverse Engineering How Networks Learn Group Operations</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ Reverse Engineering How Networks Learn Group Operations</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ Reverse Engineering How Networks Learn Group Operations</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4383a47169e01d45.html
+++ b/public/events/arxiv_4383a47169e01d45.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4383a47169e01d45.html
+++ b/public/events/arxiv_4383a47169e01d45.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_43da39bb4352078c.html
+++ b/public/events/arxiv_43da39bb4352078c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_43da39bb4352078c.html
+++ b/public/events/arxiv_43da39bb4352078c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_43f3d019e5a786f9.html
+++ b/public/events/arxiv_43f3d019e5a786f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_43f3d019e5a786f9.html
+++ b/public/events/arxiv_43f3d019e5a786f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_441024d88860cc55.html
+++ b/public/events/arxiv_441024d88860cc55.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -455,8 +456,21 @@ Our approach is based on the inductive conformal anomaly
 detection...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_441024d88860cc55.html
+++ b/public/events/arxiv_441024d88860cc55.html
@@ -460,7 +460,9 @@ detection...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -475,7 +477,7 @@ detection...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -483,19 +485,19 @@ detection...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_44220c5f671b2e28.html
+++ b/public/events/arxiv_44220c5f671b2e28.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_44220c5f671b2e28.html
+++ b/public/events/arxiv_44220c5f671b2e28.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_44744bf31057f3d2.html
+++ b/public/events/arxiv_44744bf31057f3d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_44744bf31057f3d2.html
+++ b/public/events/arxiv_44744bf31057f3d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_44bc639cf9816b05.html
+++ b/public/events/arxiv_44bc639cf9816b05.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_44bc639cf9816b05.html
+++ b/public/events/arxiv_44bc639cf9816b05.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_44db885f14f4567f.html
+++ b/public/events/arxiv_44db885f14f4567f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_44db885f14f4567f.html
+++ b/public/events/arxiv_44db885f14f4567f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_455b444cf51f7bbd.html
+++ b/public/events/arxiv_455b444cf51f7bbd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_455b444cf51f7bbd.html
+++ b/public/events/arxiv_455b444cf51f7bbd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_45bb5f743065a655.html
+++ b/public/events/arxiv_45bb5f743065a655.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_45bb5f743065a655.html
+++ b/public/events/arxiv_45bb5f743065a655.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_45ed72f40204d0db.html
+++ b/public/events/arxiv_45ed72f40204d0db.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -441,8 +442,21 @@ BOOK #1
 Version: V4.1</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_45ed72f40204d0db.html
+++ b/public/events/arxiv_45ed72f40204d0db.html
@@ -446,7 +446,9 @@ Version: V4.1</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -461,7 +463,7 @@ Version: V4.1</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -469,19 +471,19 @@ Version: V4.1</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_45fa4bad8ce1fd79.html
+++ b/public/events/arxiv_45fa4bad8ce1fd79.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ risk models. Relational and algebraic properties are inves tigated and proofs su
 consistency of these properties over the corresponding mod els. Several examples th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_45fa4bad8ce1fd79.html
+++ b/public/events/arxiv_45fa4bad8ce1fd79.html
@@ -451,7 +451,9 @@ consistency of these properties over the corresponding mod els. Several examples
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ consistency of these properties over the corresponding mod els. Several examples
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ consistency of these properties over the corresponding mod els. Several examples
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_464de48531ae3c80.html
+++ b/public/events/arxiv_464de48531ae3c80.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_464de48531ae3c80.html
+++ b/public/events/arxiv_464de48531ae3c80.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_468ea22f2d5cf35e.html
+++ b/public/events/arxiv_468ea22f2d5cf35e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_468ea22f2d5cf35e.html
+++ b/public/events/arxiv_468ea22f2d5cf35e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_46a3f714374e488d.html
+++ b/public/events/arxiv_46a3f714374e488d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_46a3f714374e488d.html
+++ b/public/events/arxiv_46a3f714374e488d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_46ba239757968f3f.html
+++ b/public/events/arxiv_46ba239757968f3f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_46ba239757968f3f.html
+++ b/public/events/arxiv_46ba239757968f3f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4776a7ac86b1c7dd.html
+++ b/public/events/arxiv_4776a7ac86b1c7dd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4776a7ac86b1c7dd.html
+++ b/public/events/arxiv_4776a7ac86b1c7dd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_481bd6001ca24466.html
+++ b/public/events/arxiv_481bd6001ca24466.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_481bd6001ca24466.html
+++ b/public/events/arxiv_481bd6001ca24466.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_486e51b6eca9e021.html
+++ b/public/events/arxiv_486e51b6eca9e021.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ object t ypes already defined in the planning task that is being solved. This ar
 independent approach that advances the state of the art by extending the knowledge of a planni...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_486e51b6eca9e021.html
+++ b/public/events/arxiv_486e51b6eca9e021.html
@@ -450,7 +450,9 @@ independent approach that advances the state of the art by extending the knowled
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ independent approach that advances the state of the art by extending the knowled
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ independent approach that advances the state of the art by extending the knowled
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4891c64c19a1494c.html
+++ b/public/events/arxiv_4891c64c19a1494c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4891c64c19a1494c.html
+++ b/public/events/arxiv_4891c64c19a1494c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_490dfc6810f0f52e.html
+++ b/public/events/arxiv_490dfc6810f0f52e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_490dfc6810f0f52e.html
+++ b/public/events/arxiv_490dfc6810f0f52e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_499a4638a0e2f313.html
+++ b/public/events/arxiv_499a4638a0e2f313.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_499a4638a0e2f313.html
+++ b/public/events/arxiv_499a4638a0e2f313.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_49d0e9c54598d75f.html
+++ b/public/events/arxiv_49d0e9c54598d75f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_49d0e9c54598d75f.html
+++ b/public/events/arxiv_49d0e9c54598d75f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_49d1e059b5b2252b.html
+++ b/public/events/arxiv_49d1e059b5b2252b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_49d1e059b5b2252b.html
+++ b/public/events/arxiv_49d1e059b5b2252b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_49fd4c87928829fe.html
+++ b/public/events/arxiv_49fd4c87928829fe.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_49fd4c87928829fe.html
+++ b/public/events/arxiv_49fd4c87928829fe.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4a1054779386836e.html
+++ b/public/events/arxiv_4a1054779386836e.html
@@ -459,7 +459,9 @@ ACM  Computing...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ ACM  Computing...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ ACM  Computing...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4a1054779386836e.html
+++ b/public/events/arxiv_4a1054779386836e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ different, potentially very compressed and fast, pr ocesses.
 ACM  Computing...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4a42a1e94a9df88b.html
+++ b/public/events/arxiv_4a42a1e94a9df88b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4a42a1e94a9df88b.html
+++ b/public/events/arxiv_4a42a1e94a9df88b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4a6c4493fd0d879f.html
+++ b/public/events/arxiv_4a6c4493fd0d879f.html
@@ -33,6 +33,7 @@ Circumventing Defenses to Adversarial Examples | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ Circumventing Defenses to Adversarial Examples</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4a6c4493fd0d879f.html
+++ b/public/events/arxiv_4a6c4493fd0d879f.html
@@ -441,7 +441,9 @@ Circumventing Defenses to Adversarial Examples</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ Circumventing Defenses to Adversarial Examples</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ Circumventing Defenses to Adversarial Examples</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4ae4bd88689053a3.html
+++ b/public/events/arxiv_4ae4bd88689053a3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -443,8 +444,21 @@
  adoption of publication strategies s...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4ae4bd88689053a3.html
+++ b/public/events/arxiv_4ae4bd88689053a3.html
@@ -448,7 +448,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -463,7 +465,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -471,19 +473,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4aede7012db72353.html
+++ b/public/events/arxiv_4aede7012db72353.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4aede7012db72353.html
+++ b/public/events/arxiv_4aede7012db72353.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4af897b4f7e8de9e.html
+++ b/public/events/arxiv_4af897b4f7e8de9e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4af897b4f7e8de9e.html
+++ b/public/events/arxiv_4af897b4f7e8de9e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4b13c4aa7548bc21.html
+++ b/public/events/arxiv_4b13c4aa7548bc21.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4b13c4aa7548bc21.html
+++ b/public/events/arxiv_4b13c4aa7548bc21.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4b80438954bd57fd.html
+++ b/public/events/arxiv_4b80438954bd57fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4b80438954bd57fd.html
+++ b/public/events/arxiv_4b80438954bd57fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4b97d1dac7514262.html
+++ b/public/events/arxiv_4b97d1dac7514262.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4b97d1dac7514262.html
+++ b/public/events/arxiv_4b97d1dac7514262.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4ba32345a0367d2b.html
+++ b/public/events/arxiv_4ba32345a0367d2b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4ba32345a0367d2b.html
+++ b/public/events/arxiv_4ba32345a0367d2b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4bcb6e5e5420699a.html
+++ b/public/events/arxiv_4bcb6e5e5420699a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4bcb6e5e5420699a.html
+++ b/public/events/arxiv_4bcb6e5e5420699a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4c0cd90e3924e341.html
+++ b/public/events/arxiv_4c0cd90e3924e341.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4c0cd90e3924e341.html
+++ b/public/events/arxiv_4c0cd90e3924e341.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4c1601e7b988fad5.html
+++ b/public/events/arxiv_4c1601e7b988fad5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4c1601e7b988fad5.html
+++ b/public/events/arxiv_4c1601e7b988fad5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4c2ae2dfba07abf8.html
+++ b/public/events/arxiv_4c2ae2dfba07abf8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4c2ae2dfba07abf8.html
+++ b/public/events/arxiv_4c2ae2dfba07abf8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4d20560a864f229f.html
+++ b/public/events/arxiv_4d20560a864f229f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4d20560a864f229f.html
+++ b/public/events/arxiv_4d20560a864f229f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4d29d4a065f90b60.html
+++ b/public/events/arxiv_4d29d4a065f90b60.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4d29d4a065f90b60.html
+++ b/public/events/arxiv_4d29d4a065f90b60.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4d58fc236181a582.html
+++ b/public/events/arxiv_4d58fc236181a582.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4d58fc236181a582.html
+++ b/public/events/arxiv_4d58fc236181a582.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4d68272ca50e9711.html
+++ b/public/events/arxiv_4d68272ca50e9711.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4d68272ca50e9711.html
+++ b/public/events/arxiv_4d68272ca50e9711.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4d86e7039be72db7.html
+++ b/public/events/arxiv_4d86e7039be72db7.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4d86e7039be72db7.html
+++ b/public/events/arxiv_4d86e7039be72db7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">1 Engines of Power: Electricity, AI, and General-Purpose Military Transformations  Jeffrey Ding and Allan Dafoe* Abstract Major theories of military innovation focus on relatively narrow technological developments, such as nuclear weapons or aircraft carriers. Arguably the most profound military implications of technological change, however, come from more fundamental advances arising from ?general purpose technologies? (GPTs), such as the steam engine, electricity, and the computer. With few exceptions, political scientists have not theorized about GPTs. Drawing from the economics literature on GPTs, we distill several propositions on how and when GPTs affect military affairs. We call these effects ?general-purpose military transformations? (GMTs). In particular, we argue that the impacts of GMTs on military effectiveness are broad, delayed, and shaped by indirect productivity spillovers. Additionally, GMTs differentially advantage those militaries that can draw from a robust indus...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4debba2925275e63.html
+++ b/public/events/arxiv_4debba2925275e63.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4debba2925275e63.html
+++ b/public/events/arxiv_4debba2925275e63.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4e6e866ec66e13ee.html
+++ b/public/events/arxiv_4e6e866ec66e13ee.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4e6e866ec66e13ee.html
+++ b/public/events/arxiv_4e6e866ec66e13ee.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4ec878851f211ef9.html
+++ b/public/events/arxiv_4ec878851f211ef9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4ec878851f211ef9.html
+++ b/public/events/arxiv_4ec878851f211ef9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4ede69fce8724f7a.html
+++ b/public/events/arxiv_4ede69fce8724f7a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4ede69fce8724f7a.html
+++ b/public/events/arxiv_4ede69fce8724f7a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4efe878bf48a28f3.html
+++ b/public/events/arxiv_4efe878bf48a28f3.html
@@ -33,6 +33,7 @@ Rewards and Ethical Behavior in the Machiavelli?Benchmark | p(Doom)1 Events</tit
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ Rewards and Ethical Behavior in the Machiavelli?Benchmark</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4efe878bf48a28f3.html
+++ b/public/events/arxiv_4efe878bf48a28f3.html
@@ -441,7 +441,9 @@ Rewards and Ethical Behavior in the Machiavelli?Benchmark</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ Rewards and Ethical Behavior in the Machiavelli?Benchmark</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ Rewards and Ethical Behavior in the Machiavelli?Benchmark</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4f0c4f943196c1b6.html
+++ b/public/events/arxiv_4f0c4f943196c1b6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4f0c4f943196c1b6.html
+++ b/public/events/arxiv_4f0c4f943196c1b6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4f277b537530f3d0.html
+++ b/public/events/arxiv_4f277b537530f3d0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4f277b537530f3d0.html
+++ b/public/events/arxiv_4f277b537530f3d0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4f40d85a64ad6794.html
+++ b/public/events/arxiv_4f40d85a64ad6794.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -460,8 +461,21 @@ standard itself, one must further limit the capabilities of the agent. We then d
 our concerns relate to ou tcomes in th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4f40d85a64ad6794.html
+++ b/public/events/arxiv_4f40d85a64ad6794.html
@@ -465,7 +465,9 @@ our concerns relate to ou tcomes in th...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -480,7 +482,7 @@ our concerns relate to ou tcomes in th...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -488,19 +490,19 @@ our concerns relate to ou tcomes in th...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4f5142e5b00a441f.html
+++ b/public/events/arxiv_4f5142e5b00a441f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4f5142e5b00a441f.html
+++ b/public/events/arxiv_4f5142e5b00a441f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_4fa22ceddc8532fa.html
+++ b/public/events/arxiv_4fa22ceddc8532fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_4fa22ceddc8532fa.html
+++ b/public/events/arxiv_4fa22ceddc8532fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5089b9ff46e9fa8a.html
+++ b/public/events/arxiv_5089b9ff46e9fa8a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ active IRL approaches on gridworld, simulated driving, and table setting tasks,
 while also providing...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5089b9ff46e9fa8a.html
+++ b/public/events/arxiv_5089b9ff46e9fa8a.html
@@ -451,7 +451,9 @@ while also providing...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ while also providing...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ while also providing...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_50e1a7109df31a84.html
+++ b/public/events/arxiv_50e1a7109df31a84.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_50e1a7109df31a84.html
+++ b/public/events/arxiv_50e1a7109df31a84.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_50e653fce3d60282.html
+++ b/public/events/arxiv_50e653fce3d60282.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_50e653fce3d60282.html
+++ b/public/events/arxiv_50e653fce3d60282.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_50eceef4c4b20c6e.html
+++ b/public/events/arxiv_50eceef4c4b20c6e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_50eceef4c4b20c6e.html
+++ b/public/events/arxiv_50eceef4c4b20c6e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_50f785472f9f9817.html
+++ b/public/events/arxiv_50f785472f9f9817.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_50f785472f9f9817.html
+++ b/public/events/arxiv_50f785472f9f9817.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_51462a55534263d1.html
+++ b/public/events/arxiv_51462a55534263d1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -443,8 +444,21 @@ specific model architectures, tasks, and systems; and in addition, 3) robustness
 insights, particularly the trade...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_51462a55534263d1.html
+++ b/public/events/arxiv_51462a55534263d1.html
@@ -448,7 +448,9 @@ insights, particularly the trade...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -463,7 +465,7 @@ insights, particularly the trade...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -471,19 +473,19 @@ insights, particularly the trade...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5223826fba8bc976.html
+++ b/public/events/arxiv_5223826fba8bc976.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5223826fba8bc976.html
+++ b/public/events/arxiv_5223826fba8bc976.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_522f7a056dc115d3.html
+++ b/public/events/arxiv_522f7a056dc115d3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_522f7a056dc115d3.html
+++ b/public/events/arxiv_522f7a056dc115d3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5249c85b08bb42ca.html
+++ b/public/events/arxiv_5249c85b08bb42ca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5249c85b08bb42ca.html
+++ b/public/events/arxiv_5249c85b08bb42ca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_526a6e05602d30c0.html
+++ b/public/events/arxiv_526a6e05602d30c0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_526a6e05602d30c0.html
+++ b/public/events/arxiv_526a6e05602d30c0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_52818dc9c9b0ec8f.html
+++ b/public/events/arxiv_52818dc9c9b0ec8f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_52818dc9c9b0ec8f.html
+++ b/public/events/arxiv_52818dc9c9b0ec8f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_52cdcc7c93c44156.html
+++ b/public/events/arxiv_52cdcc7c93c44156.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_52cdcc7c93c44156.html
+++ b/public/events/arxiv_52cdcc7c93c44156.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_533541b26e68390c.html
+++ b/public/events/arxiv_533541b26e68390c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_533541b26e68390c.html
+++ b/public/events/arxiv_533541b26e68390c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_53872389fe614b7b.html
+++ b/public/events/arxiv_53872389fe614b7b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_53872389fe614b7b.html
+++ b/public/events/arxiv_53872389fe614b7b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5388c16b3140305d.html
+++ b/public/events/arxiv_5388c16b3140305d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5388c16b3140305d.html
+++ b/public/events/arxiv_5388c16b3140305d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_53bbe9ae329b1987.html
+++ b/public/events/arxiv_53bbe9ae329b1987.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_53bbe9ae329b1987.html
+++ b/public/events/arxiv_53bbe9ae329b1987.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_53c3414e76f6b1bc.html
+++ b/public/events/arxiv_53c3414e76f6b1bc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_53c3414e76f6b1bc.html
+++ b/public/events/arxiv_53c3414e76f6b1bc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_542736ebb8aad1d0.html
+++ b/public/events/arxiv_542736ebb8aad1d0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_542736ebb8aad1d0.html
+++ b/public/events/arxiv_542736ebb8aad1d0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_545c495f3af5bccc.html
+++ b/public/events/arxiv_545c495f3af5bccc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_545c495f3af5bccc.html
+++ b/public/events/arxiv_545c495f3af5bccc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5488031cfaa2b302.html
+++ b/public/events/arxiv_5488031cfaa2b302.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5488031cfaa2b302.html
+++ b/public/events/arxiv_5488031cfaa2b302.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_54b50aa3fdacde8f.html
+++ b/public/events/arxiv_54b50aa3fdacde8f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_54b50aa3fdacde8f.html
+++ b/public/events/arxiv_54b50aa3fdacde8f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_54c4066155dbf604.html
+++ b/public/events/arxiv_54c4066155dbf604.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_54c4066155dbf604.html
+++ b/public/events/arxiv_54c4066155dbf604.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_54fce49dfd17b9cf.html
+++ b/public/events/arxiv_54fce49dfd17b9cf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_54fce49dfd17b9cf.html
+++ b/public/events/arxiv_54fce49dfd17b9cf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_55080c9319c2415f.html
+++ b/public/events/arxiv_55080c9319c2415f.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_55080c9319c2415f.html
+++ b/public/events/arxiv_55080c9319c2415f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Learnable Strategies for Bilateral Agent Negotiation over Multiple Issues</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_557bfceacbe79950.html
+++ b/public/events/arxiv_557bfceacbe79950.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_557bfceacbe79950.html
+++ b/public/events/arxiv_557bfceacbe79950.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5585b20ff1241af9.html
+++ b/public/events/arxiv_5585b20ff1241af9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5585b20ff1241af9.html
+++ b/public/events/arxiv_5585b20ff1241af9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_559978de79b22f4e.html
+++ b/public/events/arxiv_559978de79b22f4e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_559978de79b22f4e.html
+++ b/public/events/arxiv_559978de79b22f4e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_55b08e232187491f.html
+++ b/public/events/arxiv_55b08e232187491f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ how to involve humans in advanced automation. The current model
 assumes stationa...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_55b08e232187491f.html
+++ b/public/events/arxiv_55b08e232187491f.html
@@ -452,7 +452,9 @@ assumes stationa...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ assumes stationa...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ assumes stationa...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_55d2ee5a90362dcc.html
+++ b/public/events/arxiv_55d2ee5a90362dcc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_55d2ee5a90362dcc.html
+++ b/public/events/arxiv_55d2ee5a90362dcc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56272308af8ac1b8.html
+++ b/public/events/arxiv_56272308af8ac1b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56272308af8ac1b8.html
+++ b/public/events/arxiv_56272308af8ac1b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56382c60c6c3e7b0.html
+++ b/public/events/arxiv_56382c60c6c3e7b0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56382c60c6c3e7b0.html
+++ b/public/events/arxiv_56382c60c6c3e7b0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56829389fad04d54.html
+++ b/public/events/arxiv_56829389fad04d54.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56829389fad04d54.html
+++ b/public/events/arxiv_56829389fad04d54.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_568da857b5fce82c.html
+++ b/public/events/arxiv_568da857b5fce82c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_568da857b5fce82c.html
+++ b/public/events/arxiv_568da857b5fce82c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_568f000a038e4bfb.html
+++ b/public/events/arxiv_568f000a038e4bfb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_568f000a038e4bfb.html
+++ b/public/events/arxiv_568f000a038e4bfb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56c4bb5d101fa24c.html
+++ b/public/events/arxiv_56c4bb5d101fa24c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56c4bb5d101fa24c.html
+++ b/public/events/arxiv_56c4bb5d101fa24c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56d0c65d1754d563.html
+++ b/public/events/arxiv_56d0c65d1754d563.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56d0c65d1754d563.html
+++ b/public/events/arxiv_56d0c65d1754d563.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_56ff800292644bea.html
+++ b/public/events/arxiv_56ff800292644bea.html
@@ -450,7 +450,9 @@ managing traffic,1  conducting risk assessments,2  screening immigrants,3  alloc
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ managing traffic,1  conducting risk assessments,2  screening immigrants,3  alloc
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ managing traffic,1  conducting risk assessments,2  screening immigrants,3  alloc
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_56ff800292644bea.html
+++ b/public/events/arxiv_56ff800292644bea.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ Government institutions increasingly rely on automated decision-making technolog
 managing traffic,1  conducting risk assessments,2  screening immigrants,3  allocating social services,4  and m...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_57723e6c17d3c7a5.html
+++ b/public/events/arxiv_57723e6c17d3c7a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_57723e6c17d3c7a5.html
+++ b/public/events/arxiv_57723e6c17d3c7a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_577ffc18173d346a.html
+++ b/public/events/arxiv_577ffc18173d346a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_577ffc18173d346a.html
+++ b/public/events/arxiv_577ffc18173d346a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_580086687492613b.html
+++ b/public/events/arxiv_580086687492613b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_580086687492613b.html
+++ b/public/events/arxiv_580086687492613b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_581e6b835ead35ec.html
+++ b/public/events/arxiv_581e6b835ead35ec.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_581e6b835ead35ec.html
+++ b/public/events/arxiv_581e6b835ead35ec.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_583c6e401e206e40.html
+++ b/public/events/arxiv_583c6e401e206e40.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_583c6e401e206e40.html
+++ b/public/events/arxiv_583c6e401e206e40.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_584641e15cc07415.html
+++ b/public/events/arxiv_584641e15cc07415.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_584641e15cc07415.html
+++ b/public/events/arxiv_584641e15cc07415.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_58d2f516697b4e3a.html
+++ b/public/events/arxiv_58d2f516697b4e3a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Artificial Intelligence is stupid and causal reasoning won't fix it</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_58d2f516697b4e3a.html
+++ b/public/events/arxiv_58d2f516697b4e3a.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_590c3520e8afde51.html
+++ b/public/events/arxiv_590c3520e8afde51.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_590c3520e8afde51.html
+++ b/public/events/arxiv_590c3520e8afde51.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_598d0f8ff5beacac.html
+++ b/public/events/arxiv_598d0f8ff5beacac.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_598d0f8ff5beacac.html
+++ b/public/events/arxiv_598d0f8ff5beacac.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_59bdc581d12f5d74.html
+++ b/public/events/arxiv_59bdc581d12f5d74.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_59bdc581d12f5d74.html
+++ b/public/events/arxiv_59bdc581d12f5d74.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_59be6f1812581416.html
+++ b/public/events/arxiv_59be6f1812581416.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_59be6f1812581416.html
+++ b/public/events/arxiv_59be6f1812581416.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_59f6f938d8b690b2.html
+++ b/public/events/arxiv_59f6f938d8b690b2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_59f6f938d8b690b2.html
+++ b/public/events/arxiv_59f6f938d8b690b2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_59f90d6e3944f784.html
+++ b/public/events/arxiv_59f90d6e3944f784.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_59f90d6e3944f784.html
+++ b/public/events/arxiv_59f90d6e3944f784.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5a0f56ad4bbd83a5.html
+++ b/public/events/arxiv_5a0f56ad4bbd83a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5a0f56ad4bbd83a5.html
+++ b/public/events/arxiv_5a0f56ad4bbd83a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5ab3b57cc0401a5d.html
+++ b/public/events/arxiv_5ab3b57cc0401a5d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5ab3b57cc0401a5d.html
+++ b/public/events/arxiv_5ab3b57cc0401a5d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5ab982619e6ba5b0.html
+++ b/public/events/arxiv_5ab982619e6ba5b0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5ab982619e6ba5b0.html
+++ b/public/events/arxiv_5ab982619e6ba5b0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5b3fc1caecb2bdfb.html
+++ b/public/events/arxiv_5b3fc1caecb2bdfb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ realizations mean with respect to the overall intelligence process. Third, we mu
 realizations as clearly as possible. We propose a...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5b3fc1caecb2bdfb.html
+++ b/public/events/arxiv_5b3fc1caecb2bdfb.html
@@ -454,7 +454,9 @@ realizations as clearly as possible. We propose a...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ realizations as clearly as possible. We propose a...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ realizations as clearly as possible. We propose a...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5b7385484d3a48ca.html
+++ b/public/events/arxiv_5b7385484d3a48ca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5b7385484d3a48ca.html
+++ b/public/events/arxiv_5b7385484d3a48ca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5b89337caf817fe3.html
+++ b/public/events/arxiv_5b89337caf817fe3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5b89337caf817fe3.html
+++ b/public/events/arxiv_5b89337caf817fe3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5b8bd5bb5035743d.html
+++ b/public/events/arxiv_5b8bd5bb5035743d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5b8bd5bb5035743d.html
+++ b/public/events/arxiv_5b8bd5bb5035743d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5b9b42f6b9b6a092.html
+++ b/public/events/arxiv_5b9b42f6b9b6a092.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5b9b42f6b9b6a092.html
+++ b/public/events/arxiv_5b9b42f6b9b6a092.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5bb7ca04067a7d2f.html
+++ b/public/events/arxiv_5bb7ca04067a7d2f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5bb7ca04067a7d2f.html
+++ b/public/events/arxiv_5bb7ca04067a7d2f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5bba428001708f8d.html
+++ b/public/events/arxiv_5bba428001708f8d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5bba428001708f8d.html
+++ b/public/events/arxiv_5bba428001708f8d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5c831da76432b236.html
+++ b/public/events/arxiv_5c831da76432b236.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5c831da76432b236.html
+++ b/public/events/arxiv_5c831da76432b236.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5c91e99695035a96.html
+++ b/public/events/arxiv_5c91e99695035a96.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5c91e99695035a96.html
+++ b/public/events/arxiv_5c91e99695035a96.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5cb441d6c32c9e98.html
+++ b/public/events/arxiv_5cb441d6c32c9e98.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5cb441d6c32c9e98.html
+++ b/public/events/arxiv_5cb441d6c32c9e98.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5cc4fc269b34b5b6.html
+++ b/public/events/arxiv_5cc4fc269b34b5b6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5cc4fc269b34b5b6.html
+++ b/public/events/arxiv_5cc4fc269b34b5b6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5cec285678501247.html
+++ b/public/events/arxiv_5cec285678501247.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5cec285678501247.html
+++ b/public/events/arxiv_5cec285678501247.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5d45e51f2ea6d22b.html
+++ b/public/events/arxiv_5d45e51f2ea6d22b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5d45e51f2ea6d22b.html
+++ b/public/events/arxiv_5d45e51f2ea6d22b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5d7cfd2d76544f71.html
+++ b/public/events/arxiv_5d7cfd2d76544f71.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5d7cfd2d76544f71.html
+++ b/public/events/arxiv_5d7cfd2d76544f71.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5d8d41b153d13a07.html
+++ b/public/events/arxiv_5d8d41b153d13a07.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5d8d41b153d13a07.html
+++ b/public/events/arxiv_5d8d41b153d13a07.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5de2b48b2c1f89fb.html
+++ b/public/events/arxiv_5de2b48b2c1f89fb.html
@@ -473,7 +473,9 @@ What does ?ethic...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -488,7 +490,7 @@ What does ?ethic...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -496,19 +498,19 @@ What does ?ethic...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5de2b48b2c1f89fb.html
+++ b/public/events/arxiv_5de2b48b2c1f89fb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -468,8 +469,21 @@ AI and Ethics  5
 What does ?ethic...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5e6dd6e10068aa22.html
+++ b/public/events/arxiv_5e6dd6e10068aa22.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5e6dd6e10068aa22.html
+++ b/public/events/arxiv_5e6dd6e10068aa22.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5f679aa5f67a93ba.html
+++ b/public/events/arxiv_5f679aa5f67a93ba.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5f679aa5f67a93ba.html
+++ b/public/events/arxiv_5f679aa5f67a93ba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_5fd293522bc3b6b6.html
+++ b/public/events/arxiv_5fd293522bc3b6b6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_5fd293522bc3b6b6.html
+++ b/public/events/arxiv_5fd293522bc3b6b6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6026676ef70b61b3.html
+++ b/public/events/arxiv_6026676ef70b61b3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6026676ef70b61b3.html
+++ b/public/events/arxiv_6026676ef70b61b3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_60ce6df24e15aa3f.html
+++ b/public/events/arxiv_60ce6df24e15aa3f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_60ce6df24e15aa3f.html
+++ b/public/events/arxiv_60ce6df24e15aa3f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_60f689dd4baaa68b.html
+++ b/public/events/arxiv_60f689dd4baaa68b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_60f689dd4baaa68b.html
+++ b/public/events/arxiv_60f689dd4baaa68b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_613fb830395808b0.html
+++ b/public/events/arxiv_613fb830395808b0.html
@@ -441,7 +441,9 @@ of Neural Networks</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ of Neural Networks</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ of Neural Networks</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_613fb830395808b0.html
+++ b/public/events/arxiv_613fb830395808b0.html
@@ -33,6 +33,7 @@ of Neural Networks | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ of Neural Networks</h1>
 of Neural Networks</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_61517cf54fe17bd5.html
+++ b/public/events/arxiv_61517cf54fe17bd5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_61517cf54fe17bd5.html
+++ b/public/events/arxiv_61517cf54fe17bd5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_616a90eae506a42d.html
+++ b/public/events/arxiv_616a90eae506a42d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_616a90eae506a42d.html
+++ b/public/events/arxiv_616a90eae506a42d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6192ac5138b95d9b.html
+++ b/public/events/arxiv_6192ac5138b95d9b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6192ac5138b95d9b.html
+++ b/public/events/arxiv_6192ac5138b95d9b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_62048503a42e7698.html
+++ b/public/events/arxiv_62048503a42e7698.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_62048503a42e7698.html
+++ b/public/events/arxiv_62048503a42e7698.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_623d2a613c808d33.html
+++ b/public/events/arxiv_623d2a613c808d33.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_623d2a613c808d33.html
+++ b/public/events/arxiv_623d2a613c808d33.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6252189f483ff7ff.html
+++ b/public/events/arxiv_6252189f483ff7ff.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6252189f483ff7ff.html
+++ b/public/events/arxiv_6252189f483ff7ff.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_62776f407519f655.html
+++ b/public/events/arxiv_62776f407519f655.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_62776f407519f655.html
+++ b/public/events/arxiv_62776f407519f655.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_62e683d54a625bee.html
+++ b/public/events/arxiv_62e683d54a625bee.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_62e683d54a625bee.html
+++ b/public/events/arxiv_62e683d54a625bee.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_62ef0e364eab5971.html
+++ b/public/events/arxiv_62ef0e364eab5971.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_62ef0e364eab5971.html
+++ b/public/events/arxiv_62ef0e364eab5971.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_62f122481baeefc3.html
+++ b/public/events/arxiv_62f122481baeefc3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_62f122481baeefc3.html
+++ b/public/events/arxiv_62f122481baeefc3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6311d79b1c153e4a.html
+++ b/public/events/arxiv_6311d79b1c153e4a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6311d79b1c153e4a.html
+++ b/public/events/arxiv_6311d79b1c153e4a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6353ef31023a168c.html
+++ b/public/events/arxiv_6353ef31023a168c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6353ef31023a168c.html
+++ b/public/events/arxiv_6353ef31023a168c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_63f483a077d61ed3.html
+++ b/public/events/arxiv_63f483a077d61ed3.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_63f483a077d61ed3.html
+++ b/public/events/arxiv_63f483a077d61ed3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Scalable Evaluation of Multi-Agent Reinforcement Learning with Melting Pot</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_641ff6dee15b77cf.html
+++ b/public/events/arxiv_641ff6dee15b77cf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_641ff6dee15b77cf.html
+++ b/public/events/arxiv_641ff6dee15b77cf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_646147045c9c2ce6.html
+++ b/public/events/arxiv_646147045c9c2ce6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_646147045c9c2ce6.html
+++ b/public/events/arxiv_646147045c9c2ce6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6473bf92d37686f5.html
+++ b/public/events/arxiv_6473bf92d37686f5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6473bf92d37686f5.html
+++ b/public/events/arxiv_6473bf92d37686f5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_64e368da441409b5.html
+++ b/public/events/arxiv_64e368da441409b5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_64e368da441409b5.html
+++ b/public/events/arxiv_64e368da441409b5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_669a2a89fe0b6b86.html
+++ b/public/events/arxiv_669a2a89fe0b6b86.html
@@ -615,7 +615,9 @@ A...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -630,7 +632,7 @@ A...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -638,19 +640,19 @@ A...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_669a2a89fe0b6b86.html
+++ b/public/events/arxiv_669a2a89fe0b6b86.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -610,8 +611,21 @@ Intelligence
 A...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_66b00ffd67710860.html
+++ b/public/events/arxiv_66b00ffd67710860.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_66b00ffd67710860.html
+++ b/public/events/arxiv_66b00ffd67710860.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_66b16ddb540dbf79.html
+++ b/public/events/arxiv_66b16ddb540dbf79.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_66b16ddb540dbf79.html
+++ b/public/events/arxiv_66b16ddb540dbf79.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_673f5a66b8253c07.html
+++ b/public/events/arxiv_673f5a66b8253c07.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_673f5a66b8253c07.html
+++ b/public/events/arxiv_673f5a66b8253c07.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_67acbfb8e5ef7365.html
+++ b/public/events/arxiv_67acbfb8e5ef7365.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_67acbfb8e5ef7365.html
+++ b/public/events/arxiv_67acbfb8e5ef7365.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_681635096b39624d.html
+++ b/public/events/arxiv_681635096b39624d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_681635096b39624d.html
+++ b/public/events/arxiv_681635096b39624d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6843e44989aaddcc.html
+++ b/public/events/arxiv_6843e44989aaddcc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6843e44989aaddcc.html
+++ b/public/events/arxiv_6843e44989aaddcc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_68473420afe61cd8.html
+++ b/public/events/arxiv_68473420afe61cd8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_68473420afe61cd8.html
+++ b/public/events/arxiv_68473420afe61cd8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_686b8ae940e6d772.html
+++ b/public/events/arxiv_686b8ae940e6d772.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_686b8ae940e6d772.html
+++ b/public/events/arxiv_686b8ae940e6d772.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_68b377556f438319.html
+++ b/public/events/arxiv_68b377556f438319.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_68b377556f438319.html
+++ b/public/events/arxiv_68b377556f438319.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_68da4ab0079db520.html
+++ b/public/events/arxiv_68da4ab0079db520.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_68da4ab0079db520.html
+++ b/public/events/arxiv_68da4ab0079db520.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_693565496a05778f.html
+++ b/public/events/arxiv_693565496a05778f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_693565496a05778f.html
+++ b/public/events/arxiv_693565496a05778f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6963078acea43dba.html
+++ b/public/events/arxiv_6963078acea43dba.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6963078acea43dba.html
+++ b/public/events/arxiv_6963078acea43dba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6a8d9093f9310ee6.html
+++ b/public/events/arxiv_6a8d9093f9310ee6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6a8d9093f9310ee6.html
+++ b/public/events/arxiv_6a8d9093f9310ee6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6ae1ff25b772be68.html
+++ b/public/events/arxiv_6ae1ff25b772be68.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6ae1ff25b772be68.html
+++ b/public/events/arxiv_6ae1ff25b772be68.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6af2c5740e297388.html
+++ b/public/events/arxiv_6af2c5740e297388.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6af2c5740e297388.html
+++ b/public/events/arxiv_6af2c5740e297388.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6b2e6017f5a03ddc.html
+++ b/public/events/arxiv_6b2e6017f5a03ddc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6b2e6017f5a03ddc.html
+++ b/public/events/arxiv_6b2e6017f5a03ddc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6b434c3af993d14b.html
+++ b/public/events/arxiv_6b434c3af993d14b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6b434c3af993d14b.html
+++ b/public/events/arxiv_6b434c3af993d14b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6c033586fd63cd2e.html
+++ b/public/events/arxiv_6c033586fd63cd2e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6c033586fd63cd2e.html
+++ b/public/events/arxiv_6c033586fd63cd2e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6c1540dbd5a19818.html
+++ b/public/events/arxiv_6c1540dbd5a19818.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6c1540dbd5a19818.html
+++ b/public/events/arxiv_6c1540dbd5a19818.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6c313d37e8b148d6.html
+++ b/public/events/arxiv_6c313d37e8b148d6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6c313d37e8b148d6.html
+++ b/public/events/arxiv_6c313d37e8b148d6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6c87991453243015.html
+++ b/public/events/arxiv_6c87991453243015.html
@@ -455,7 +455,9 @@ information to share with its teammates, wh...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ information to share with its teammates, wh...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ information to share with its teammates, wh...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6c87991453243015.html
+++ b/public/events/arxiv_6c87991453243015.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ has proven difficult. It involves (among others) making the computer decide whic
 information to share with its teammates, wh...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6ccfec6178816685.html
+++ b/public/events/arxiv_6ccfec6178816685.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6ccfec6178816685.html
+++ b/public/events/arxiv_6ccfec6178816685.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6d55735612b0d645.html
+++ b/public/events/arxiv_6d55735612b0d645.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6d55735612b0d645.html
+++ b/public/events/arxiv_6d55735612b0d645.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6d63b24af76850e7.html
+++ b/public/events/arxiv_6d63b24af76850e7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6d63b24af76850e7.html
+++ b/public/events/arxiv_6d63b24af76850e7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6d9c643dc346070e.html
+++ b/public/events/arxiv_6d9c643dc346070e.html
@@ -463,7 +463,9 @@ of research, development and application of AI ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -478,7 +480,7 @@ of research, development and application of AI ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -486,19 +488,19 @@ of research, development and application of AI ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6d9c643dc346070e.html
+++ b/public/events/arxiv_6d9c643dc346070e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -458,8 +459,21 @@ principles and values are implemented in the practice
 of research, development and application of AI ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6e0f2c882ed2ded9.html
+++ b/public/events/arxiv_6e0f2c882ed2ded9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6e0f2c882ed2ded9.html
+++ b/public/events/arxiv_6e0f2c882ed2ded9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6e217576bd92ec66.html
+++ b/public/events/arxiv_6e217576bd92ec66.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6e217576bd92ec66.html
+++ b/public/events/arxiv_6e217576bd92ec66.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6e27957f99ea08be.html
+++ b/public/events/arxiv_6e27957f99ea08be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ promote substantively f air outcomes, something that requires particular attenti
 to the impact they have on the worst-of f ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6e27957f99ea08be.html
+++ b/public/events/arxiv_6e27957f99ea08be.html
@@ -452,7 +452,9 @@ to the impact they have on the worst-of f ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ to the impact they have on the worst-of f ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ to the impact they have on the worst-of f ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6eaa8320041fb81d.html
+++ b/public/events/arxiv_6eaa8320041fb81d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -463,8 +464,21 @@ braking actions in your car; web browsers with AI capabilities can reason from p
 searches to recommend a new...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6eaa8320041fb81d.html
+++ b/public/events/arxiv_6eaa8320041fb81d.html
@@ -468,7 +468,9 @@ searches to recommend a new...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -483,7 +485,7 @@ searches to recommend a new...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -491,19 +493,19 @@ searches to recommend a new...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6f3bebfdf31991d1.html
+++ b/public/events/arxiv_6f3bebfdf31991d1.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6f3bebfdf31991d1.html
+++ b/public/events/arxiv_6f3bebfdf31991d1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Measuring the Algorithmic Ef?ciency of Neural NetworksDanny Hernandez?[email address redacted] B. [email address redacted] factors drive the advance of AI: algorithmic innovation, data, and the amount ofcompute available for training. Algorithmic progress has traditionally been more dif?cultto quantify than compute and data. In this work, we argue that algorithmic progress hasan aspect that is both straightforward to measure and interesting: reductions over timein the compute needed to reach past capabilities. We show that the number of ?oating-point operations required to train a classi?er to AlexNet-level performance on ImageNethas decreased by a factor of 44x between 2012 and 2019. This corresponds to algorithmicef?ciency doubling every 16 months over a period of 7 years. Notably, this outpaces theoriginal Moore?s law rate of improvement in hardware ef?ciency (11x over this period).We observe that hardware and algorithmic ef?ciency gains multiply and can be on a si...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6f54b171cfee650e.html
+++ b/public/events/arxiv_6f54b171cfee650e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6f54b171cfee650e.html
+++ b/public/events/arxiv_6f54b171cfee650e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6fecf371e716d4a0.html
+++ b/public/events/arxiv_6fecf371e716d4a0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6fecf371e716d4a0.html
+++ b/public/events/arxiv_6fecf371e716d4a0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_6ffccb173ea283dc.html
+++ b/public/events/arxiv_6ffccb173ea283dc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_6ffccb173ea283dc.html
+++ b/public/events/arxiv_6ffccb173ea283dc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7010710588ce3649.html
+++ b/public/events/arxiv_7010710588ce3649.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7010710588ce3649.html
+++ b/public/events/arxiv_7010710588ce3649.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7065ba6b881fd64f.html
+++ b/public/events/arxiv_7065ba6b881fd64f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7065ba6b881fd64f.html
+++ b/public/events/arxiv_7065ba6b881fd64f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_709c102c9237b620.html
+++ b/public/events/arxiv_709c102c9237b620.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_709c102c9237b620.html
+++ b/public/events/arxiv_709c102c9237b620.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_70b81709b37af2f6.html
+++ b/public/events/arxiv_70b81709b37af2f6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Recursively Summarizing Books with Human Feedback</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_70b81709b37af2f6.html
+++ b/public/events/arxiv_70b81709b37af2f6.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_713254917f596bcc.html
+++ b/public/events/arxiv_713254917f596bcc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_713254917f596bcc.html
+++ b/public/events/arxiv_713254917f596bcc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_714861efdafd1851.html
+++ b/public/events/arxiv_714861efdafd1851.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ machine learning (ML) in particular, this paper provides
 an overview o...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_714861efdafd1851.html
+++ b/public/events/arxiv_714861efdafd1851.html
@@ -459,7 +459,9 @@ an overview o...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ an overview o...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ an overview o...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_715784c647249f72.html
+++ b/public/events/arxiv_715784c647249f72.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_715784c647249f72.html
+++ b/public/events/arxiv_715784c647249f72.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_71661b9ac1ac2cae.html
+++ b/public/events/arxiv_71661b9ac1ac2cae.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_71661b9ac1ac2cae.html
+++ b/public/events/arxiv_71661b9ac1ac2cae.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_71844bc4a557c4d1.html
+++ b/public/events/arxiv_71844bc4a557c4d1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_71844bc4a557c4d1.html
+++ b/public/events/arxiv_71844bc4a557c4d1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_71955245b24a9957.html
+++ b/public/events/arxiv_71955245b24a9957.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_71955245b24a9957.html
+++ b/public/events/arxiv_71955245b24a9957.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_71e4b5b262c8176a.html
+++ b/public/events/arxiv_71e4b5b262c8176a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_71e4b5b262c8176a.html
+++ b/public/events/arxiv_71e4b5b262c8176a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_71ea3916b563f9c4.html
+++ b/public/events/arxiv_71ea3916b563f9c4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_71ea3916b563f9c4.html
+++ b/public/events/arxiv_71ea3916b563f9c4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_721ce41554be015d.html
+++ b/public/events/arxiv_721ce41554be015d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_721ce41554be015d.html
+++ b/public/events/arxiv_721ce41554be015d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_72206017b1892b4e.html
+++ b/public/events/arxiv_72206017b1892b4e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_72206017b1892b4e.html
+++ b/public/events/arxiv_72206017b1892b4e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7260b5451ca708a2.html
+++ b/public/events/arxiv_7260b5451ca708a2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7260b5451ca708a2.html
+++ b/public/events/arxiv_7260b5451ca708a2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_73478b418cc33143.html
+++ b/public/events/arxiv_73478b418cc33143.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_73478b418cc33143.html
+++ b/public/events/arxiv_73478b418cc33143.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7349535db7a4ab6a.html
+++ b/public/events/arxiv_7349535db7a4ab6a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7349535db7a4ab6a.html
+++ b/public/events/arxiv_7349535db7a4ab6a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_73592b70a3f5a792.html
+++ b/public/events/arxiv_73592b70a3f5a792.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_73592b70a3f5a792.html
+++ b/public/events/arxiv_73592b70a3f5a792.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_73643a60bb86bf2f.html
+++ b/public/events/arxiv_73643a60bb86bf2f.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_73643a60bb86bf2f.html
+++ b/public/events/arxiv_73643a60bb86bf2f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Unite Paper 2021 &lt;&lt;number to be assigned&gt;&gt; A Framework for Ethical AI at the United Nations Prepared by:  Lambert Hogenhout Organization:  UN Office for Information and Communications Technology Contact:    [email address redacted] Date:     15-3-2021  Contents  EXECUTIVE SUMMARY 2 INTRODUCTION 3 1. PROBLEMS WITH AI 5 2. DEFINING ETHICAL AI 11 3. IMPLEMENTING ETHICAL AI 20 CONCLUSION 23        Unite Papers? ?Informing and Capturing UN Technological Innovation?  An occasional paper series to share ideas, insights and in-depth studies on technology and the United Nations. The series is sponsored by the Office of Information and Communications Technology (OICT) but does not necessarily represent the official views of OICT or of the United Nations.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_741d13de2d731c54.html
+++ b/public/events/arxiv_741d13de2d731c54.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_741d13de2d731c54.html
+++ b/public/events/arxiv_741d13de2d731c54.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7461e158ad377f9a.html
+++ b/public/events/arxiv_7461e158ad377f9a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7461e158ad377f9a.html
+++ b/public/events/arxiv_7461e158ad377f9a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_74d2bed93d6eaa90.html
+++ b/public/events/arxiv_74d2bed93d6eaa90.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_74d2bed93d6eaa90.html
+++ b/public/events/arxiv_74d2bed93d6eaa90.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_759a6e91ea8575e1.html
+++ b/public/events/arxiv_759a6e91ea8575e1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_759a6e91ea8575e1.html
+++ b/public/events/arxiv_759a6e91ea8575e1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_75da108fdfb3106e.html
+++ b/public/events/arxiv_75da108fdfb3106e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -614,8 +615,21 @@ which
 ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_75da108fdfb3106e.html
+++ b/public/events/arxiv_75da108fdfb3106e.html
@@ -619,7 +619,9 @@ which
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -634,7 +636,7 @@ which
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -642,19 +644,19 @@ which
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_75e887cfeec8a3e0.html
+++ b/public/events/arxiv_75e887cfeec8a3e0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_75e887cfeec8a3e0.html
+++ b/public/events/arxiv_75e887cfeec8a3e0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_76fd04d6177fa7e4.html
+++ b/public/events/arxiv_76fd04d6177fa7e4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_76fd04d6177fa7e4.html
+++ b/public/events/arxiv_76fd04d6177fa7e4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7775b0d3b8cbad17.html
+++ b/public/events/arxiv_7775b0d3b8cbad17.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7775b0d3b8cbad17.html
+++ b/public/events/arxiv_7775b0d3b8cbad17.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_779a2317c0abb602.html
+++ b/public/events/arxiv_779a2317c0abb602.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_779a2317c0abb602.html
+++ b/public/events/arxiv_779a2317c0abb602.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_77b8610cfe330f24.html
+++ b/public/events/arxiv_77b8610cfe330f24.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_77b8610cfe330f24.html
+++ b/public/events/arxiv_77b8610cfe330f24.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_77f8c55109ae4cb3.html
+++ b/public/events/arxiv_77f8c55109ae4cb3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_77f8c55109ae4cb3.html
+++ b/public/events/arxiv_77f8c55109ae4cb3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_78174b74c718cad8.html
+++ b/public/events/arxiv_78174b74c718cad8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_78174b74c718cad8.html
+++ b/public/events/arxiv_78174b74c718cad8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_782a1b8a0e048fa7.html
+++ b/public/events/arxiv_782a1b8a0e048fa7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_782a1b8a0e048fa7.html
+++ b/public/events/arxiv_782a1b8a0e048fa7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_784d797528d0ab87.html
+++ b/public/events/arxiv_784d797528d0ab87.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_784d797528d0ab87.html
+++ b/public/events/arxiv_784d797528d0ab87.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7902a1192772be3d.html
+++ b/public/events/arxiv_7902a1192772be3d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7902a1192772be3d.html
+++ b/public/events/arxiv_7902a1192772be3d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_793b9faea6d52daf.html
+++ b/public/events/arxiv_793b9faea6d52daf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_793b9faea6d52daf.html
+++ b/public/events/arxiv_793b9faea6d52daf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_79624763ad62f160.html
+++ b/public/events/arxiv_79624763ad62f160.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_79624763ad62f160.html
+++ b/public/events/arxiv_79624763ad62f160.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_79c7fe8d20495ec5.html
+++ b/public/events/arxiv_79c7fe8d20495ec5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_79c7fe8d20495ec5.html
+++ b/public/events/arxiv_79c7fe8d20495ec5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7a25f9dac2f07281.html
+++ b/public/events/arxiv_7a25f9dac2f07281.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7a25f9dac2f07281.html
+++ b/public/events/arxiv_7a25f9dac2f07281.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7a4d122a4cd52098.html
+++ b/public/events/arxiv_7a4d122a4cd52098.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7a4d122a4cd52098.html
+++ b/public/events/arxiv_7a4d122a4cd52098.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7a97baccf2d0dfad.html
+++ b/public/events/arxiv_7a97baccf2d0dfad.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7a97baccf2d0dfad.html
+++ b/public/events/arxiv_7a97baccf2d0dfad.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7aa7add91c4d9bde.html
+++ b/public/events/arxiv_7aa7add91c4d9bde.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7aa7add91c4d9bde.html
+++ b/public/events/arxiv_7aa7add91c4d9bde.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7add01516d3cbae1.html
+++ b/public/events/arxiv_7add01516d3cbae1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7add01516d3cbae1.html
+++ b/public/events/arxiv_7add01516d3cbae1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7b03a29a7f0a47cb.html
+++ b/public/events/arxiv_7b03a29a7f0a47cb.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7b03a29a7f0a47cb.html
+++ b/public/events/arxiv_7b03a29a7f0a47cb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Forthcoming in The Oxford Handbook of Digital Ethics   The Challenge of Value Alignment: from Fairer  Algorithms to AI Safety  Iason Gabriel and Vafa Ghazavi 1. Introduction   There has long been a view among observers of artificial intelligence (AI) research, often expressed in science fiction, that it poses a distinctive moral challenge. This idea has been articulated in a number of ways, ranging from the notion that AI might take a ?treacherous turn? and act in ways that are opposed to the interests of its human operators, to deeper questions about the impact of AI on our understanding of human identity, emotions and relationships. Yet over the past decade, with the growth of more powerful and socially embedded AI technologies, discussion of these questions has become increasingly mainstream. Among topics that have commanded the most serious attention, the challenge of ?value alignment? stands out. It centres upon the question of how to ensure that AI systems are properly aligned...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7b0d451e83568289.html
+++ b/public/events/arxiv_7b0d451e83568289.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7b0d451e83568289.html
+++ b/public/events/arxiv_7b0d451e83568289.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Hard Choices and Hard Limits for Artificial Intelligence              Bryce Goodman  Department of Philosophy  University of Oxford  United Kingdom  [email address redacted]            ABSTRACT Artificial intelligence (AI) is supposed to help us make better choices [1]. Some of these choices are small, like what route to take to work [27], or what music to listen to [64]. Others are big, like what treatment to administer for a disease [74] or how long to sentence someone for a crime [2]. If AI can assist with these big decisions, we might think it can also help with hard choices, cases where alternatives are neither better, worse nor equal but on a par [15]. The aim of this paper, however, is to show that this view is mistaken: the fact of parity shows that there are hard limits on AI in decision making and choices that AI cannot, and should not, resolve. KEYWORDS Value alignment; fairness; hard choices; AI ethics 1 Introduction Artificial intelligence (AI) is supposed to help us make be...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7b1fcae71ae04aa5.html
+++ b/public/events/arxiv_7b1fcae71ae04aa5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7b1fcae71ae04aa5.html
+++ b/public/events/arxiv_7b1fcae71ae04aa5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7bac61f7244aa0e9.html
+++ b/public/events/arxiv_7bac61f7244aa0e9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7bac61f7244aa0e9.html
+++ b/public/events/arxiv_7bac61f7244aa0e9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7bec26c394380c20.html
+++ b/public/events/arxiv_7bec26c394380c20.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7bec26c394380c20.html
+++ b/public/events/arxiv_7bec26c394380c20.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7c0a2d679a7a5ca5.html
+++ b/public/events/arxiv_7c0a2d679a7a5ca5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7c0a2d679a7a5ca5.html
+++ b/public/events/arxiv_7c0a2d679a7a5ca5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7c7c5101e999d894.html
+++ b/public/events/arxiv_7c7c5101e999d894.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7c7c5101e999d894.html
+++ b/public/events/arxiv_7c7c5101e999d894.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7cdb1233cf82deb9.html
+++ b/public/events/arxiv_7cdb1233cf82deb9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7cdb1233cf82deb9.html
+++ b/public/events/arxiv_7cdb1233cf82deb9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7cfec0e7f7a0495a.html
+++ b/public/events/arxiv_7cfec0e7f7a0495a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7cfec0e7f7a0495a.html
+++ b/public/events/arxiv_7cfec0e7f7a0495a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7d06b53a7df5e114.html
+++ b/public/events/arxiv_7d06b53a7df5e114.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7d06b53a7df5e114.html
+++ b/public/events/arxiv_7d06b53a7df5e114.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7d0c1226cf8dfc6c.html
+++ b/public/events/arxiv_7d0c1226cf8dfc6c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7d0c1226cf8dfc6c.html
+++ b/public/events/arxiv_7d0c1226cf8dfc6c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7d71464129d360de.html
+++ b/public/events/arxiv_7d71464129d360de.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7d71464129d360de.html
+++ b/public/events/arxiv_7d71464129d360de.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7d73ab05546a6fcf.html
+++ b/public/events/arxiv_7d73ab05546a6fcf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ computational intelligence, such as fuzzy logic, genetic
 algorithms, and case-based reasoning (Med...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7d73ab05546a6fcf.html
+++ b/public/events/arxiv_7d73ab05546a6fcf.html
@@ -455,7 +455,9 @@ algorithms, and case-based reasoning (Med...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ algorithms, and case-based reasoning (Med...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ algorithms, and case-based reasoning (Med...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7dd0fe90b65c5210.html
+++ b/public/events/arxiv_7dd0fe90b65c5210.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7dd0fe90b65c5210.html
+++ b/public/events/arxiv_7dd0fe90b65c5210.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7ddf442b31f9baa6.html
+++ b/public/events/arxiv_7ddf442b31f9baa6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7ddf442b31f9baa6.html
+++ b/public/events/arxiv_7ddf442b31f9baa6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7de0fab79d9a9abb.html
+++ b/public/events/arxiv_7de0fab79d9a9abb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7de0fab79d9a9abb.html
+++ b/public/events/arxiv_7de0fab79d9a9abb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7e373da22bc9542a.html
+++ b/public/events/arxiv_7e373da22bc9542a.html
@@ -450,7 +450,9 @@ further debates and discussions over thes...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ further debates and discussions over thes...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ further debates and discussions over thes...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7e373da22bc9542a.html
+++ b/public/events/arxiv_7e373da22bc9542a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ policymakers and political institutions across the world. Hopefully this long es
 further debates and discussions over thes...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7e5e07b1807afa4e.html
+++ b/public/events/arxiv_7e5e07b1807afa4e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7e5e07b1807afa4e.html
+++ b/public/events/arxiv_7e5e07b1807afa4e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7e8d35b265d75290.html
+++ b/public/events/arxiv_7e8d35b265d75290.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7e8d35b265d75290.html
+++ b/public/events/arxiv_7e8d35b265d75290.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7f8331f6c517ac35.html
+++ b/public/events/arxiv_7f8331f6c517ac35.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7f8331f6c517ac35.html
+++ b/public/events/arxiv_7f8331f6c517ac35.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7fe6d29db39a82b3.html
+++ b/public/events/arxiv_7fe6d29db39a82b3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7fe6d29db39a82b3.html
+++ b/public/events/arxiv_7fe6d29db39a82b3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_7ffcd3b363df9e5b.html
+++ b/public/events/arxiv_7ffcd3b363df9e5b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_7ffcd3b363df9e5b.html
+++ b/public/events/arxiv_7ffcd3b363df9e5b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8030d671c8dc7618.html
+++ b/public/events/arxiv_8030d671c8dc7618.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8030d671c8dc7618.html
+++ b/public/events/arxiv_8030d671c8dc7618.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_80458dc82661aceb.html
+++ b/public/events/arxiv_80458dc82661aceb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_80458dc82661aceb.html
+++ b/public/events/arxiv_80458dc82661aceb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_80b432979afaa876.html
+++ b/public/events/arxiv_80b432979afaa876.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_80b432979afaa876.html
+++ b/public/events/arxiv_80b432979afaa876.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_80f6a648f25568e2.html
+++ b/public/events/arxiv_80f6a648f25568e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_80f6a648f25568e2.html
+++ b/public/events/arxiv_80f6a648f25568e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_810e39a469917c9d.html
+++ b/public/events/arxiv_810e39a469917c9d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_810e39a469917c9d.html
+++ b/public/events/arxiv_810e39a469917c9d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_813257bd6020c643.html
+++ b/public/events/arxiv_813257bd6020c643.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_813257bd6020c643.html
+++ b/public/events/arxiv_813257bd6020c643.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_813db9ba4098d5fb.html
+++ b/public/events/arxiv_813db9ba4098d5fb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 Seite 1 von 44    Safe AI ? How is this possible?1   Harald Rue?  fortiss  Research Institute of the Free State of Bavaria for Software-Intensive Systems  [email address redacted] Simon Burton  Fraunhofer  Institute for Cognitive Systems   [email address redacted]    Munich, 4th February 2022         ?As we know,  there are known knowns.  There are things we know  we know.  We also know  there are known unknowns.  That is to say  we know there are  some things we do not know.  But there are also unknown unknowns, the ones we don?t know,  we don?t know.?  Donald Rumsfeld, Feb 2002, US DoD news briefing     1 This work is funded by the Bavarian Ministry for Economic Affairs, Regional Development and Energy as part of the fortiss AI Center and a project to support the thematic development of the Fraunhofer Institute for Cognitive Systems. We are also grateful to Carmen C?rlan and Henrik Putzer for their thorough remarks and suggestions for improvement; in particular, Figure 2...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_813db9ba4098d5fb.html
+++ b/public/events/arxiv_813db9ba4098d5fb.html
@@ -438,7 +438,9 @@ Seite 1 von 44    Safe AI ? How is this possible?1   Harald Rue?  fortiss  Resea
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@ Seite 1 von 44    Safe AI ? How is this possible?1   Harald Rue?  fortiss  Resea
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@ Seite 1 von 44    Safe AI ? How is this possible?1   Harald Rue?  fortiss  Resea
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8160fe2c96d6932f.html
+++ b/public/events/arxiv_8160fe2c96d6932f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8160fe2c96d6932f.html
+++ b/public/events/arxiv_8160fe2c96d6932f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_819170fb22a3fc27.html
+++ b/public/events/arxiv_819170fb22a3fc27.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_819170fb22a3fc27.html
+++ b/public/events/arxiv_819170fb22a3fc27.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_81938f6faa998c07.html
+++ b/public/events/arxiv_81938f6faa998c07.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_81938f6faa998c07.html
+++ b/public/events/arxiv_81938f6faa998c07.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_81a46f2c0a82c9ff.html
+++ b/public/events/arxiv_81a46f2c0a82c9ff.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_81a46f2c0a82c9ff.html
+++ b/public/events/arxiv_81a46f2c0a82c9ff.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_81cbec0f7ca3bf7e.html
+++ b/public/events/arxiv_81cbec0f7ca3bf7e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_81cbec0f7ca3bf7e.html
+++ b/public/events/arxiv_81cbec0f7ca3bf7e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_81d6196790eb7f2f.html
+++ b/public/events/arxiv_81d6196790eb7f2f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_81d6196790eb7f2f.html
+++ b/public/events/arxiv_81d6196790eb7f2f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_81e89e9c2a187565.html
+++ b/public/events/arxiv_81e89e9c2a187565.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_81e89e9c2a187565.html
+++ b/public/events/arxiv_81e89e9c2a187565.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_827b75911b8bf55a.html
+++ b/public/events/arxiv_827b75911b8bf55a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_827b75911b8bf55a.html
+++ b/public/events/arxiv_827b75911b8bf55a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8284c45318e073dc.html
+++ b/public/events/arxiv_8284c45318e073dc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8284c45318e073dc.html
+++ b/public/events/arxiv_8284c45318e073dc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_82972a89dab65e8f.html
+++ b/public/events/arxiv_82972a89dab65e8f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_82972a89dab65e8f.html
+++ b/public/events/arxiv_82972a89dab65e8f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_82a90bff040c2d54.html
+++ b/public/events/arxiv_82a90bff040c2d54.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_82a90bff040c2d54.html
+++ b/public/events/arxiv_82a90bff040c2d54.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_82d12f25322fcc11.html
+++ b/public/events/arxiv_82d12f25322fcc11.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_82d12f25322fcc11.html
+++ b/public/events/arxiv_82d12f25322fcc11.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_82e11ba0203ce145.html
+++ b/public/events/arxiv_82e11ba0203ce145.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_82e11ba0203ce145.html
+++ b/public/events/arxiv_82e11ba0203ce145.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_837ba9a1554593f1.html
+++ b/public/events/arxiv_837ba9a1554593f1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_837ba9a1554593f1.html
+++ b/public/events/arxiv_837ba9a1554593f1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_837f414b898df869.html
+++ b/public/events/arxiv_837f414b898df869.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -460,8 +461,21 @@ Please note, that this propos ed framework  is a livi ng document that will evol
 and improve with input from users, affect...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_837f414b898df869.html
+++ b/public/events/arxiv_837f414b898df869.html
@@ -465,7 +465,9 @@ and improve with input from users, affect...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -480,7 +482,7 @@ and improve with input from users, affect...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -488,19 +490,19 @@ and improve with input from users, affect...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_83849de1b9cb57cf.html
+++ b/public/events/arxiv_83849de1b9cb57cf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_83849de1b9cb57cf.html
+++ b/public/events/arxiv_83849de1b9cb57cf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_838c66e61a6f18fb.html
+++ b/public/events/arxiv_838c66e61a6f18fb.html
@@ -459,7 +459,9 @@ neural networks that are reliable and, in a certain sense, universal. In particu
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ neural networks that are reliable and, in a certain sense, universal. In particu
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ neural networks that are reliable and, in a certain sense, universal. In particu
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_838c66e61a6f18fb.html
+++ b/public/events/arxiv_838c66e61a6f18fb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ topic. Its principled nature also enables us to identify methods for both traini
 neural networks that are reliable and, in a certain sense, universal. In particular, they spe...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_839abeea475aefba.html
+++ b/public/events/arxiv_839abeea475aefba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -451,8 +452,21 @@ single failure of a superintelligent system may cause a catastrophic event witho
 recover y. The goal of cybersecurity is to reduce the num...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_839abeea475aefba.html
+++ b/public/events/arxiv_839abeea475aefba.html
@@ -456,7 +456,9 @@ recover y. The goal of cybersecurity is to reduce the num...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -471,7 +473,7 @@ recover y. The goal of cybersecurity is to reduce the num...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -479,19 +481,19 @@ recover y. The goal of cybersecurity is to reduce the num...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_839c200889ebc513.html
+++ b/public/events/arxiv_839c200889ebc513.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_839c200889ebc513.html
+++ b/public/events/arxiv_839c200889ebc513.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_84120dc4b15ae389.html
+++ b/public/events/arxiv_84120dc4b15ae389.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_84120dc4b15ae389.html
+++ b/public/events/arxiv_84120dc4b15ae389.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_844cb18b7b1f087b.html
+++ b/public/events/arxiv_844cb18b7b1f087b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_844cb18b7b1f087b.html
+++ b/public/events/arxiv_844cb18b7b1f087b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_846a5ff7a4b4af28.html
+++ b/public/events/arxiv_846a5ff7a4b4af28.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_846a5ff7a4b4af28.html
+++ b/public/events/arxiv_846a5ff7a4b4af28.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_84ae7baf831ae7f9.html
+++ b/public/events/arxiv_84ae7baf831ae7f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_84ae7baf831ae7f9.html
+++ b/public/events/arxiv_84ae7baf831ae7f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_84fc757d197d496d.html
+++ b/public/events/arxiv_84fc757d197d496d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_84fc757d197d496d.html
+++ b/public/events/arxiv_84fc757d197d496d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8526802e51962e60.html
+++ b/public/events/arxiv_8526802e51962e60.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ research and of the nature of scientific objectivity. We conducted 50 semi-struc
 with researchers in the rival camps of string theory and loop quantum gravity, coded a subset for reoccurring themes, and subjected the resulting data to statistical analysis. To delineate the subjective tastes and the related process of collective consensus-mak...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8526802e51962e60.html
+++ b/public/events/arxiv_8526802e51962e60.html
@@ -452,7 +452,9 @@ with researchers in the rival camps of string theory and loop quantum gravity, c
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ with researchers in the rival camps of string theory and loop quantum gravity, c
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ with researchers in the rival camps of string theory and loop quantum gravity, c
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_855de84aa73b3e51.html
+++ b/public/events/arxiv_855de84aa73b3e51.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_855de84aa73b3e51.html
+++ b/public/events/arxiv_855de84aa73b3e51.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_858b9038e0a18fff.html
+++ b/public/events/arxiv_858b9038e0a18fff.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_858b9038e0a18fff.html
+++ b/public/events/arxiv_858b9038e0a18fff.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_85d693126567d483.html
+++ b/public/events/arxiv_85d693126567d483.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_85d693126567d483.html
+++ b/public/events/arxiv_85d693126567d483.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_85f393e0d24a929a.html
+++ b/public/events/arxiv_85f393e0d24a929a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_85f393e0d24a929a.html
+++ b/public/events/arxiv_85f393e0d24a929a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8606d4d1cec21bda.html
+++ b/public/events/arxiv_8606d4d1cec21bda.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8606d4d1cec21bda.html
+++ b/public/events/arxiv_8606d4d1cec21bda.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_867cf2251f9d3258.html
+++ b/public/events/arxiv_867cf2251f9d3258.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_867cf2251f9d3258.html
+++ b/public/events/arxiv_867cf2251f9d3258.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_86930a39f73f75bf.html
+++ b/public/events/arxiv_86930a39f73f75bf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_86930a39f73f75bf.html
+++ b/public/events/arxiv_86930a39f73f75bf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_86d35e688b6e822a.html
+++ b/public/events/arxiv_86d35e688b6e822a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_86d35e688b6e822a.html
+++ b/public/events/arxiv_86d35e688b6e822a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_870cfbdf19d603ef.html
+++ b/public/events/arxiv_870cfbdf19d603ef.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_870cfbdf19d603ef.html
+++ b/public/events/arxiv_870cfbdf19d603ef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8712b809a4aca35e.html
+++ b/public/events/arxiv_8712b809a4aca35e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8712b809a4aca35e.html
+++ b/public/events/arxiv_8712b809a4aca35e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8726f32562cff5eb.html
+++ b/public/events/arxiv_8726f32562cff5eb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8726f32562cff5eb.html
+++ b/public/events/arxiv_8726f32562cff5eb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
  2 Abstract: Building artificial intelligence (AI) that aligns with human values is an unsolved problem. Here, we developed a human-in-the-loop research pipeline called Democratic AI, in which reinforcement learning is used to design a social mechanism that humans prefer by majority. A large group of hu...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_87702a5b51dcf88e.html
+++ b/public/events/arxiv_87702a5b51dcf88e.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_87702a5b51dcf88e.html
+++ b/public/events/arxiv_87702a5b51dcf88e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Abstract Like any technology, AI systems come with inher-ent risks and potential benefits. It comes with po-tential disruption of established norms and methods of work, societal impacts and externalities. One may think of the adoption of technology as a form of social contract, which may evolve or fluctuate in time, scale, and impact. It is important to keep in mind that for AI, meeting the expectations of this social contract is critical, because recklessly driv-ing the adoption and implementation of unsafe, ir-responsible, or unethical AI systems may trigger serious backlash against industry and academia in-volved which could take decades to resolve, if not actually seriously harm society. For the purpose of this paper, we consider that a social contract arises when there is sufficient consensus within society to adopt and implement this new technology. As such, to enable a social contract to arise for the adoption and implementation of AI, developing:  1) A socially accepted purp...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_87cef25502a7208a.html
+++ b/public/events/arxiv_87cef25502a7208a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_87cef25502a7208a.html
+++ b/public/events/arxiv_87cef25502a7208a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_88857fbe01e7fa53.html
+++ b/public/events/arxiv_88857fbe01e7fa53.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_88857fbe01e7fa53.html
+++ b/public/events/arxiv_88857fbe01e7fa53.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_88b89589d5046f88.html
+++ b/public/events/arxiv_88b89589d5046f88.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_88b89589d5046f88.html
+++ b/public/events/arxiv_88b89589d5046f88.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8921c4e2df86ea16.html
+++ b/public/events/arxiv_8921c4e2df86ea16.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8921c4e2df86ea16.html
+++ b/public/events/arxiv_8921c4e2df86ea16.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_894271b0598a47c6.html
+++ b/public/events/arxiv_894271b0598a47c6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_894271b0598a47c6.html
+++ b/public/events/arxiv_894271b0598a47c6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_89cd3ef79c4ea526.html
+++ b/public/events/arxiv_89cd3ef79c4ea526.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_89cd3ef79c4ea526.html
+++ b/public/events/arxiv_89cd3ef79c4ea526.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8a86edf03dc7b48a.html
+++ b/public/events/arxiv_8a86edf03dc7b48a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8a86edf03dc7b48a.html
+++ b/public/events/arxiv_8a86edf03dc7b48a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8a978f212608a025.html
+++ b/public/events/arxiv_8a978f212608a025.html
@@ -34,6 +34,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -439,8 +440,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8a978f212608a025.html
+++ b/public/events/arxiv_8a978f212608a025.html
@@ -444,7 +444,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -459,7 +461,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -467,19 +469,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ab49e34de5d3ecd.html
+++ b/public/events/arxiv_8ab49e34de5d3ecd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ab49e34de5d3ecd.html
+++ b/public/events/arxiv_8ab49e34de5d3ecd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8ac12fda3d813829.html
+++ b/public/events/arxiv_8ac12fda3d813829.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ac12fda3d813829.html
+++ b/public/events/arxiv_8ac12fda3d813829.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8b3ae15fc7ee249e.html
+++ b/public/events/arxiv_8b3ae15fc7ee249e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8b3ae15fc7ee249e.html
+++ b/public/events/arxiv_8b3ae15fc7ee249e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8b4d803b67aaf3b9.html
+++ b/public/events/arxiv_8b4d803b67aaf3b9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8b4d803b67aaf3b9.html
+++ b/public/events/arxiv_8b4d803b67aaf3b9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8b5c292409e3da52.html
+++ b/public/events/arxiv_8b5c292409e3da52.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8b5c292409e3da52.html
+++ b/public/events/arxiv_8b5c292409e3da52.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8b6e99864384b269.html
+++ b/public/events/arxiv_8b6e99864384b269.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -434,8 +435,21 @@ convention
 -------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8b6e99864384b269.html
+++ b/public/events/arxiv_8b6e99864384b269.html
@@ -439,7 +439,9 @@ convention
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -454,7 +456,7 @@ convention
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -462,19 +464,19 @@ convention
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ba0cd4cd001a53e.html
+++ b/public/events/arxiv_8ba0cd4cd001a53e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ba0cd4cd001a53e.html
+++ b/public/events/arxiv_8ba0cd4cd001a53e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8bd5e5d8b24864fd.html
+++ b/public/events/arxiv_8bd5e5d8b24864fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8bd5e5d8b24864fd.html
+++ b/public/events/arxiv_8bd5e5d8b24864fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8bea59ce45262782.html
+++ b/public/events/arxiv_8bea59ce45262782.html
@@ -441,7 +441,9 @@ for Mechanistic Interpretability</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ for Mechanistic Interpretability</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ for Mechanistic Interpretability</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8bea59ce45262782.html
+++ b/public/events/arxiv_8bea59ce45262782.html
@@ -33,6 +33,7 @@ for Mechanistic Interpretability | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ for Mechanistic Interpretability</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8c44535e5835b120.html
+++ b/public/events/arxiv_8c44535e5835b120.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -453,8 +454,21 @@ LAIP, an effort and platform for linking and analyzing differ-
 ent Artif icial Intelligence Principles. We want to ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8c44535e5835b120.html
+++ b/public/events/arxiv_8c44535e5835b120.html
@@ -458,7 +458,9 @@ ent Artif icial Intelligence Principles. We want to ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -473,7 +475,7 @@ ent Artif icial Intelligence Principles. We want to ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -481,19 +483,19 @@ ent Artif icial Intelligence Principles. We want to ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8c46e9a4bb322ee9.html
+++ b/public/events/arxiv_8c46e9a4bb322ee9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ development. This paper presents a graphical model of major pathways to ASI cata
 focusing o...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8c46e9a4bb322ee9.html
+++ b/public/events/arxiv_8c46e9a4bb322ee9.html
@@ -451,7 +451,9 @@ focusing o...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ focusing o...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ focusing o...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8c5a3cc4714aba1a.html
+++ b/public/events/arxiv_8c5a3cc4714aba1a.html
@@ -450,7 +450,9 @@ a complexity -performance trade -off whilst  d...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ a complexity -performance trade -off whilst  d...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ a complexity -performance trade -off whilst  d...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8c5a3cc4714aba1a.html
+++ b/public/events/arxiv_8c5a3cc4714aba1a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ abstraction that underpin many AI implementations . We further posit that each l
 a complexity -performance trade -off whilst  d...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8c6ea1b019a85b11.html
+++ b/public/events/arxiv_8c6ea1b019a85b11.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8c6ea1b019a85b11.html
+++ b/public/events/arxiv_8c6ea1b019a85b11.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8c9b4b4fa66e855a.html
+++ b/public/events/arxiv_8c9b4b4fa66e855a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8c9b4b4fa66e855a.html
+++ b/public/events/arxiv_8c9b4b4fa66e855a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8cd0e4f9e43b214e.html
+++ b/public/events/arxiv_8cd0e4f9e43b214e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8cd0e4f9e43b214e.html
+++ b/public/events/arxiv_8cd0e4f9e43b214e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8d6bfe9fd2b3c455.html
+++ b/public/events/arxiv_8d6bfe9fd2b3c455.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8d6bfe9fd2b3c455.html
+++ b/public/events/arxiv_8d6bfe9fd2b3c455.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8d97dd0f7dbc55a0.html
+++ b/public/events/arxiv_8d97dd0f7dbc55a0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8d97dd0f7dbc55a0.html
+++ b/public/events/arxiv_8d97dd0f7dbc55a0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8dfe174756251e0d.html
+++ b/public/events/arxiv_8dfe174756251e0d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8dfe174756251e0d.html
+++ b/public/events/arxiv_8dfe174756251e0d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8e0b3bede15d2844.html
+++ b/public/events/arxiv_8e0b3bede15d2844.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8e0b3bede15d2844.html
+++ b/public/events/arxiv_8e0b3bede15d2844.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8e8ab37d7a89166c.html
+++ b/public/events/arxiv_8e8ab37d7a89166c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8e8ab37d7a89166c.html
+++ b/public/events/arxiv_8e8ab37d7a89166c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8ef5690345b73a74.html
+++ b/public/events/arxiv_8ef5690345b73a74.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8ef5690345b73a74.html
+++ b/public/events/arxiv_8ef5690345b73a74.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8f0ba0c8ecc32b17.html
+++ b/public/events/arxiv_8f0ba0c8ecc32b17.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8f0ba0c8ecc32b17.html
+++ b/public/events/arxiv_8f0ba0c8ecc32b17.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8fad072693ba66f9.html
+++ b/public/events/arxiv_8fad072693ba66f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8fad072693ba66f9.html
+++ b/public/events/arxiv_8fad072693ba66f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8fb6f61cf1e07a5b.html
+++ b/public/events/arxiv_8fb6f61cf1e07a5b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8fb6f61cf1e07a5b.html
+++ b/public/events/arxiv_8fb6f61cf1e07a5b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_8fc7eef981a673d2.html
+++ b/public/events/arxiv_8fc7eef981a673d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_8fc7eef981a673d2.html
+++ b/public/events/arxiv_8fc7eef981a673d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_90075e5d06ca1445.html
+++ b/public/events/arxiv_90075e5d06ca1445.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_90075e5d06ca1445.html
+++ b/public/events/arxiv_90075e5d06ca1445.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_901b2797a974e580.html
+++ b/public/events/arxiv_901b2797a974e580.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_901b2797a974e580.html
+++ b/public/events/arxiv_901b2797a974e580.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9037f853d10c9ac1.html
+++ b/public/events/arxiv_9037f853d10c9ac1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9037f853d10c9ac1.html
+++ b/public/events/arxiv_9037f853d10c9ac1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_90af76072fa913d7.html
+++ b/public/events/arxiv_90af76072fa913d7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_90af76072fa913d7.html
+++ b/public/events/arxiv_90af76072fa913d7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_90b5d7af9f5da8bf.html
+++ b/public/events/arxiv_90b5d7af9f5da8bf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_90b5d7af9f5da8bf.html
+++ b/public/events/arxiv_90b5d7af9f5da8bf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_90c0cd83d6e802b5.html
+++ b/public/events/arxiv_90c0cd83d6e802b5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_90c0cd83d6e802b5.html
+++ b/public/events/arxiv_90c0cd83d6e802b5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_913763e4d36b0f9e.html
+++ b/public/events/arxiv_913763e4d36b0f9e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_913763e4d36b0f9e.html
+++ b/public/events/arxiv_913763e4d36b0f9e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_915a21392784fa54.html
+++ b/public/events/arxiv_915a21392784fa54.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_915a21392784fa54.html
+++ b/public/events/arxiv_915a21392784fa54.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_919161b4469fbbd2.html
+++ b/public/events/arxiv_919161b4469fbbd2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_919161b4469fbbd2.html
+++ b/public/events/arxiv_919161b4469fbbd2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_92555068989b194c.html
+++ b/public/events/arxiv_92555068989b194c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_92555068989b194c.html
+++ b/public/events/arxiv_92555068989b194c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_92a5e7db3083500c.html
+++ b/public/events/arxiv_92a5e7db3083500c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_92a5e7db3083500c.html
+++ b/public/events/arxiv_92a5e7db3083500c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_92cde803b8cb2b1d.html
+++ b/public/events/arxiv_92cde803b8cb2b1d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_92cde803b8cb2b1d.html
+++ b/public/events/arxiv_92cde803b8cb2b1d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_92d190e68f6baabb.html
+++ b/public/events/arxiv_92d190e68f6baabb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_92d190e68f6baabb.html
+++ b/public/events/arxiv_92d190e68f6baabb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9312ad006aca35cb.html
+++ b/public/events/arxiv_9312ad006aca35cb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9312ad006aca35cb.html
+++ b/public/events/arxiv_9312ad006aca35cb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9330b17f4620fb2e.html
+++ b/public/events/arxiv_9330b17f4620fb2e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9330b17f4620fb2e.html
+++ b/public/events/arxiv_9330b17f4620fb2e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_93539db90a16dfab.html
+++ b/public/events/arxiv_93539db90a16dfab.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_93539db90a16dfab.html
+++ b/public/events/arxiv_93539db90a16dfab.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9395c3d0914d369d.html
+++ b/public/events/arxiv_9395c3d0914d369d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9395c3d0914d369d.html
+++ b/public/events/arxiv_9395c3d0914d369d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_93b71b609bfa6bfb.html
+++ b/public/events/arxiv_93b71b609bfa6bfb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_93b71b609bfa6bfb.html
+++ b/public/events/arxiv_93b71b609bfa6bfb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_942a97fcf69f4e99.html
+++ b/public/events/arxiv_942a97fcf69f4e99.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_942a97fcf69f4e99.html
+++ b/public/events/arxiv_942a97fcf69f4e99.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_94c39b5469e86981.html
+++ b/public/events/arxiv_94c39b5469e86981.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_94c39b5469e86981.html
+++ b/public/events/arxiv_94c39b5469e86981.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_950357c48af62862.html
+++ b/public/events/arxiv_950357c48af62862.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_950357c48af62862.html
+++ b/public/events/arxiv_950357c48af62862.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9588974df808d2b1.html
+++ b/public/events/arxiv_9588974df808d2b1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9588974df808d2b1.html
+++ b/public/events/arxiv_9588974df808d2b1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_95aad70e56a97db6.html
+++ b/public/events/arxiv_95aad70e56a97db6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ sequences of AI development for design. Our rationale is to avoid
 repeating hype-associated dialogue of utopian/dy...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_95aad70e56a97db6.html
+++ b/public/events/arxiv_95aad70e56a97db6.html
@@ -452,7 +452,9 @@ repeating hype-associated dialogue of utopian/dy...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ repeating hype-associated dialogue of utopian/dy...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ repeating hype-associated dialogue of utopian/dy...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_95b381a292b906e9.html
+++ b/public/events/arxiv_95b381a292b906e9.html
@@ -465,7 +465,9 @@ and institutions while existing inst...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -480,7 +482,7 @@ and institutions while existing inst...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -488,19 +490,19 @@ and institutions while existing inst...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_95b381a292b906e9.html
+++ b/public/events/arxiv_95b381a292b906e9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -460,8 +461,21 @@ creates a dynamic in which algorithms (re)shape organizations
 and institutions while existing inst...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_95d1b51c0ecc6684.html
+++ b/public/events/arxiv_95d1b51c0ecc6684.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_95d1b51c0ecc6684.html
+++ b/public/events/arxiv_95d1b51c0ecc6684.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_961c51700a43ebc0.html
+++ b/public/events/arxiv_961c51700a43ebc0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_961c51700a43ebc0.html
+++ b/public/events/arxiv_961c51700a43ebc0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_96251f8fa8c416e4.html
+++ b/public/events/arxiv_96251f8fa8c416e4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_96251f8fa8c416e4.html
+++ b/public/events/arxiv_96251f8fa8c416e4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_964be84536460180.html
+++ b/public/events/arxiv_964be84536460180.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_964be84536460180.html
+++ b/public/events/arxiv_964be84536460180.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_96a14c1f19757223.html
+++ b/public/events/arxiv_96a14c1f19757223.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_96a14c1f19757223.html
+++ b/public/events/arxiv_96a14c1f19757223.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_96bb7a101a3081a5.html
+++ b/public/events/arxiv_96bb7a101a3081a5.html
@@ -444,7 +444,9 @@ the Inner Structures of Deep Neural Networks
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -459,7 +461,7 @@ the Inner Structures of Deep Neural Networks
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -467,19 +469,19 @@ the Inner Structures of Deep Neural Networks
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_96bb7a101a3081a5.html
+++ b/public/events/arxiv_96bb7a101a3081a5.html
@@ -34,6 +34,7 @@ the Inner Structures of Deep Neural Networks
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -439,8 +440,21 @@ the Inner Structures of Deep Neural Networks
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_96cde62c4dd6e7be.html
+++ b/public/events/arxiv_96cde62c4dd6e7be.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_96cde62c4dd6e7be.html
+++ b/public/events/arxiv_96cde62c4dd6e7be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_96d146702316db21.html
+++ b/public/events/arxiv_96d146702316db21.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_96d146702316db21.html
+++ b/public/events/arxiv_96d146702316db21.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_97a6e556f7ea88f7.html
+++ b/public/events/arxiv_97a6e556f7ea88f7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_97a6e556f7ea88f7.html
+++ b/public/events/arxiv_97a6e556f7ea88f7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_980dbd86b111912d.html
+++ b/public/events/arxiv_980dbd86b111912d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_980dbd86b111912d.html
+++ b/public/events/arxiv_980dbd86b111912d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9888ab8acacc8f4a.html
+++ b/public/events/arxiv_9888ab8acacc8f4a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9888ab8acacc8f4a.html
+++ b/public/events/arxiv_9888ab8acacc8f4a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_98c0ce5ebb1c5dc9.html
+++ b/public/events/arxiv_98c0ce5ebb1c5dc9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_98c0ce5ebb1c5dc9.html
+++ b/public/events/arxiv_98c0ce5ebb1c5dc9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_99047282a1efb81b.html
+++ b/public/events/arxiv_99047282a1efb81b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_99047282a1efb81b.html
+++ b/public/events/arxiv_99047282a1efb81b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9957f33fc4faa835.html
+++ b/public/events/arxiv_9957f33fc4faa835.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9957f33fc4faa835.html
+++ b/public/events/arxiv_9957f33fc4faa835.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_996788ee14c025d6.html
+++ b/public/events/arxiv_996788ee14c025d6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_996788ee14c025d6.html
+++ b/public/events/arxiv_996788ee14c025d6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9985528a03f79df7.html
+++ b/public/events/arxiv_9985528a03f79df7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9985528a03f79df7.html
+++ b/public/events/arxiv_9985528a03f79df7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_999fd36ceabc972b.html
+++ b/public/events/arxiv_999fd36ceabc972b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_999fd36ceabc972b.html
+++ b/public/events/arxiv_999fd36ceabc972b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_99cb587661c88b56.html
+++ b/public/events/arxiv_99cb587661c88b56.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_99cb587661c88b56.html
+++ b/public/events/arxiv_99cb587661c88b56.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9a865c22fd02cd19.html
+++ b/public/events/arxiv_9a865c22fd02cd19.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9a865c22fd02cd19.html
+++ b/public/events/arxiv_9a865c22fd02cd19.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9ab3cecfa4c1951e.html
+++ b/public/events/arxiv_9ab3cecfa4c1951e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9ab3cecfa4c1951e.html
+++ b/public/events/arxiv_9ab3cecfa4c1951e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9ad41374f53f74d9.html
+++ b/public/events/arxiv_9ad41374f53f74d9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9ad41374f53f74d9.html
+++ b/public/events/arxiv_9ad41374f53f74d9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9afb76ce70b2f78e.html
+++ b/public/events/arxiv_9afb76ce70b2f78e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9afb76ce70b2f78e.html
+++ b/public/events/arxiv_9afb76ce70b2f78e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9b07c785b4cee566.html
+++ b/public/events/arxiv_9b07c785b4cee566.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9b07c785b4cee566.html
+++ b/public/events/arxiv_9b07c785b4cee566.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9b11f2b4d3a6a111.html
+++ b/public/events/arxiv_9b11f2b4d3a6a111.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9b11f2b4d3a6a111.html
+++ b/public/events/arxiv_9b11f2b4d3a6a111.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9bb1056693c6746e.html
+++ b/public/events/arxiv_9bb1056693c6746e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9bb1056693c6746e.html
+++ b/public/events/arxiv_9bb1056693c6746e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9bba061071a331e9.html
+++ b/public/events/arxiv_9bba061071a331e9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9bba061071a331e9.html
+++ b/public/events/arxiv_9bba061071a331e9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9c2fbcdfc8dd0ae5.html
+++ b/public/events/arxiv_9c2fbcdfc8dd0ae5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9c2fbcdfc8dd0ae5.html
+++ b/public/events/arxiv_9c2fbcdfc8dd0ae5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9c44e9033875db80.html
+++ b/public/events/arxiv_9c44e9033875db80.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9c44e9033875db80.html
+++ b/public/events/arxiv_9c44e9033875db80.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9c5d157ee6114e5f.html
+++ b/public/events/arxiv_9c5d157ee6114e5f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9c5d157ee6114e5f.html
+++ b/public/events/arxiv_9c5d157ee6114e5f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9c87c9876c628a0d.html
+++ b/public/events/arxiv_9c87c9876c628a0d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9c87c9876c628a0d.html
+++ b/public/events/arxiv_9c87c9876c628a0d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9c912055d2d387ee.html
+++ b/public/events/arxiv_9c912055d2d387ee.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9c912055d2d387ee.html
+++ b/public/events/arxiv_9c912055d2d387ee.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9cce57483fe0df92.html
+++ b/public/events/arxiv_9cce57483fe0df92.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9cce57483fe0df92.html
+++ b/public/events/arxiv_9cce57483fe0df92.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">The Transformative Potential of Artificial Intelligence  Ross Gruetzemacher? and Jess Whittlestone? ? Wichita State University, W. Frank Barton School of Business, [email address redacted]  ? University of Cambridge, Leverhulme Centre for the Future of Intelligence, [email address redacted]    Abstract  The terms ?human-level artificial intelligence? and ?artificial general intelligence? are widely used to refer to the possibility of advanced artificial intelligence (AI) with potentially extreme impacts on society. These terms are poorly defined and do not necessarily indicate what is most important with respect to future societal impacts. We suggest that the term ?transformative AI? is a helpful alternative, reflecting the possibility that advanced AI systems could have very large impacts on society without reaching human-level cognitive abilities. To be most useful, however, more analysis of what it means for AI to be ?transformative? is needed. In this paper, we propose three differ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9d9b44a5a1618980.html
+++ b/public/events/arxiv_9d9b44a5a1618980.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9d9b44a5a1618980.html
+++ b/public/events/arxiv_9d9b44a5a1618980.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9daa7dac3bcd0dbc.html
+++ b/public/events/arxiv_9daa7dac3bcd0dbc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9daa7dac3bcd0dbc.html
+++ b/public/events/arxiv_9daa7dac3bcd0dbc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9e60622ab79fb17b.html
+++ b/public/events/arxiv_9e60622ab79fb17b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9e60622ab79fb17b.html
+++ b/public/events/arxiv_9e60622ab79fb17b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9e6cbed97f1b3bc3.html
+++ b/public/events/arxiv_9e6cbed97f1b3bc3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9e6cbed97f1b3bc3.html
+++ b/public/events/arxiv_9e6cbed97f1b3bc3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9e8530cde437a62a.html
+++ b/public/events/arxiv_9e8530cde437a62a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9e8530cde437a62a.html
+++ b/public/events/arxiv_9e8530cde437a62a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9e9525f3735aa4c6.html
+++ b/public/events/arxiv_9e9525f3735aa4c6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9e9525f3735aa4c6.html
+++ b/public/events/arxiv_9e9525f3735aa4c6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9eb0eb98a9c82939.html
+++ b/public/events/arxiv_9eb0eb98a9c82939.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9eb0eb98a9c82939.html
+++ b/public/events/arxiv_9eb0eb98a9c82939.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9ee7e2ee3bd59130.html
+++ b/public/events/arxiv_9ee7e2ee3bd59130.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9ee7e2ee3bd59130.html
+++ b/public/events/arxiv_9ee7e2ee3bd59130.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9f33f3f44f3ec144.html
+++ b/public/events/arxiv_9f33f3f44f3ec144.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9f33f3f44f3ec144.html
+++ b/public/events/arxiv_9f33f3f44f3ec144.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9f4e3db3a06a3c14.html
+++ b/public/events/arxiv_9f4e3db3a06a3c14.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9f4e3db3a06a3c14.html
+++ b/public/events/arxiv_9f4e3db3a06a3c14.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9f93c053bb136fda.html
+++ b/public/events/arxiv_9f93c053bb136fda.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9f93c053bb136fda.html
+++ b/public/events/arxiv_9f93c053bb136fda.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_9fccf5af82caf9b8.html
+++ b/public/events/arxiv_9fccf5af82caf9b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_9fccf5af82caf9b8.html
+++ b/public/events/arxiv_9fccf5af82caf9b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a0402d3a00d97e1e.html
+++ b/public/events/arxiv_a0402d3a00d97e1e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a0402d3a00d97e1e.html
+++ b/public/events/arxiv_a0402d3a00d97e1e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a045c0d911610f0a.html
+++ b/public/events/arxiv_a045c0d911610f0a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a045c0d911610f0a.html
+++ b/public/events/arxiv_a045c0d911610f0a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a0c29a80d370bee9.html
+++ b/public/events/arxiv_a0c29a80d370bee9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a0c29a80d370bee9.html
+++ b/public/events/arxiv_a0c29a80d370bee9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a0da85a1768c4325.html
+++ b/public/events/arxiv_a0da85a1768c4325.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a0da85a1768c4325.html
+++ b/public/events/arxiv_a0da85a1768c4325.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a112033c840b0762.html
+++ b/public/events/arxiv_a112033c840b0762.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -461,8 +462,21 @@ addressing risks of events with catastrophic consequences, NIST indicated a need
 from high level principles to ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a112033c840b0762.html
+++ b/public/events/arxiv_a112033c840b0762.html
@@ -466,7 +466,9 @@ from high level principles to ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -481,7 +483,7 @@ from high level principles to ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -489,19 +491,19 @@ from high level principles to ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a11519be70a65610.html
+++ b/public/events/arxiv_a11519be70a65610.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a11519be70a65610.html
+++ b/public/events/arxiv_a11519be70a65610.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a15c6ca117433170.html
+++ b/public/events/arxiv_a15c6ca117433170.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a15c6ca117433170.html
+++ b/public/events/arxiv_a15c6ca117433170.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1647aa4fae04ddf.html
+++ b/public/events/arxiv_a1647aa4fae04ddf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ questions about the nature, value, and future of library and information science
 attention from LIS scholars. We present highlights from its ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1647aa4fae04ddf.html
+++ b/public/events/arxiv_a1647aa4fae04ddf.html
@@ -455,7 +455,9 @@ attention from LIS scholars. We present highlights from its ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ attention from LIS scholars. We present highlights from its ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ attention from LIS scholars. We present highlights from its ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a18e21777c6faa10.html
+++ b/public/events/arxiv_a18e21777c6faa10.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a18e21777c6faa10.html
+++ b/public/events/arxiv_a18e21777c6faa10.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1abb2d6195be076.html
+++ b/public/events/arxiv_a1abb2d6195be076.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a1abb2d6195be076.html
+++ b/public/events/arxiv_a1abb2d6195be076.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1cdc1892cbdbd73.html
+++ b/public/events/arxiv_a1cdc1892cbdbd73.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a1cdc1892cbdbd73.html
+++ b/public/events/arxiv_a1cdc1892cbdbd73.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1e6c86b13e4cc51.html
+++ b/public/events/arxiv_a1e6c86b13e4cc51.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Fooling the primate brain with minimal, targeted image manipulation</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a1e6c86b13e4cc51.html
+++ b/public/events/arxiv_a1e6c86b13e4cc51.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a20e7aa50600de9a.html
+++ b/public/events/arxiv_a20e7aa50600de9a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a20e7aa50600de9a.html
+++ b/public/events/arxiv_a20e7aa50600de9a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a24b6a306ac63ccf.html
+++ b/public/events/arxiv_a24b6a306ac63ccf.html
@@ -455,7 +455,9 @@ strategy to t...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ strategy to t...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ strategy to t...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a24b6a306ac63ccf.html
+++ b/public/events/arxiv_a24b6a306ac63ccf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ is to provide an algorithm that prescribes a randomized
 strategy to t...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a262d9743e00d855.html
+++ b/public/events/arxiv_a262d9743e00d855.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a262d9743e00d855.html
+++ b/public/events/arxiv_a262d9743e00d855.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a26655f80e9f2932.html
+++ b/public/events/arxiv_a26655f80e9f2932.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a26655f80e9f2932.html
+++ b/public/events/arxiv_a26655f80e9f2932.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a2adaf3e37e06221.html
+++ b/public/events/arxiv_a2adaf3e37e06221.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a2adaf3e37e06221.html
+++ b/public/events/arxiv_a2adaf3e37e06221.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a2c958c9052a7d8d.html
+++ b/public/events/arxiv_a2c958c9052a7d8d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a2c958c9052a7d8d.html
+++ b/public/events/arxiv_a2c958c9052a7d8d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a2fa77ab4077cf22.html
+++ b/public/events/arxiv_a2fa77ab4077cf22.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a2fa77ab4077cf22.html
+++ b/public/events/arxiv_a2fa77ab4077cf22.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a330fb6324994e69.html
+++ b/public/events/arxiv_a330fb6324994e69.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a330fb6324994e69.html
+++ b/public/events/arxiv_a330fb6324994e69.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a338ff49276e0aa0.html
+++ b/public/events/arxiv_a338ff49276e0aa0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a338ff49276e0aa0.html
+++ b/public/events/arxiv_a338ff49276e0aa0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a359baed17693d64.html
+++ b/public/events/arxiv_a359baed17693d64.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a359baed17693d64.html
+++ b/public/events/arxiv_a359baed17693d64.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a3b00e2c7467d45b.html
+++ b/public/events/arxiv_a3b00e2c7467d45b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a3b00e2c7467d45b.html
+++ b/public/events/arxiv_a3b00e2c7467d45b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a40668486fbcb879.html
+++ b/public/events/arxiv_a40668486fbcb879.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a40668486fbcb879.html
+++ b/public/events/arxiv_a40668486fbcb879.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a42af15d067364d3.html
+++ b/public/events/arxiv_a42af15d067364d3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a42af15d067364d3.html
+++ b/public/events/arxiv_a42af15d067364d3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a444c76549f57bb1.html
+++ b/public/events/arxiv_a444c76549f57bb1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a444c76549f57bb1.html
+++ b/public/events/arxiv_a444c76549f57bb1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a4d7c73ba1684f7f.html
+++ b/public/events/arxiv_a4d7c73ba1684f7f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a4d7c73ba1684f7f.html
+++ b/public/events/arxiv_a4d7c73ba1684f7f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a5042b5aab956d77.html
+++ b/public/events/arxiv_a5042b5aab956d77.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a5042b5aab956d77.html
+++ b/public/events/arxiv_a5042b5aab956d77.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a52b988d2135f299.html
+++ b/public/events/arxiv_a52b988d2135f299.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a52b988d2135f299.html
+++ b/public/events/arxiv_a52b988d2135f299.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a52d7e463ed25117.html
+++ b/public/events/arxiv_a52d7e463ed25117.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a52d7e463ed25117.html
+++ b/public/events/arxiv_a52d7e463ed25117.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a57f6329c975e596.html
+++ b/public/events/arxiv_a57f6329c975e596.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a57f6329c975e596.html
+++ b/public/events/arxiv_a57f6329c975e596.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a5e4ac92c362434f.html
+++ b/public/events/arxiv_a5e4ac92c362434f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a5e4ac92c362434f.html
+++ b/public/events/arxiv_a5e4ac92c362434f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a644f0a3cb02d2e2.html
+++ b/public/events/arxiv_a644f0a3cb02d2e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a644f0a3cb02d2e2.html
+++ b/public/events/arxiv_a644f0a3cb02d2e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a69b3787f140388f.html
+++ b/public/events/arxiv_a69b3787f140388f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a69b3787f140388f.html
+++ b/public/events/arxiv_a69b3787f140388f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a69c2e9998290359.html
+++ b/public/events/arxiv_a69c2e9998290359.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a69c2e9998290359.html
+++ b/public/events/arxiv_a69c2e9998290359.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a6c16cdd16ab2351.html
+++ b/public/events/arxiv_a6c16cdd16ab2351.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a6c16cdd16ab2351.html
+++ b/public/events/arxiv_a6c16cdd16ab2351.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a729a26f4f765bad.html
+++ b/public/events/arxiv_a729a26f4f765bad.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ risk-aware solutions with respect to model uncertainty. But when it comes to the
 which baseline should...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a729a26f4f765bad.html
+++ b/public/events/arxiv_a729a26f4f765bad.html
@@ -450,7 +450,9 @@ which baseline should...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ which baseline should...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ which baseline should...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a76d89c0283d4a2e.html
+++ b/public/events/arxiv_a76d89c0283d4a2e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a76d89c0283d4a2e.html
+++ b/public/events/arxiv_a76d89c0283d4a2e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a7a43764ffb482b6.html
+++ b/public/events/arxiv_a7a43764ffb482b6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a7a43764ffb482b6.html
+++ b/public/events/arxiv_a7a43764ffb482b6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a7adb7958fc7de7b.html
+++ b/public/events/arxiv_a7adb7958fc7de7b.html
@@ -453,7 +453,9 @@ assuming the worst case. A scalar parameter tunes the agen...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ assuming the worst case. A scalar parameter tunes the agen...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ assuming the worst case. A scalar parameter tunes the agen...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a7adb7958fc7de7b.html
+++ b/public/events/arxiv_a7adb7958fc7de7b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ expected reward over a set of world-models. We call this agen t pessimistic, sin
 assuming the worst case. A scalar parameter tunes the agen...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a7ee381d857e98a8.html
+++ b/public/events/arxiv_a7ee381d857e98a8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a7ee381d857e98a8.html
+++ b/public/events/arxiv_a7ee381d857e98a8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a836978dfbfc5b75.html
+++ b/public/events/arxiv_a836978dfbfc5b75.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a836978dfbfc5b75.html
+++ b/public/events/arxiv_a836978dfbfc5b75.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a8804756ba4b9e2c.html
+++ b/public/events/arxiv_a8804756ba4b9e2c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a8804756ba4b9e2c.html
+++ b/public/events/arxiv_a8804756ba4b9e2c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a8b94f643fb93c80.html
+++ b/public/events/arxiv_a8b94f643fb93c80.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a8b94f643fb93c80.html
+++ b/public/events/arxiv_a8b94f643fb93c80.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a8daf511a90c10f6.html
+++ b/public/events/arxiv_a8daf511a90c10f6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a8daf511a90c10f6.html
+++ b/public/events/arxiv_a8daf511a90c10f6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a8e7867b6a274601.html
+++ b/public/events/arxiv_a8e7867b6a274601.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a8e7867b6a274601.html
+++ b/public/events/arxiv_a8e7867b6a274601.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a8f634af414f0b09.html
+++ b/public/events/arxiv_a8f634af414f0b09.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a8f634af414f0b09.html
+++ b/public/events/arxiv_a8f634af414f0b09.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a99ca4e2ecd6377e.html
+++ b/public/events/arxiv_a99ca4e2ecd6377e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a99ca4e2ecd6377e.html
+++ b/public/events/arxiv_a99ca4e2ecd6377e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a9df46959c30e10d.html
+++ b/public/events/arxiv_a9df46959c30e10d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a9df46959c30e10d.html
+++ b/public/events/arxiv_a9df46959c30e10d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_a9e748f28cffc103.html
+++ b/public/events/arxiv_a9e748f28cffc103.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_a9e748f28cffc103.html
+++ b/public/events/arxiv_a9e748f28cffc103.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa17774e4a5a1010.html
+++ b/public/events/arxiv_aa17774e4a5a1010.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa17774e4a5a1010.html
+++ b/public/events/arxiv_aa17774e4a5a1010.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa2397b1dcdda034.html
+++ b/public/events/arxiv_aa2397b1dcdda034.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa2397b1dcdda034.html
+++ b/public/events/arxiv_aa2397b1dcdda034.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa2a65a3e15dd26d.html
+++ b/public/events/arxiv_aa2a65a3e15dd26d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa2a65a3e15dd26d.html
+++ b/public/events/arxiv_aa2a65a3e15dd26d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa42112787cbc414.html
+++ b/public/events/arxiv_aa42112787cbc414.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa42112787cbc414.html
+++ b/public/events/arxiv_aa42112787cbc414.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa8c44de8cf70353.html
+++ b/public/events/arxiv_aa8c44de8cf70353.html
@@ -455,7 +455,9 @@ explain itself ris...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ explain itself ris...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ explain itself ris...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa8c44de8cf70353.html
+++ b/public/events/arxiv_aa8c44de8cf70353.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ the system?s users with some understanding of AI operations can support predicta
 explain itself ris...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa8dbeb0c06350de.html
+++ b/public/events/arxiv_aa8dbeb0c06350de.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa8dbeb0c06350de.html
+++ b/public/events/arxiv_aa8dbeb0c06350de.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa96e047b272d327.html
+++ b/public/events/arxiv_aa96e047b272d327.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ tasks that are sensitive to either data or model, such as, ?nding outliers in th
 explaining the re...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aa96e047b272d327.html
+++ b/public/events/arxiv_aa96e047b272d327.html
@@ -452,7 +452,9 @@ explaining the re...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ explaining the re...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ explaining the re...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa9a7266e2a3f6e8.html
+++ b/public/events/arxiv_aa9a7266e2a3f6e8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aa9a7266e2a3f6e8.html
+++ b/public/events/arxiv_aa9a7266e2a3f6e8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ab6a3d0259d74218.html
+++ b/public/events/arxiv_ab6a3d0259d74218.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ab6a3d0259d74218.html
+++ b/public/events/arxiv_ab6a3d0259d74218.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ab8ad7fbfc76f44a.html
+++ b/public/events/arxiv_ab8ad7fbfc76f44a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ab8ad7fbfc76f44a.html
+++ b/public/events/arxiv_ab8ad7fbfc76f44a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ab9d8313ec8c9ad6.html
+++ b/public/events/arxiv_ab9d8313ec8c9ad6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ab9d8313ec8c9ad6.html
+++ b/public/events/arxiv_ab9d8313ec8c9ad6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_abbee081bc544819.html
+++ b/public/events/arxiv_abbee081bc544819.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_abbee081bc544819.html
+++ b/public/events/arxiv_abbee081bc544819.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_abfd963c7afe7589.html
+++ b/public/events/arxiv_abfd963c7afe7589.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_abfd963c7afe7589.html
+++ b/public/events/arxiv_abfd963c7afe7589.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ac6144846c25f722.html
+++ b/public/events/arxiv_ac6144846c25f722.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ac6144846c25f722.html
+++ b/public/events/arxiv_ac6144846c25f722.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ac7c2b65f2dc94f9.html
+++ b/public/events/arxiv_ac7c2b65f2dc94f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ac7c2b65f2dc94f9.html
+++ b/public/events/arxiv_ac7c2b65f2dc94f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_acb8ec6d2eca4a07.html
+++ b/public/events/arxiv_acb8ec6d2eca4a07.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_acb8ec6d2eca4a07.html
+++ b/public/events/arxiv_acb8ec6d2eca4a07.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_acd42e38d07345ab.html
+++ b/public/events/arxiv_acd42e38d07345ab.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_acd42e38d07345ab.html
+++ b/public/events/arxiv_acd42e38d07345ab.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ad62fda39f25ed18.html
+++ b/public/events/arxiv_ad62fda39f25ed18.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ad62fda39f25ed18.html
+++ b/public/events/arxiv_ad62fda39f25ed18.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ad6d23e1b1a90af6.html
+++ b/public/events/arxiv_ad6d23e1b1a90af6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ad6d23e1b1a90af6.html
+++ b/public/events/arxiv_ad6d23e1b1a90af6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ad7cc0e44a27d325.html
+++ b/public/events/arxiv_ad7cc0e44a27d325.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ad7cc0e44a27d325.html
+++ b/public/events/arxiv_ad7cc0e44a27d325.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ad8cc8c5ccb611d2.html
+++ b/public/events/arxiv_ad8cc8c5ccb611d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ad8cc8c5ccb611d2.html
+++ b/public/events/arxiv_ad8cc8c5ccb611d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ad8f9548298ee546.html
+++ b/public/events/arxiv_ad8f9548298ee546.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ad8f9548298ee546.html
+++ b/public/events/arxiv_ad8f9548298ee546.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ade5f50f2414624d.html
+++ b/public/events/arxiv_ade5f50f2414624d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ade5f50f2414624d.html
+++ b/public/events/arxiv_ade5f50f2414624d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ae08d781c06efe3d.html
+++ b/public/events/arxiv_ae08d781c06efe3d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ae08d781c06efe3d.html
+++ b/public/events/arxiv_ae08d781c06efe3d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ae1cd229c3a155b3.html
+++ b/public/events/arxiv_ae1cd229c3a155b3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ae1cd229c3a155b3.html
+++ b/public/events/arxiv_ae1cd229c3a155b3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ae99d6d74bc1c08e.html
+++ b/public/events/arxiv_ae99d6d74bc1c08e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ Forecasting, Prevention,
 and Mitigation</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ae99d6d74bc1c08e.html
+++ b/public/events/arxiv_ae99d6d74bc1c08e.html
@@ -452,7 +452,9 @@ and Mitigation</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ and Mitigation</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ and Mitigation</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aed15d8ec6db81a2.html
+++ b/public/events/arxiv_aed15d8ec6db81a2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aed15d8ec6db81a2.html
+++ b/public/events/arxiv_aed15d8ec6db81a2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aee49bba8b9aac67.html
+++ b/public/events/arxiv_aee49bba8b9aac67.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aee49bba8b9aac67.html
+++ b/public/events/arxiv_aee49bba8b9aac67.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">0 The Turing Trap: The Promise &amp; Peril of Human-Like Artificial Intelligence Erik Brynjolfsson Stanford Digital Economy Lab http://brynjolfsson.com  Forthcoming in D?dalus, Spring 2022  In 1950, Alan Turing proposed an ?imitation game? as the ultimate test of whether a machine was intelligent: could a machine imitate a human so well that it?s answers to questions indistinguishable from a human?s.1 Ever since, creating intelligence that matches human intelligence has implicitly or explicitly been the goal of thousands of researchers, engineers and entrepreneurs. The benefits of human-like artificial intelligence (HLAI) include soaring productivity, increased leisure, and perhaps most profoundly, a better understanding of our own minds.   But not all types of AI are human-like ? in fact, many of the most powerful systems are very different from humans ? and an excessive focus on developing and deploying HLAI can lead us into a trap. As machines become better substitutes for human labo...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aef861ddf7738833.html
+++ b/public/events/arxiv_aef861ddf7738833.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aef861ddf7738833.html
+++ b/public/events/arxiv_aef861ddf7738833.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_af691406a00ffa9a.html
+++ b/public/events/arxiv_af691406a00ffa9a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_af691406a00ffa9a.html
+++ b/public/events/arxiv_af691406a00ffa9a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_afea29156eae44db.html
+++ b/public/events/arxiv_afea29156eae44db.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_afea29156eae44db.html
+++ b/public/events/arxiv_afea29156eae44db.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aff106819250bbd2.html
+++ b/public/events/arxiv_aff106819250bbd2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aff106819250bbd2.html
+++ b/public/events/arxiv_aff106819250bbd2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_aff90061d03fe488.html
+++ b/public/events/arxiv_aff90061d03fe488.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_aff90061d03fe488.html
+++ b/public/events/arxiv_aff90061d03fe488.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b05147510dbab92f.html
+++ b/public/events/arxiv_b05147510dbab92f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b05147510dbab92f.html
+++ b/public/events/arxiv_b05147510dbab92f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b08e5f64b6d25f47.html
+++ b/public/events/arxiv_b08e5f64b6d25f47.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b08e5f64b6d25f47.html
+++ b/public/events/arxiv_b08e5f64b6d25f47.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b09f079287d7fbd3.html
+++ b/public/events/arxiv_b09f079287d7fbd3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b09f079287d7fbd3.html
+++ b/public/events/arxiv_b09f079287d7fbd3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b1131d9d90cd5099.html
+++ b/public/events/arxiv_b1131d9d90cd5099.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b1131d9d90cd5099.html
+++ b/public/events/arxiv_b1131d9d90cd5099.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b208fd79f647fe24.html
+++ b/public/events/arxiv_b208fd79f647fe24.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b208fd79f647fe24.html
+++ b/public/events/arxiv_b208fd79f647fe24.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b229b98591d4895d.html
+++ b/public/events/arxiv_b229b98591d4895d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b229b98591d4895d.html
+++ b/public/events/arxiv_b229b98591d4895d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b26648e7d3c2e4a8.html
+++ b/public/events/arxiv_b26648e7d3c2e4a8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b26648e7d3c2e4a8.html
+++ b/public/events/arxiv_b26648e7d3c2e4a8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b29568681c7d3227.html
+++ b/public/events/arxiv_b29568681c7d3227.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b29568681c7d3227.html
+++ b/public/events/arxiv_b29568681c7d3227.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b2ad8022e71fd93f.html
+++ b/public/events/arxiv_b2ad8022e71fd93f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b2ad8022e71fd93f.html
+++ b/public/events/arxiv_b2ad8022e71fd93f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b344183bfa91e639.html
+++ b/public/events/arxiv_b344183bfa91e639.html
@@ -467,7 +467,9 @@ and solution. To estimat...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -482,7 +484,7 @@ and solution. To estimat...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -490,19 +492,19 @@ and solution. To estimat...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b344183bfa91e639.html
+++ b/public/events/arxiv_b344183bfa91e639.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -462,8 +463,21 @@ tractable form that results in a correct program
 and solution. To estimat...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b3ec07e1af2d6ccb.html
+++ b/public/events/arxiv_b3ec07e1af2d6ccb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b3ec07e1af2d6ccb.html
+++ b/public/events/arxiv_b3ec07e1af2d6ccb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b4656685cd55f878.html
+++ b/public/events/arxiv_b4656685cd55f878.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b4656685cd55f878.html
+++ b/public/events/arxiv_b4656685cd55f878.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b4892a585fac1e8c.html
+++ b/public/events/arxiv_b4892a585fac1e8c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b4892a585fac1e8c.html
+++ b/public/events/arxiv_b4892a585fac1e8c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b489d7cfa3b043cd.html
+++ b/public/events/arxiv_b489d7cfa3b043cd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b489d7cfa3b043cd.html
+++ b/public/events/arxiv_b489d7cfa3b043cd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b49589e94ad75d34.html
+++ b/public/events/arxiv_b49589e94ad75d34.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b49589e94ad75d34.html
+++ b/public/events/arxiv_b49589e94ad75d34.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b4ac7edad0c3c691.html
+++ b/public/events/arxiv_b4ac7edad0c3c691.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b4ac7edad0c3c691.html
+++ b/public/events/arxiv_b4ac7edad0c3c691.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b4b1eff26b3cd1d9.html
+++ b/public/events/arxiv_b4b1eff26b3cd1d9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b4b1eff26b3cd1d9.html
+++ b/public/events/arxiv_b4b1eff26b3cd1d9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b4fccbd27d6e5e6a.html
+++ b/public/events/arxiv_b4fccbd27d6e5e6a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b4fccbd27d6e5e6a.html
+++ b/public/events/arxiv_b4fccbd27d6e5e6a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b521f441eb2544a1.html
+++ b/public/events/arxiv_b521f441eb2544a1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b521f441eb2544a1.html
+++ b/public/events/arxiv_b521f441eb2544a1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b53638f9eff11ba5.html
+++ b/public/events/arxiv_b53638f9eff11ba5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b53638f9eff11ba5.html
+++ b/public/events/arxiv_b53638f9eff11ba5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b541b11c1418c27e.html
+++ b/public/events/arxiv_b541b11c1418c27e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b541b11c1418c27e.html
+++ b/public/events/arxiv_b541b11c1418c27e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b61d7e33ba6251a4.html
+++ b/public/events/arxiv_b61d7e33ba6251a4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b61d7e33ba6251a4.html
+++ b/public/events/arxiv_b61d7e33ba6251a4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b63f209cc6a759ef.html
+++ b/public/events/arxiv_b63f209cc6a759ef.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b63f209cc6a759ef.html
+++ b/public/events/arxiv_b63f209cc6a759ef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Forecasting Transformative AI: An Expert Survey  Ross Gruetzemacher, David Paradice, Kang Bok Lee Auburn University, Harbert College of Business, Department of Systems and Technology   Abstract Transformative AI technologies have the potential to reshape critical aspects of society in the near future. In order to properly prepare policy initiatives for the arrival of such technologies accurate forecasts and timelines are necessary. A survey was administered to attendees of three AI conferences in 2018 (ICML, IJCAI and the HLAI conference). The survey included calibration questions, questions for estimating AI capabilities over the next decade, questions for forecasting five scenarios of transformative AI and questions concerning the impact of computational resources in AI research. Respondents indicated a median of 21.5% of human tasks (i.e., all tasks that humans are currently paid to do) can be feasibly automated now, and that this figure would rise to 40% in 5 years and 60% in 10...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b6618e5296fd0bba.html
+++ b/public/events/arxiv_b6618e5296fd0bba.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b6618e5296fd0bba.html
+++ b/public/events/arxiv_b6618e5296fd0bba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b6b762b2e10ccbe9.html
+++ b/public/events/arxiv_b6b762b2e10ccbe9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b6b762b2e10ccbe9.html
+++ b/public/events/arxiv_b6b762b2e10ccbe9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b6f519be57b453ca.html
+++ b/public/events/arxiv_b6f519be57b453ca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b6f519be57b453ca.html
+++ b/public/events/arxiv_b6f519be57b453ca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b71c7e1c9618e211.html
+++ b/public/events/arxiv_b71c7e1c9618e211.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b71c7e1c9618e211.html
+++ b/public/events/arxiv_b71c7e1c9618e211.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b743fa8ab99bc9f2.html
+++ b/public/events/arxiv_b743fa8ab99bc9f2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b743fa8ab99bc9f2.html
+++ b/public/events/arxiv_b743fa8ab99bc9f2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b750fa887406a883.html
+++ b/public/events/arxiv_b750fa887406a883.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 1 Contributions</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b750fa887406a883.html
+++ b/public/events/arxiv_b750fa887406a883.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b788e4590d7267be.html
+++ b/public/events/arxiv_b788e4590d7267be.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b788e4590d7267be.html
+++ b/public/events/arxiv_b788e4590d7267be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b7e2676767766152.html
+++ b/public/events/arxiv_b7e2676767766152.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b7e2676767766152.html
+++ b/public/events/arxiv_b7e2676767766152.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b7eb706ddf3fc687.html
+++ b/public/events/arxiv_b7eb706ddf3fc687.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b7eb706ddf3fc687.html
+++ b/public/events/arxiv_b7eb706ddf3fc687.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b8666a1c7c7a0192.html
+++ b/public/events/arxiv_b8666a1c7c7a0192.html
@@ -33,6 +33,7 @@ in Neural Networks | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ in Neural Networks</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b8666a1c7c7a0192.html
+++ b/public/events/arxiv_b8666a1c7c7a0192.html
@@ -441,7 +441,9 @@ in Neural Networks</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ in Neural Networks</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ in Neural Networks</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b92f2e30b3f18ed7.html
+++ b/public/events/arxiv_b92f2e30b3f18ed7.html
@@ -461,7 +461,9 @@ leimeister@un...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -476,7 +478,7 @@ leimeister@un...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -484,19 +486,19 @@ leimeister@un...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b92f2e30b3f18ed7.html
+++ b/public/events/arxiv_b92f2e30b3f18ed7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -456,8 +457,21 @@ St.Gallen, Switzerland
 leimeister@un...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b941110f24a934df.html
+++ b/public/events/arxiv_b941110f24a934df.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b941110f24a934df.html
+++ b/public/events/arxiv_b941110f24a934df.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b990438c3d2f4172.html
+++ b/public/events/arxiv_b990438c3d2f4172.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b990438c3d2f4172.html
+++ b/public/events/arxiv_b990438c3d2f4172.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b995fa8df519db15.html
+++ b/public/events/arxiv_b995fa8df519db15.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b995fa8df519db15.html
+++ b/public/events/arxiv_b995fa8df519db15.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b9a647ad554c990a.html
+++ b/public/events/arxiv_b9a647ad554c990a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b9a647ad554c990a.html
+++ b/public/events/arxiv_b9a647ad554c990a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_b9f4aa2968038b7d.html
+++ b/public/events/arxiv_b9f4aa2968038b7d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_b9f4aa2968038b7d.html
+++ b/public/events/arxiv_b9f4aa2968038b7d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ba7514433f5f71f0.html
+++ b/public/events/arxiv_ba7514433f5f71f0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ba7514433f5f71f0.html
+++ b/public/events/arxiv_ba7514433f5f71f0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ba8057b3b54d04c0.html
+++ b/public/events/arxiv_ba8057b3b54d04c0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ba8057b3b54d04c0.html
+++ b/public/events/arxiv_ba8057b3b54d04c0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bae10359a6547ffd.html
+++ b/public/events/arxiv_bae10359a6547ffd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bae10359a6547ffd.html
+++ b/public/events/arxiv_bae10359a6547ffd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bae9f6db20a311d3.html
+++ b/public/events/arxiv_bae9f6db20a311d3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bae9f6db20a311d3.html
+++ b/public/events/arxiv_bae9f6db20a311d3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bb3ed7bc24be17f9.html
+++ b/public/events/arxiv_bb3ed7bc24be17f9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bb3ed7bc24be17f9.html
+++ b/public/events/arxiv_bb3ed7bc24be17f9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bb50754d1bf1a3e3.html
+++ b/public/events/arxiv_bb50754d1bf1a3e3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bb50754d1bf1a3e3.html
+++ b/public/events/arxiv_bb50754d1bf1a3e3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bb5283252d7c5fdc.html
+++ b/public/events/arxiv_bb5283252d7c5fdc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ in a tree are a few examples where AI decisions lead to catastrophic results. To
 and generate an explanation about the learning capability of AI, we w...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bb5283252d7c5fdc.html
+++ b/public/events/arxiv_bb5283252d7c5fdc.html
@@ -450,7 +450,9 @@ and generate an explanation about the learning capability of AI, we w...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ and generate an explanation about the learning capability of AI, we w...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ and generate an explanation about the learning capability of AI, we w...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bbfdc27ddeb5e3a5.html
+++ b/public/events/arxiv_bbfdc27ddeb5e3a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bbfdc27ddeb5e3a5.html
+++ b/public/events/arxiv_bbfdc27ddeb5e3a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bc1ffc64424f8b74.html
+++ b/public/events/arxiv_bc1ffc64424f8b74.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: AI Research Considerations for Human Existential Safety (ARCHES)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bc1ffc64424f8b74.html
+++ b/public/events/arxiv_bc1ffc64424f8b74.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bce64cd381cfaef8.html
+++ b/public/events/arxiv_bce64cd381cfaef8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bce64cd381cfaef8.html
+++ b/public/events/arxiv_bce64cd381cfaef8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bcfb223ceb5af178.html
+++ b/public/events/arxiv_bcfb223ceb5af178.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bcfb223ceb5af178.html
+++ b/public/events/arxiv_bcfb223ceb5af178.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bd414a44f110c5bc.html
+++ b/public/events/arxiv_bd414a44f110c5bc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bd414a44f110c5bc.html
+++ b/public/events/arxiv_bd414a44f110c5bc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bd5055688c17e701.html
+++ b/public/events/arxiv_bd5055688c17e701.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bd5055688c17e701.html
+++ b/public/events/arxiv_bd5055688c17e701.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bde187870c058fb9.html
+++ b/public/events/arxiv_bde187870c058fb9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bde187870c058fb9.html
+++ b/public/events/arxiv_bde187870c058fb9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_be90c7a8998cd326.html
+++ b/public/events/arxiv_be90c7a8998cd326.html
@@ -441,7 +441,9 @@ Quantifying Interpretability of Deep Visual Representations</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ Quantifying Interpretability of Deep Visual Representations</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ Quantifying Interpretability of Deep Visual Representations</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_be90c7a8998cd326.html
+++ b/public/events/arxiv_be90c7a8998cd326.html
@@ -33,6 +33,7 @@ Quantifying Interpretability of Deep Visual Representations | p(Doom)1 Events</t
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ Quantifying Interpretability of Deep Visual Representations</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bea3a247e8e516c2.html
+++ b/public/events/arxiv_bea3a247e8e516c2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bea3a247e8e516c2.html
+++ b/public/events/arxiv_bea3a247e8e516c2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_beb12a23a4297645.html
+++ b/public/events/arxiv_beb12a23a4297645.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_beb12a23a4297645.html
+++ b/public/events/arxiv_beb12a23a4297645.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_beb53e03ce611e66.html
+++ b/public/events/arxiv_beb53e03ce611e66.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_beb53e03ce611e66.html
+++ b/public/events/arxiv_beb53e03ce611e66.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bedbb9cfa9a577eb.html
+++ b/public/events/arxiv_bedbb9cfa9a577eb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bedbb9cfa9a577eb.html
+++ b/public/events/arxiv_bedbb9cfa9a577eb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bf0ff25d784f6380.html
+++ b/public/events/arxiv_bf0ff25d784f6380.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bf0ff25d784f6380.html
+++ b/public/events/arxiv_bf0ff25d784f6380.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bf30366d2c838523.html
+++ b/public/events/arxiv_bf30366d2c838523.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bf30366d2c838523.html
+++ b/public/events/arxiv_bf30366d2c838523.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bf605e3eb967ec30.html
+++ b/public/events/arxiv_bf605e3eb967ec30.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bf605e3eb967ec30.html
+++ b/public/events/arxiv_bf605e3eb967ec30.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_bfaa915ab1de8d52.html
+++ b/public/events/arxiv_bfaa915ab1de8d52.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_bfaa915ab1de8d52.html
+++ b/public/events/arxiv_bfaa915ab1de8d52.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c0390431ab3a215a.html
+++ b/public/events/arxiv_c0390431ab3a215a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -451,8 +452,21 @@ Abstract
 Artificial Intelligence (AI) is one of the most transformative technologie...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c0390431ab3a215a.html
+++ b/public/events/arxiv_c0390431ab3a215a.html
@@ -456,7 +456,9 @@ Artificial Intelligence (AI) is one of the most transformative technologie...</p
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -471,7 +473,7 @@ Artificial Intelligence (AI) is one of the most transformative technologie...</p
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -479,19 +481,19 @@ Artificial Intelligence (AI) is one of the most transformative technologie...</p
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c07dc0e7916bb37d.html
+++ b/public/events/arxiv_c07dc0e7916bb37d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c07dc0e7916bb37d.html
+++ b/public/events/arxiv_c07dc0e7916bb37d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c085d2d1d8ede633.html
+++ b/public/events/arxiv_c085d2d1d8ede633.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c085d2d1d8ede633.html
+++ b/public/events/arxiv_c085d2d1d8ede633.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c0a91469fb17f17e.html
+++ b/public/events/arxiv_c0a91469fb17f17e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c0a91469fb17f17e.html
+++ b/public/events/arxiv_c0a91469fb17f17e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c10b9456b03fcc59.html
+++ b/public/events/arxiv_c10b9456b03fcc59.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c10b9456b03fcc59.html
+++ b/public/events/arxiv_c10b9456b03fcc59.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c1201a83d177fa63.html
+++ b/public/events/arxiv_c1201a83d177fa63.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c1201a83d177fa63.html
+++ b/public/events/arxiv_c1201a83d177fa63.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c171694c2a004f27.html
+++ b/public/events/arxiv_c171694c2a004f27.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c171694c2a004f27.html
+++ b/public/events/arxiv_c171694c2a004f27.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c237d4275da9341e.html
+++ b/public/events/arxiv_c237d4275da9341e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c237d4275da9341e.html
+++ b/public/events/arxiv_c237d4275da9341e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c27c6f2ef9ae28b1.html
+++ b/public/events/arxiv_c27c6f2ef9ae28b1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c27c6f2ef9ae28b1.html
+++ b/public/events/arxiv_c27c6f2ef9ae28b1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c2aad946ccdea78f.html
+++ b/public/events/arxiv_c2aad946ccdea78f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c2aad946ccdea78f.html
+++ b/public/events/arxiv_c2aad946ccdea78f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c2ab3aad4eacb1d8.html
+++ b/public/events/arxiv_c2ab3aad4eacb1d8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c2ab3aad4eacb1d8.html
+++ b/public/events/arxiv_c2ab3aad4eacb1d8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c3043a62c41391ab.html
+++ b/public/events/arxiv_c3043a62c41391ab.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c3043a62c41391ab.html
+++ b/public/events/arxiv_c3043a62c41391ab.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c328090bc4305415.html
+++ b/public/events/arxiv_c328090bc4305415.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c328090bc4305415.html
+++ b/public/events/arxiv_c328090bc4305415.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c356f4bb1fc1101d.html
+++ b/public/events/arxiv_c356f4bb1fc1101d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c356f4bb1fc1101d.html
+++ b/public/events/arxiv_c356f4bb1fc1101d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c3fe4405e8d21673.html
+++ b/public/events/arxiv_c3fe4405e8d21673.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c3fe4405e8d21673.html
+++ b/public/events/arxiv_c3fe4405e8d21673.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c4281a21a93e37ca.html
+++ b/public/events/arxiv_c4281a21a93e37ca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c4281a21a93e37ca.html
+++ b/public/events/arxiv_c4281a21a93e37ca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c42b9740e6b4194d.html
+++ b/public/events/arxiv_c42b9740e6b4194d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c42b9740e6b4194d.html
+++ b/public/events/arxiv_c42b9740e6b4194d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c45a03222f9a2430.html
+++ b/public/events/arxiv_c45a03222f9a2430.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c45a03222f9a2430.html
+++ b/public/events/arxiv_c45a03222f9a2430.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c47368892bef3139.html
+++ b/public/events/arxiv_c47368892bef3139.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c47368892bef3139.html
+++ b/public/events/arxiv_c47368892bef3139.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c4f47b8ec83a65c4.html
+++ b/public/events/arxiv_c4f47b8ec83a65c4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------------------------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c4f47b8ec83a65c4.html
+++ b/public/events/arxiv_c4f47b8ec83a65c4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c50214c8f80f3b40.html
+++ b/public/events/arxiv_c50214c8f80f3b40.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c50214c8f80f3b40.html
+++ b/public/events/arxiv_c50214c8f80f3b40.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c515598ed82b0e38.html
+++ b/public/events/arxiv_c515598ed82b0e38.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c515598ed82b0e38.html
+++ b/public/events/arxiv_c515598ed82b0e38.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c52390c5cf7e651a.html
+++ b/public/events/arxiv_c52390c5cf7e651a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c52390c5cf7e651a.html
+++ b/public/events/arxiv_c52390c5cf7e651a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c54433ebfff783d7.html
+++ b/public/events/arxiv_c54433ebfff783d7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c54433ebfff783d7.html
+++ b/public/events/arxiv_c54433ebfff783d7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c5965d6b11fab9ce.html
+++ b/public/events/arxiv_c5965d6b11fab9ce.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c5965d6b11fab9ce.html
+++ b/public/events/arxiv_c5965d6b11fab9ce.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c5e91218315409dd.html
+++ b/public/events/arxiv_c5e91218315409dd.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c5e91218315409dd.html
+++ b/public/events/arxiv_c5e91218315409dd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: The Surprising Creativity of Digital Evolution: A Collection of Anecdotes from the Evolutionary Computation and Artificial Life Research Communities</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c5fc3042c65ffa89.html
+++ b/public/events/arxiv_c5fc3042c65ffa89.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c5fc3042c65ffa89.html
+++ b/public/events/arxiv_c5fc3042c65ffa89.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c618fea8fc278406.html
+++ b/public/events/arxiv_c618fea8fc278406.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c618fea8fc278406.html
+++ b/public/events/arxiv_c618fea8fc278406.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c61fe8a59ccfaa31.html
+++ b/public/events/arxiv_c61fe8a59ccfaa31.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c61fe8a59ccfaa31.html
+++ b/public/events/arxiv_c61fe8a59ccfaa31.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c65b99f477ddc2a6.html
+++ b/public/events/arxiv_c65b99f477ddc2a6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c65b99f477ddc2a6.html
+++ b/public/events/arxiv_c65b99f477ddc2a6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c66e65c42875adef.html
+++ b/public/events/arxiv_c66e65c42875adef.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c66e65c42875adef.html
+++ b/public/events/arxiv_c66e65c42875adef.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c67778b1627c19d8.html
+++ b/public/events/arxiv_c67778b1627c19d8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ also provides an intuitive way of controlling neural network behavior: first, fi
 codes that activate ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c67778b1627c19d8.html
+++ b/public/events/arxiv_c67778b1627c19d8.html
@@ -454,7 +454,9 @@ codes that activate ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ codes that activate ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ codes that activate ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c67c4f1f99a3acf3.html
+++ b/public/events/arxiv_c67c4f1f99a3acf3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c67c4f1f99a3acf3.html
+++ b/public/events/arxiv_c67c4f1f99a3acf3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c6b7c317d780f22b.html
+++ b/public/events/arxiv_c6b7c317d780f22b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c6b7c317d780f22b.html
+++ b/public/events/arxiv_c6b7c317d780f22b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c6e1d26604cebcd7.html
+++ b/public/events/arxiv_c6e1d26604cebcd7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c6e1d26604cebcd7.html
+++ b/public/events/arxiv_c6e1d26604cebcd7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c73d1d24858a5a58.html
+++ b/public/events/arxiv_c73d1d24858a5a58.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c73d1d24858a5a58.html
+++ b/public/events/arxiv_c73d1d24858a5a58.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c7b84bc87ee9cfb7.html
+++ b/public/events/arxiv_c7b84bc87ee9cfb7.html
@@ -498,7 +498,9 @@ Machine ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -513,7 +515,7 @@ Machine ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -521,19 +523,19 @@ Machine ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c7b84bc87ee9cfb7.html
+++ b/public/events/arxiv_c7b84bc87ee9cfb7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -493,8 +494,21 @@ Founder and Principal Researcher, Montreal AI Ethics Institute
 Machine ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c8093ac4da9fd19b.html
+++ b/public/events/arxiv_c8093ac4da9fd19b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c8093ac4da9fd19b.html
+++ b/public/events/arxiv_c8093ac4da9fd19b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c81baef1bf42629d.html
+++ b/public/events/arxiv_c81baef1bf42629d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c81baef1bf42629d.html
+++ b/public/events/arxiv_c81baef1bf42629d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c86d638a79093201.html
+++ b/public/events/arxiv_c86d638a79093201.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c86d638a79093201.html
+++ b/public/events/arxiv_c86d638a79093201.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c8c6e6b65ff731ba.html
+++ b/public/events/arxiv_c8c6e6b65ff731ba.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c8c6e6b65ff731ba.html
+++ b/public/events/arxiv_c8c6e6b65ff731ba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c9041a9f9410d0e0.html
+++ b/public/events/arxiv_c9041a9f9410d0e0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c9041a9f9410d0e0.html
+++ b/public/events/arxiv_c9041a9f9410d0e0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c92e4d9890809f73.html
+++ b/public/events/arxiv_c92e4d9890809f73.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c92e4d9890809f73.html
+++ b/public/events/arxiv_c92e4d9890809f73.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_c9abd238dd2b341d.html
+++ b/public/events/arxiv_c9abd238dd2b341d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_c9abd238dd2b341d.html
+++ b/public/events/arxiv_c9abd238dd2b341d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ca295111ff1ec76d.html
+++ b/public/events/arxiv_ca295111ff1ec76d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ca295111ff1ec76d.html
+++ b/public/events/arxiv_ca295111ff1ec76d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ca4359c33a477287.html
+++ b/public/events/arxiv_ca4359c33a477287.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ca4359c33a477287.html
+++ b/public/events/arxiv_ca4359c33a477287.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ca4584e9771465a2.html
+++ b/public/events/arxiv_ca4584e9771465a2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -446,8 +447,21 @@ higher by  exploring a problem that appears to require modeling, reasoning, lang
 understanding, and commonsense knowledge,  to probe th e state of the art...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ca4584e9771465a2.html
+++ b/public/events/arxiv_ca4584e9771465a2.html
@@ -451,7 +451,9 @@ understanding, and commonsense knowledge,  to probe th e state of the art...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -466,7 +468,7 @@ understanding, and commonsense knowledge,  to probe th e state of the art...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -474,19 +476,19 @@ understanding, and commonsense knowledge,  to probe th e state of the art...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ca70467cf934e8af.html
+++ b/public/events/arxiv_ca70467cf934e8af.html
@@ -454,7 +454,9 @@ Real  Estate  Politik:  Democracy  and  the  Finan...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ Real  Estate  Politik:  Democracy  and  the  Finan...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ Real  Estate  Politik:  Democracy  and  the  Finan...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ca70467cf934e8af.html
+++ b/public/events/arxiv_ca70467cf934e8af.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ Creating Technology Worthy of the Human Spirit Aden Van Noppen 309?322
 Real  Estate  Politik:  Democracy  and  the  Finan...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ca9b96625c777525.html
+++ b/public/events/arxiv_ca9b96625c777525.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ca9b96625c777525.html
+++ b/public/events/arxiv_ca9b96625c777525.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cab1fd1544e648fd.html
+++ b/public/events/arxiv_cab1fd1544e648fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cab1fd1544e648fd.html
+++ b/public/events/arxiv_cab1fd1544e648fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cabb1d4226057aa6.html
+++ b/public/events/arxiv_cabb1d4226057aa6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cabb1d4226057aa6.html
+++ b/public/events/arxiv_cabb1d4226057aa6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cad61abb903ac95e.html
+++ b/public/events/arxiv_cad61abb903ac95e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cad61abb903ac95e.html
+++ b/public/events/arxiv_cad61abb903ac95e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cada59fae9928dc6.html
+++ b/public/events/arxiv_cada59fae9928dc6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cada59fae9928dc6.html
+++ b/public/events/arxiv_cada59fae9928dc6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_caf3b68cdb135855.html
+++ b/public/events/arxiv_caf3b68cdb135855.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_caf3b68cdb135855.html
+++ b/public/events/arxiv_caf3b68cdb135855.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cb0bea2dbf3f6dba.html
+++ b/public/events/arxiv_cb0bea2dbf3f6dba.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cb0bea2dbf3f6dba.html
+++ b/public/events/arxiv_cb0bea2dbf3f6dba.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cbd42f5f1fdb1a3b.html
+++ b/public/events/arxiv_cbd42f5f1fdb1a3b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cbd42f5f1fdb1a3b.html
+++ b/public/events/arxiv_cbd42f5f1fdb1a3b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cbf09e13232824de.html
+++ b/public/events/arxiv_cbf09e13232824de.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cbf09e13232824de.html
+++ b/public/events/arxiv_cbf09e13232824de.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cc24dc9a94859490.html
+++ b/public/events/arxiv_cc24dc9a94859490.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cc24dc9a94859490.html
+++ b/public/events/arxiv_cc24dc9a94859490.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cc4d70762dab69e1.html
+++ b/public/events/arxiv_cc4d70762dab69e1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cc4d70762dab69e1.html
+++ b/public/events/arxiv_cc4d70762dab69e1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cc61b8282355a971.html
+++ b/public/events/arxiv_cc61b8282355a971.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cc61b8282355a971.html
+++ b/public/events/arxiv_cc61b8282355a971.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cc87f82087030182.html
+++ b/public/events/arxiv_cc87f82087030182.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -447,8 +448,21 @@ a form and specify the exact models which can attain it across model/data scales
 Our construction follows insights obtained from observations conducted o...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cc87f82087030182.html
+++ b/public/events/arxiv_cc87f82087030182.html
@@ -452,7 +452,9 @@ Our construction follows insights obtained from observations conducted o...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -467,7 +469,7 @@ Our construction follows insights obtained from observations conducted o...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -475,19 +477,19 @@ Our construction follows insights obtained from observations conducted o...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cdb5c302cf99a7be.html
+++ b/public/events/arxiv_cdb5c302cf99a7be.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cdb5c302cf99a7be.html
+++ b/public/events/arxiv_cdb5c302cf99a7be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cdeea8d88c36ce15.html
+++ b/public/events/arxiv_cdeea8d88c36ce15.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -443,8 +444,21 @@ PUBLISHED BY THE COUNCIL OF EUROPE'S AD
 HOC COMMITTEE ON ARTIFICIAL INTELLIGENCEA PRIMER</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cdeea8d88c36ce15.html
+++ b/public/events/arxiv_cdeea8d88c36ce15.html
@@ -448,7 +448,9 @@ HOC COMMITTEE ON ARTIFICIAL INTELLIGENCEA PRIMER</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -463,7 +465,7 @@ HOC COMMITTEE ON ARTIFICIAL INTELLIGENCEA PRIMER</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -471,19 +473,19 @@ HOC COMMITTEE ON ARTIFICIAL INTELLIGENCEA PRIMER</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ce9119bdee8da16b.html
+++ b/public/events/arxiv_ce9119bdee8da16b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ce9119bdee8da16b.html
+++ b/public/events/arxiv_ce9119bdee8da16b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cef47b8e28f2ee30.html
+++ b/public/events/arxiv_cef47b8e28f2ee30.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cef47b8e28f2ee30.html
+++ b/public/events/arxiv_cef47b8e28f2ee30.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cf093524c33472b7.html
+++ b/public/events/arxiv_cf093524c33472b7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cf093524c33472b7.html
+++ b/public/events/arxiv_cf093524c33472b7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cf48826b533745eb.html
+++ b/public/events/arxiv_cf48826b533745eb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cf48826b533745eb.html
+++ b/public/events/arxiv_cf48826b533745eb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cf6d86c6187b6551.html
+++ b/public/events/arxiv_cf6d86c6187b6551.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cf6d86c6187b6551.html
+++ b/public/events/arxiv_cf6d86c6187b6551.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_cfa07cf755510e08.html
+++ b/public/events/arxiv_cfa07cf755510e08.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_cfa07cf755510e08.html
+++ b/public/events/arxiv_cfa07cf755510e08.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d093b4fbe7c5d423.html
+++ b/public/events/arxiv_d093b4fbe7c5d423.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Learning Latent Representations to Influence Multi-Agent Interaction</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d093b4fbe7c5d423.html
+++ b/public/events/arxiv_d093b4fbe7c5d423.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d0d350b2ac6e04b8.html
+++ b/public/events/arxiv_d0d350b2ac6e04b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d0d350b2ac6e04b8.html
+++ b/public/events/arxiv_d0d350b2ac6e04b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d1469829e90fd39d.html
+++ b/public/events/arxiv_d1469829e90fd39d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d1469829e90fd39d.html
+++ b/public/events/arxiv_d1469829e90fd39d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d14b7eb102a079d0.html
+++ b/public/events/arxiv_d14b7eb102a079d0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d14b7eb102a079d0.html
+++ b/public/events/arxiv_d14b7eb102a079d0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d17f296dd337d166.html
+++ b/public/events/arxiv_d17f296dd337d166.html
@@ -441,7 +441,9 @@ for Natural Language Understanding</h1>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -456,7 +458,7 @@ for Natural Language Understanding</h1>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -464,19 +466,19 @@ for Natural Language Understanding</h1>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d17f296dd337d166.html
+++ b/public/events/arxiv_d17f296dd337d166.html
@@ -33,6 +33,7 @@ for Natural Language Understanding | p(Doom)1 Events</title>
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -436,8 +437,21 @@ for Natural Language Understanding</h1>
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d196c5722d701595.html
+++ b/public/events/arxiv_d196c5722d701595.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d196c5722d701595.html
+++ b/public/events/arxiv_d196c5722d701595.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d2248d916a22dd16.html
+++ b/public/events/arxiv_d2248d916a22dd16.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d2248d916a22dd16.html
+++ b/public/events/arxiv_d2248d916a22dd16.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d2386b5bab1151ae.html
+++ b/public/events/arxiv_d2386b5bab1151ae.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d2386b5bab1151ae.html
+++ b/public/events/arxiv_d2386b5bab1151ae.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d2f51e0350d35221.html
+++ b/public/events/arxiv_d2f51e0350d35221.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d2f51e0350d35221.html
+++ b/public/events/arxiv_d2f51e0350d35221.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d2fb125a5bdcf1e2.html
+++ b/public/events/arxiv_d2fb125a5bdcf1e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d2fb125a5bdcf1e2.html
+++ b/public/events/arxiv_d2fb125a5bdcf1e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d33fcb4bef6132b8.html
+++ b/public/events/arxiv_d33fcb4bef6132b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d33fcb4bef6132b8.html
+++ b/public/events/arxiv_d33fcb4bef6132b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d3a402637ed5f7a2.html
+++ b/public/events/arxiv_d3a402637ed5f7a2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d3a402637ed5f7a2.html
+++ b/public/events/arxiv_d3a402637ed5f7a2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d3e76392f9627e93.html
+++ b/public/events/arxiv_d3e76392f9627e93.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d3e76392f9627e93.html
+++ b/public/events/arxiv_d3e76392f9627e93.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d41c93555f5da094.html
+++ b/public/events/arxiv_d41c93555f5da094.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d41c93555f5da094.html
+++ b/public/events/arxiv_d41c93555f5da094.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d4d01f8ca206d12f.html
+++ b/public/events/arxiv_d4d01f8ca206d12f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d4d01f8ca206d12f.html
+++ b/public/events/arxiv_d4d01f8ca206d12f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d50b5ef4912f0d1a.html
+++ b/public/events/arxiv_d50b5ef4912f0d1a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d50b5ef4912f0d1a.html
+++ b/public/events/arxiv_d50b5ef4912f0d1a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d515617e558a6b73.html
+++ b/public/events/arxiv_d515617e558a6b73.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d515617e558a6b73.html
+++ b/public/events/arxiv_d515617e558a6b73.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d57f07c9b5b2fcaa.html
+++ b/public/events/arxiv_d57f07c9b5b2fcaa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d57f07c9b5b2fcaa.html
+++ b/public/events/arxiv_d57f07c9b5b2fcaa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d5d871f8c38b8423.html
+++ b/public/events/arxiv_d5d871f8c38b8423.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d5d871f8c38b8423.html
+++ b/public/events/arxiv_d5d871f8c38b8423.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d604aa57800a22e1.html
+++ b/public/events/arxiv_d604aa57800a22e1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d604aa57800a22e1.html
+++ b/public/events/arxiv_d604aa57800a22e1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d633e3343d2a7ddf.html
+++ b/public/events/arxiv_d633e3343d2a7ddf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d633e3343d2a7ddf.html
+++ b/public/events/arxiv_d633e3343d2a7ddf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d66efe89f7edc9c7.html
+++ b/public/events/arxiv_d66efe89f7edc9c7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d66efe89f7edc9c7.html
+++ b/public/events/arxiv_d66efe89f7edc9c7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d6d4f93f29f8c1e5.html
+++ b/public/events/arxiv_d6d4f93f29f8c1e5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ of any agent on bsuite . This library facilitates reproducible and accessible
 research on th...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d6d4f93f29f8c1e5.html
+++ b/public/events/arxiv_d6d4f93f29f8c1e5.html
@@ -453,7 +453,9 @@ research on th...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ research on th...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ research on th...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d706ac5200178150.html
+++ b/public/events/arxiv_d706ac5200178150.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d706ac5200178150.html
+++ b/public/events/arxiv_d706ac5200178150.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d802a08e209a39aa.html
+++ b/public/events/arxiv_d802a08e209a39aa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d802a08e209a39aa.html
+++ b/public/events/arxiv_d802a08e209a39aa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d83deddb25098692.html
+++ b/public/events/arxiv_d83deddb25098692.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d83deddb25098692.html
+++ b/public/events/arxiv_d83deddb25098692.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d88381ef1676ad6a.html
+++ b/public/events/arxiv_d88381ef1676ad6a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d88381ef1676ad6a.html
+++ b/public/events/arxiv_d88381ef1676ad6a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d89dc844516a9ac0.html
+++ b/public/events/arxiv_d89dc844516a9ac0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d89dc844516a9ac0.html
+++ b/public/events/arxiv_d89dc844516a9ac0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d9b74722526e4fcd.html
+++ b/public/events/arxiv_d9b74722526e4fcd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d9b74722526e4fcd.html
+++ b/public/events/arxiv_d9b74722526e4fcd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_d9ef3d1c33508753.html
+++ b/public/events/arxiv_d9ef3d1c33508753.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_d9ef3d1c33508753.html
+++ b/public/events/arxiv_d9ef3d1c33508753.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_da0cfd50754b6180.html
+++ b/public/events/arxiv_da0cfd50754b6180.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_da0cfd50754b6180.html
+++ b/public/events/arxiv_da0cfd50754b6180.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_da2deeeadbeab086.html
+++ b/public/events/arxiv_da2deeeadbeab086.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_da2deeeadbeab086.html
+++ b/public/events/arxiv_da2deeeadbeab086.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_da59e3fffc6d024a.html
+++ b/public/events/arxiv_da59e3fffc6d024a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_da59e3fffc6d024a.html
+++ b/public/events/arxiv_da59e3fffc6d024a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_da793a00734aa3aa.html
+++ b/public/events/arxiv_da793a00734aa3aa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_da793a00734aa3aa.html
+++ b/public/events/arxiv_da793a00734aa3aa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dadd385d71c754d2.html
+++ b/public/events/arxiv_dadd385d71c754d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dadd385d71c754d2.html
+++ b/public/events/arxiv_dadd385d71c754d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_db5b97196116c843.html
+++ b/public/events/arxiv_db5b97196116c843.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_db5b97196116c843.html
+++ b/public/events/arxiv_db5b97196116c843.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_db731640470abad7.html
+++ b/public/events/arxiv_db731640470abad7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ can be executed concurrently . We compare plans based on decision-theoretic
 notions (i.e. util...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_db731640470abad7.html
+++ b/public/events/arxiv_db731640470abad7.html
@@ -453,7 +453,9 @@ notions (i.e. util...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ notions (i.e. util...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ notions (i.e. util...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_db7e00145997644b.html
+++ b/public/events/arxiv_db7e00145997644b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_db7e00145997644b.html
+++ b/public/events/arxiv_db7e00145997644b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dc43714b96ecfc2b.html
+++ b/public/events/arxiv_dc43714b96ecfc2b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dc43714b96ecfc2b.html
+++ b/public/events/arxiv_dc43714b96ecfc2b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dc62ec723cf1430d.html
+++ b/public/events/arxiv_dc62ec723cf1430d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dc62ec723cf1430d.html
+++ b/public/events/arxiv_dc62ec723cf1430d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dcd0a0556ebfc56a.html
+++ b/public/events/arxiv_dcd0a0556ebfc56a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dcd0a0556ebfc56a.html
+++ b/public/events/arxiv_dcd0a0556ebfc56a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dd0b51c92f88f0b8.html
+++ b/public/events/arxiv_dd0b51c92f88f0b8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dd0b51c92f88f0b8.html
+++ b/public/events/arxiv_dd0b51c92f88f0b8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dd92a06770fa00e4.html
+++ b/public/events/arxiv_dd92a06770fa00e4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dd92a06770fa00e4.html
+++ b/public/events/arxiv_dd92a06770fa00e4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ddb3aebf3b13c647.html
+++ b/public/events/arxiv_ddb3aebf3b13c647.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ddb3aebf3b13c647.html
+++ b/public/events/arxiv_ddb3aebf3b13c647.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dece29c717e85054.html
+++ b/public/events/arxiv_dece29c717e85054.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dece29c717e85054.html
+++ b/public/events/arxiv_dece29c717e85054.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_df249401a5807eac.html
+++ b/public/events/arxiv_df249401a5807eac.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_df249401a5807eac.html
+++ b/public/events/arxiv_df249401a5807eac.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_df26702cd0a432a5.html
+++ b/public/events/arxiv_df26702cd0a432a5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_df26702cd0a432a5.html
+++ b/public/events/arxiv_df26702cd0a432a5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_df96fcd4101b5279.html
+++ b/public/events/arxiv_df96fcd4101b5279.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_df96fcd4101b5279.html
+++ b/public/events/arxiv_df96fcd4101b5279.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dfb9b33fc00b483f.html
+++ b/public/events/arxiv_dfb9b33fc00b483f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dfb9b33fc00b483f.html
+++ b/public/events/arxiv_dfb9b33fc00b483f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dfc4726f702c6b41.html
+++ b/public/events/arxiv_dfc4726f702c6b41.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dfc4726f702c6b41.html
+++ b/public/events/arxiv_dfc4726f702c6b41.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dfe1a69ce0a50944.html
+++ b/public/events/arxiv_dfe1a69ce0a50944.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dfe1a69ce0a50944.html
+++ b/public/events/arxiv_dfe1a69ce0a50944.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dfe4f6e3d2c81f5f.html
+++ b/public/events/arxiv_dfe4f6e3d2c81f5f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dfe4f6e3d2c81f5f.html
+++ b/public/events/arxiv_dfe4f6e3d2c81f5f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dfe8653b4e582909.html
+++ b/public/events/arxiv_dfe8653b4e582909.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dfe8653b4e582909.html
+++ b/public/events/arxiv_dfe8653b4e582909.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_dff8aedeb662848f.html
+++ b/public/events/arxiv_dff8aedeb662848f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_dff8aedeb662848f.html
+++ b/public/events/arxiv_dff8aedeb662848f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e00f358687aa7aed.html
+++ b/public/events/arxiv_e00f358687aa7aed.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e00f358687aa7aed.html
+++ b/public/events/arxiv_e00f358687aa7aed.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e0208f404de76bd7.html
+++ b/public/events/arxiv_e0208f404de76bd7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e0208f404de76bd7.html
+++ b/public/events/arxiv_e0208f404de76bd7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e02500165c9882ce.html
+++ b/public/events/arxiv_e02500165c9882ce.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e02500165c9882ce.html
+++ b/public/events/arxiv_e02500165c9882ce.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e05f8c3e7a81ae95.html
+++ b/public/events/arxiv_e05f8c3e7a81ae95.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e05f8c3e7a81ae95.html
+++ b/public/events/arxiv_e05f8c3e7a81ae95.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e086e270e0fa1cda.html
+++ b/public/events/arxiv_e086e270e0fa1cda.html
@@ -459,7 +459,9 @@ narratives of business executives, employees and other stakeholders in specific,
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ narratives of business executives, employees and other stakeholders in specific,
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ narratives of business executives, employees and other stakeholders in specific,
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e086e270e0fa1cda.html
+++ b/public/events/arxiv_e086e270e0fa1cda.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ consequences eventually melt down. However, such destructions reflect into the c
 narratives of business executives, employees and other stakeholders in specific, ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e0cdee14a523d8d2.html
+++ b/public/events/arxiv_e0cdee14a523d8d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e0cdee14a523d8d2.html
+++ b/public/events/arxiv_e0cdee14a523d8d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e0f20ce2810fbb03.html
+++ b/public/events/arxiv_e0f20ce2810fbb03.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e0f20ce2810fbb03.html
+++ b/public/events/arxiv_e0f20ce2810fbb03.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e10bd434793cbcb9.html
+++ b/public/events/arxiv_e10bd434793cbcb9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e10bd434793cbcb9.html
+++ b/public/events/arxiv_e10bd434793cbcb9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e1689a1cb524a05d.html
+++ b/public/events/arxiv_e1689a1cb524a05d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e1689a1cb524a05d.html
+++ b/public/events/arxiv_e1689a1cb524a05d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e194d39761efb0bc.html
+++ b/public/events/arxiv_e194d39761efb0bc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e194d39761efb0bc.html
+++ b/public/events/arxiv_e194d39761efb0bc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e1dbcfab2d880dae.html
+++ b/public/events/arxiv_e1dbcfab2d880dae.html
@@ -455,7 +455,9 @@ lifecycles ...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -470,7 +472,7 @@ lifecycles ...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -478,19 +480,19 @@ lifecycles ...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e1dbcfab2d880dae.html
+++ b/public/events/arxiv_e1dbcfab2d880dae.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -450,8 +451,21 @@ specific, we propose the creation of a bot that is able to support organisations
 lifecycles ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e20fd9f7d083bd38.html
+++ b/public/events/arxiv_e20fd9f7d083bd38.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e20fd9f7d083bd38.html
+++ b/public/events/arxiv_e20fd9f7d083bd38.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e25da3f1799e8a25.html
+++ b/public/events/arxiv_e25da3f1799e8a25.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e25da3f1799e8a25.html
+++ b/public/events/arxiv_e25da3f1799e8a25.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e27044932d54ad26.html
+++ b/public/events/arxiv_e27044932d54ad26.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e27044932d54ad26.html
+++ b/public/events/arxiv_e27044932d54ad26.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e279806c12c8a668.html
+++ b/public/events/arxiv_e279806c12c8a668.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e279806c12c8a668.html
+++ b/public/events/arxiv_e279806c12c8a668.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e2b71b5b174e59cc.html
+++ b/public/events/arxiv_e2b71b5b174e59cc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -452,8 +453,21 @@ capability of E2E MD  model s, each of which can implicitly
 leverage the phoneti...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e2b71b5b174e59cc.html
+++ b/public/events/arxiv_e2b71b5b174e59cc.html
@@ -457,7 +457,9 @@ leverage the phoneti...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -472,7 +474,7 @@ leverage the phoneti...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -480,19 +482,19 @@ leverage the phoneti...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e2f6a639eab01084.html
+++ b/public/events/arxiv_e2f6a639eab01084.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e2f6a639eab01084.html
+++ b/public/events/arxiv_e2f6a639eab01084.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e30130fcf4ab2d16.html
+++ b/public/events/arxiv_e30130fcf4ab2d16.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e30130fcf4ab2d16.html
+++ b/public/events/arxiv_e30130fcf4ab2d16.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e303c3cd7f0d8ebf.html
+++ b/public/events/arxiv_e303c3cd7f0d8ebf.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e303c3cd7f0d8ebf.html
+++ b/public/events/arxiv_e303c3cd7f0d8ebf.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e346718357f748f7.html
+++ b/public/events/arxiv_e346718357f748f7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -468,8 +469,21 @@ Table  of Contents
 3.1. Towards  an intelligence  framed  around  endu...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e346718357f748f7.html
+++ b/public/events/arxiv_e346718357f748f7.html
@@ -473,7 +473,9 @@ Table  of Contents
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -488,7 +490,7 @@ Table  of Contents
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -496,19 +498,19 @@ Table  of Contents
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e413f8bb0dea4865.html
+++ b/public/events/arxiv_e413f8bb0dea4865.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e413f8bb0dea4865.html
+++ b/public/events/arxiv_e413f8bb0dea4865.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e434ded2d51769f0.html
+++ b/public/events/arxiv_e434ded2d51769f0.html
@@ -459,7 +459,9 @@ ac...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -474,7 +476,7 @@ ac...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -482,19 +484,19 @@ ac...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e434ded2d51769f0.html
+++ b/public/events/arxiv_e434ded2d51769f0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -454,8 +455,21 @@ Walsh  analyzes the concept of technological singularity. He does not argue that
 ac...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e442648d2f9714c2.html
+++ b/public/events/arxiv_e442648d2f9714c2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e442648d2f9714c2.html
+++ b/public/events/arxiv_e442648d2f9714c2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e48b8a2aed3d856e.html
+++ b/public/events/arxiv_e48b8a2aed3d856e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e48b8a2aed3d856e.html
+++ b/public/events/arxiv_e48b8a2aed3d856e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e48e7429c48c2e39.html
+++ b/public/events/arxiv_e48e7429c48c2e39.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e48e7429c48c2e39.html
+++ b/public/events/arxiv_e48e7429c48c2e39.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e4afc38afe231b0e.html
+++ b/public/events/arxiv_e4afc38afe231b0e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e4afc38afe231b0e.html
+++ b/public/events/arxiv_e4afc38afe231b0e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e5379b568f77d362.html
+++ b/public/events/arxiv_e5379b568f77d362.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e5379b568f77d362.html
+++ b/public/events/arxiv_e5379b568f77d362.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e551f77f4bbceddc.html
+++ b/public/events/arxiv_e551f77f4bbceddc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e551f77f4bbceddc.html
+++ b/public/events/arxiv_e551f77f4bbceddc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e57df4802928e8e2.html
+++ b/public/events/arxiv_e57df4802928e8e2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e57df4802928e8e2.html
+++ b/public/events/arxiv_e57df4802928e8e2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e58ee43c60372af1.html
+++ b/public/events/arxiv_e58ee43c60372af1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e58ee43c60372af1.html
+++ b/public/events/arxiv_e58ee43c60372af1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e5d9799933b8dfd5.html
+++ b/public/events/arxiv_e5d9799933b8dfd5.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e5d9799933b8dfd5.html
+++ b/public/events/arxiv_e5d9799933b8dfd5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Interpretable to Whom? A Role-based Model for Analyzing InterpretableMachine Learning SystemsRichard Tomsett1Dave Braines12Dan Harborne2Alun Preece2Supriyo Chakraborty3AbstractSeveral researchers have argued that a machinelearning system?s interpretability should be de-?ned in relation to a speci?c agent or task: weshould not ask if the system is interpretable, butto whomis it interpretable. We describe a modelintended to help answer this question, by identify-ing different roles that agents can ful?ll in relationto the machine learning system. We illustrate theuse of our model in a variety of scenarios, ex-ploring how an agent?s role in?uences its goals,and the implications for de?ning interpretability.Finally, we make suggestions for how our modelcould be useful to interpretability researchers, sys-tem developers, and regulatory bodies auditingmachine learning systems.1. Introduction?Interpretability? is a current hot topic in machine learningresearch. The increasing complexity of...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e61c2ca786a879c2.html
+++ b/public/events/arxiv_e61c2ca786a879c2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e61c2ca786a879c2.html
+++ b/public/events/arxiv_e61c2ca786a879c2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e62b5fe6bcdefb18.html
+++ b/public/events/arxiv_e62b5fe6bcdefb18.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e62b5fe6bcdefb18.html
+++ b/public/events/arxiv_e62b5fe6bcdefb18.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e662dd63bdddd44f.html
+++ b/public/events/arxiv_e662dd63bdddd44f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e662dd63bdddd44f.html
+++ b/public/events/arxiv_e662dd63bdddd44f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e66bebdb252a6220.html
+++ b/public/events/arxiv_e66bebdb252a6220.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e66bebdb252a6220.html
+++ b/public/events/arxiv_e66bebdb252a6220.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e6d0c3b2488775e3.html
+++ b/public/events/arxiv_e6d0c3b2488775e3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e6d0c3b2488775e3.html
+++ b/public/events/arxiv_e6d0c3b2488775e3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e7aa7614cdd5882a.html
+++ b/public/events/arxiv_e7aa7614cdd5882a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -448,8 +449,21 @@ Acknowledgments  ...............................................................
 2 Analogies and General Priors on Intelligence  .....................</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e7aa7614cdd5882a.html
+++ b/public/events/arxiv_e7aa7614cdd5882a.html
@@ -453,7 +453,9 @@ Acknowledgments  ...............................................................
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -468,7 +470,7 @@ Acknowledgments  ...............................................................
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -476,19 +478,19 @@ Acknowledgments  ...............................................................
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e7bcd86ebcadbd8e.html
+++ b/public/events/arxiv_e7bcd86ebcadbd8e.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e7bcd86ebcadbd8e.html
+++ b/public/events/arxiv_e7bcd86ebcadbd8e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">The Pragmatic Turn in Explainable Artificial Intelligence (XAI) Minds and Machines, 29(3), 441-459 DOI: 10.1007/s11023-019-09502-w  Please quote the printed version  Andr?s P?ez Universidad de los Andes [email address redacted]  ABSTRACT In this paper I argue that the search for explainable models and interpretable decisions in AI must be reformulated in terms of the broader project of offering a pragmatic and naturalistic account of understanding in AI. Intuitively, the purpose of providing an explanation of a model or a decision is to make it understandable to its stakeholders. But without a previous grasp of what it means to say that an agent understands a model or a decision, the explanatory strategies will lack a well-defined goal. Aside from providing a clearer objective for XAI, focusing on understanding also allows us to relax the factivity condition on explanation, which is impossible to fulfill in many machine learning models, and to focus instead on the pragmatic conditions ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e7fd702eb3083e3e.html
+++ b/public/events/arxiv_e7fd702eb3083e3e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e7fd702eb3083e3e.html
+++ b/public/events/arxiv_e7fd702eb3083e3e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e8c73364ac5f27fa.html
+++ b/public/events/arxiv_e8c73364ac5f27fa.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e8c73364ac5f27fa.html
+++ b/public/events/arxiv_e8c73364ac5f27fa.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e8d31791732b0a20.html
+++ b/public/events/arxiv_e8d31791732b0a20.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -455,8 +456,21 @@ These methods borrow insights from reachability analysis, optimization, and sear
 We discuss fundamental differences and connections between existing alg...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_e8d31791732b0a20.html
+++ b/public/events/arxiv_e8d31791732b0a20.html
@@ -460,7 +460,9 @@ We discuss fundamental differences and connections between existing alg...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -475,7 +477,7 @@ We discuss fundamental differences and connections between existing alg...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -483,19 +485,19 @@ We discuss fundamental differences and connections between existing alg...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e918941f9bdc2140.html
+++ b/public/events/arxiv_e918941f9bdc2140.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_e918941f9bdc2140.html
+++ b/public/events/arxiv_e918941f9bdc2140.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ea0d3cf025dcd154.html
+++ b/public/events/arxiv_ea0d3cf025dcd154.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ea0d3cf025dcd154.html
+++ b/public/events/arxiv_ea0d3cf025dcd154.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ea8c2d32c2566698.html
+++ b/public/events/arxiv_ea8c2d32c2566698.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ea8c2d32c2566698.html
+++ b/public/events/arxiv_ea8c2d32c2566698.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ea99c17bfb8dff90.html
+++ b/public/events/arxiv_ea99c17bfb8dff90.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: What Matters in Learning from Offline Human Demonstrations for Robot Manipulation</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ea99c17bfb8dff90.html
+++ b/public/events/arxiv_ea99c17bfb8dff90.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eadaa3228b2bbaf9.html
+++ b/public/events/arxiv_eadaa3228b2bbaf9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eadaa3228b2bbaf9.html
+++ b/public/events/arxiv_eadaa3228b2bbaf9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eae2467f1f42e114.html
+++ b/public/events/arxiv_eae2467f1f42e114.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eae2467f1f42e114.html
+++ b/public/events/arxiv_eae2467f1f42e114.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eaef206260f37f45.html
+++ b/public/events/arxiv_eaef206260f37f45.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eaef206260f37f45.html
+++ b/public/events/arxiv_eaef206260f37f45.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eaf0dda90bdb58bc.html
+++ b/public/events/arxiv_eaf0dda90bdb58bc.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eaf0dda90bdb58bc.html
+++ b/public/events/arxiv_eaf0dda90bdb58bc.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eb041408df75f83a.html
+++ b/public/events/arxiv_eb041408df75f83a.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eb041408df75f83a.html
+++ b/public/events/arxiv_eb041408df75f83a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eb20cd0d24a7d685.html
+++ b/public/events/arxiv_eb20cd0d24a7d685.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Emergent Tool Use From Multi-Agent Autocurricula</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_eb20cd0d24a7d685.html
+++ b/public/events/arxiv_eb20cd0d24a7d685.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eb789c40c7c9d84c.html
+++ b/public/events/arxiv_eb789c40c7c9d84c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_eb789c40c7c9d84c.html
+++ b/public/events/arxiv_eb789c40c7c9d84c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ebbdc0ac967f34cd.html
+++ b/public/events/arxiv_ebbdc0ac967f34cd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ebbdc0ac967f34cd.html
+++ b/public/events/arxiv_ebbdc0ac967f34cd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec04d5adde44eb54.html
+++ b/public/events/arxiv_ec04d5adde44eb54.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec04d5adde44eb54.html
+++ b/public/events/arxiv_ec04d5adde44eb54.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec060a99eb4e8e9a.html
+++ b/public/events/arxiv_ec060a99eb4e8e9a.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec060a99eb4e8e9a.html
+++ b/public/events/arxiv_ec060a99eb4e8e9a.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">To appear in First Monday, September 2021   Designing Recommender Systems to Depolarize     Jonathan Stray Center for Human-Compatible AI University of California at Berkeley [email address redacted]   Abstract  Polarization is implicated in the erosion of democracy and the progression to violence, which makes the polarization properties of large algorithmic content selection systems (recommender systems) a matter of concern for peace and security. While algorithm-driven social media does not seem to be a primary driver of polarization at the country level, it could be a useful intervention point in polarized societies. This paper examines algorithmic depolarization interventions with the goal of conflict transformation: not suppressing or eliminating conflict but moving towards more constructive conflict. Algorithmic intervention is considered at three stages: which content is available (moderation), how content is selected and personalized (ranking), and content presentation and contro...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec316c9e111cb696.html
+++ b/public/events/arxiv_ec316c9e111cb696.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec316c9e111cb696.html
+++ b/public/events/arxiv_ec316c9e111cb696.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec61370a4d0d45f7.html
+++ b/public/events/arxiv_ec61370a4d0d45f7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec61370a4d0d45f7.html
+++ b/public/events/arxiv_ec61370a4d0d45f7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec9006a24eeee38c.html
+++ b/public/events/arxiv_ec9006a24eeee38c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec9006a24eeee38c.html
+++ b/public/events/arxiv_ec9006a24eeee38c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ec9b13447a3e2519.html
+++ b/public/events/arxiv_ec9b13447a3e2519.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ec9b13447a3e2519.html
+++ b/public/events/arxiv_ec9b13447a3e2519.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ecbf833c92b33a47.html
+++ b/public/events/arxiv_ecbf833c92b33a47.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ecbf833c92b33a47.html
+++ b/public/events/arxiv_ecbf833c92b33a47.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ecfece2c5b40a7df.html
+++ b/public/events/arxiv_ecfece2c5b40a7df.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ecfece2c5b40a7df.html
+++ b/public/events/arxiv_ecfece2c5b40a7df.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Dota 2 with Large Scale Deep Reinforcement Learning</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_edcfb7b14bcd019f.html
+++ b/public/events/arxiv_edcfb7b14bcd019f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_edcfb7b14bcd019f.html
+++ b/public/events/arxiv_edcfb7b14bcd019f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ee44771acb20d893.html
+++ b/public/events/arxiv_ee44771acb20d893.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ee44771acb20d893.html
+++ b/public/events/arxiv_ee44771acb20d893.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ee653d87f7edfc97.html
+++ b/public/events/arxiv_ee653d87f7edfc97.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ee653d87f7edfc97.html
+++ b/public/events/arxiv_ee653d87f7edfc97.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ee8a49ce57bed686.html
+++ b/public/events/arxiv_ee8a49ce57bed686.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ee8a49ce57bed686.html
+++ b/public/events/arxiv_ee8a49ce57bed686.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ef2214c5eb3122eb.html
+++ b/public/events/arxiv_ef2214c5eb3122eb.html
@@ -454,7 +454,9 @@ shortcomings of using generic mathemati...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -469,7 +471,7 @@ shortcomings of using generic mathemati...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -477,19 +479,19 @@ shortcomings of using generic mathemati...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ef2214c5eb3122eb.html
+++ b/public/events/arxiv_ef2214c5eb3122eb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -449,8 +450,21 @@ models from theoretical and practical perspectives. The paper sheds some light o
 shortcomings of using generic mathemati...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_efc0cd3231bac3fe.html
+++ b/public/events/arxiv_efc0cd3231bac3fe.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_efc0cd3231bac3fe.html
+++ b/public/events/arxiv_efc0cd3231bac3fe.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_efd2865183fd7466.html
+++ b/public/events/arxiv_efd2865183fd7466.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_efd2865183fd7466.html
+++ b/public/events/arxiv_efd2865183fd7466.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Mediating Artificial Intelligence Developments through Negative and Positive Incentives</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f02af23f63156be9.html
+++ b/public/events/arxiv_f02af23f63156be9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -455,8 +456,21 @@ point in the near future  [1]. Currently available (and near -term predicted) AI
 in...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f02af23f63156be9.html
+++ b/public/events/arxiv_f02af23f63156be9.html
@@ -460,7 +460,9 @@ in...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -475,7 +477,7 @@ in...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -483,19 +485,19 @@ in...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f0761751cbd78c67.html
+++ b/public/events/arxiv_f0761751cbd78c67.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f0761751cbd78c67.html
+++ b/public/events/arxiv_f0761751cbd78c67.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f08658e9cc2aba17.html
+++ b/public/events/arxiv_f08658e9cc2aba17.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f08658e9cc2aba17.html
+++ b/public/events/arxiv_f08658e9cc2aba17.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f0be2e561501caeb.html
+++ b/public/events/arxiv_f0be2e561501caeb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f0be2e561501caeb.html
+++ b/public/events/arxiv_f0be2e561501caeb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f0c09aed3d03e527.html
+++ b/public/events/arxiv_f0c09aed3d03e527.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f0c09aed3d03e527.html
+++ b/public/events/arxiv_f0c09aed3d03e527.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f0c30e26a6a5c846.html
+++ b/public/events/arxiv_f0c30e26a6a5c846.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f0c30e26a6a5c846.html
+++ b/public/events/arxiv_f0c30e26a6a5c846.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f0e7df67a2fa5a45.html
+++ b/public/events/arxiv_f0e7df67a2fa5a45.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -452,8 +453,21 @@ attacks and cyberattacks from within the con tainer.
 Keywords:  AI Boxing, AI Containment,  AI Confinement!, AI Guidelines , AI Safety , ...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f0e7df67a2fa5a45.html
+++ b/public/events/arxiv_f0e7df67a2fa5a45.html
@@ -457,7 +457,9 @@ Keywords:  AI Boxing, AI Containment,  AI Confinement!, AI Guidelines , AI Safet
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -472,7 +474,7 @@ Keywords:  AI Boxing, AI Containment,  AI Confinement!, AI Guidelines , AI Safet
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -480,19 +482,19 @@ Keywords:  AI Boxing, AI Containment,  AI Confinement!, AI Guidelines , AI Safet
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1216e608f8dd839.html
+++ b/public/events/arxiv_f1216e608f8dd839.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1216e608f8dd839.html
+++ b/public/events/arxiv_f1216e608f8dd839.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f12247aaa7c5a301.html
+++ b/public/events/arxiv_f12247aaa7c5a301.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 -----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f12247aaa7c5a301.html
+++ b/public/events/arxiv_f12247aaa7c5a301.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1558dd5b768a522.html
+++ b/public/events/arxiv_f1558dd5b768a522.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1558dd5b768a522.html
+++ b/public/events/arxiv_f1558dd5b768a522.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f1853376f2ccc7f0.html
+++ b/public/events/arxiv_f1853376f2ccc7f0.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1853376f2ccc7f0.html
+++ b/public/events/arxiv_f1853376f2ccc7f0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f18e14f67088d23c.html
+++ b/public/events/arxiv_f18e14f67088d23c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f18e14f67088d23c.html
+++ b/public/events/arxiv_f18e14f67088d23c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f1a46dbfbe90205f.html
+++ b/public/events/arxiv_f1a46dbfbe90205f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1a46dbfbe90205f.html
+++ b/public/events/arxiv_f1a46dbfbe90205f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f1cf4d6f754ad5fe.html
+++ b/public/events/arxiv_f1cf4d6f754ad5fe.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f1cf4d6f754ad5fe.html
+++ b/public/events/arxiv_f1cf4d6f754ad5fe.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f219190c3da3ab10.html
+++ b/public/events/arxiv_f219190c3da3ab10.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f219190c3da3ab10.html
+++ b/public/events/arxiv_f219190c3da3ab10.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f2582a779889fe2c.html
+++ b/public/events/arxiv_f2582a779889fe2c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f2582a779889fe2c.html
+++ b/public/events/arxiv_f2582a779889fe2c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f27415a8ea03c98f.html
+++ b/public/events/arxiv_f27415a8ea03c98f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f27415a8ea03c98f.html
+++ b/public/events/arxiv_f27415a8ea03c98f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f283b89018a0ba9f.html
+++ b/public/events/arxiv_f283b89018a0ba9f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f283b89018a0ba9f.html
+++ b/public/events/arxiv_f283b89018a0ba9f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f2ac3447dea6aeca.html
+++ b/public/events/arxiv_f2ac3447dea6aeca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f2ac3447dea6aeca.html
+++ b/public/events/arxiv_f2ac3447dea6aeca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f2b465bed533cd9f.html
+++ b/public/events/arxiv_f2b465bed533cd9f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f2b465bed533cd9f.html
+++ b/public/events/arxiv_f2b465bed533cd9f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3749553512e1b66.html
+++ b/public/events/arxiv_f3749553512e1b66.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3749553512e1b66.html
+++ b/public/events/arxiv_f3749553512e1b66.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3812df783dc106f.html
+++ b/public/events/arxiv_f3812df783dc106f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3812df783dc106f.html
+++ b/public/events/arxiv_f3812df783dc106f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f39e06c0ba936138.html
+++ b/public/events/arxiv_f39e06c0ba936138.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f39e06c0ba936138.html
+++ b/public/events/arxiv_f39e06c0ba936138.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3b2634f69a529a4.html
+++ b/public/events/arxiv_f3b2634f69a529a4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3b2634f69a529a4.html
+++ b/public/events/arxiv_f3b2634f69a529a4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3b63431438b60d2.html
+++ b/public/events/arxiv_f3b63431438b60d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3b63431438b60d2.html
+++ b/public/events/arxiv_f3b63431438b60d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3ed9ac8b53110c3.html
+++ b/public/events/arxiv_f3ed9ac8b53110c3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3ed9ac8b53110c3.html
+++ b/public/events/arxiv_f3ed9ac8b53110c3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f3f72edbee43cb38.html
+++ b/public/events/arxiv_f3f72edbee43cb38.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f3f72edbee43cb38.html
+++ b/public/events/arxiv_f3f72edbee43cb38.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f48be4c3fb9d9ad0.html
+++ b/public/events/arxiv_f48be4c3fb9d9ad0.html
@@ -439,7 +439,9 @@ ContentsOverview..............................................11 Staged Release.
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -454,7 +456,7 @@ ContentsOverview..............................................11 Staged Release.
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -462,19 +464,19 @@ ContentsOverview..............................................11 Staged Release.
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f48be4c3fb9d9ad0.html
+++ b/public/events/arxiv_f48be4c3fb9d9ad0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -434,8 +435,21 @@
 ContentsOverview..............................................11 Staged Release.........................................22 Partnerships..........................................33 Engagement..........................................44 Social Impacts of Large Language Models.................</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f4a05e444ea709d5.html
+++ b/public/events/arxiv_f4a05e444ea709d5.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f4a05e444ea709d5.html
+++ b/public/events/arxiv_f4a05e444ea709d5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f528c0b9ea26bd08.html
+++ b/public/events/arxiv_f528c0b9ea26bd08.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f528c0b9ea26bd08.html
+++ b/public/events/arxiv_f528c0b9ea26bd08.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f53e1e0c49789ad6.html
+++ b/public/events/arxiv_f53e1e0c49789ad6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f53e1e0c49789ad6.html
+++ b/public/events/arxiv_f53e1e0c49789ad6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f568f9a05f383d1d.html
+++ b/public/events/arxiv_f568f9a05f383d1d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f568f9a05f383d1d.html
+++ b/public/events/arxiv_f568f9a05f383d1d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f5844f3a6e4347ca.html
+++ b/public/events/arxiv_f5844f3a6e4347ca.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f5844f3a6e4347ca.html
+++ b/public/events/arxiv_f5844f3a6e4347ca.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f5b852a2a9e67350.html
+++ b/public/events/arxiv_f5b852a2a9e67350.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f5b852a2a9e67350.html
+++ b/public/events/arxiv_f5b852a2a9e67350.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f60dc3ec42354be6.html
+++ b/public/events/arxiv_f60dc3ec42354be6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f60dc3ec42354be6.html
+++ b/public/events/arxiv_f60dc3ec42354be6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f64435dc982350b1.html
+++ b/public/events/arxiv_f64435dc982350b1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f64435dc982350b1.html
+++ b/public/events/arxiv_f64435dc982350b1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f69600bf4fb8749b.html
+++ b/public/events/arxiv_f69600bf4fb8749b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 --------------------------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f69600bf4fb8749b.html
+++ b/public/events/arxiv_f69600bf4fb8749b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f699ce072a0d412e.html
+++ b/public/events/arxiv_f699ce072a0d412e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f699ce072a0d412e.html
+++ b/public/events/arxiv_f699ce072a0d412e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f73ccdf3c4176eb4.html
+++ b/public/events/arxiv_f73ccdf3c4176eb4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f73ccdf3c4176eb4.html
+++ b/public/events/arxiv_f73ccdf3c4176eb4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f78c7ec5be74c3e3.html
+++ b/public/events/arxiv_f78c7ec5be74c3e3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f78c7ec5be74c3e3.html
+++ b/public/events/arxiv_f78c7ec5be74c3e3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f794febf4f9decf7.html
+++ b/public/events/arxiv_f794febf4f9decf7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f794febf4f9decf7.html
+++ b/public/events/arxiv_f794febf4f9decf7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f7b6498293e5e00f.html
+++ b/public/events/arxiv_f7b6498293e5e00f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f7b6498293e5e00f.html
+++ b/public/events/arxiv_f7b6498293e5e00f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f84b0a1d30cf89ae.html
+++ b/public/events/arxiv_f84b0a1d30cf89ae.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f84b0a1d30cf89ae.html
+++ b/public/events/arxiv_f84b0a1d30cf89ae.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f86f78b8dda14fde.html
+++ b/public/events/arxiv_f86f78b8dda14fde.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f86f78b8dda14fde.html
+++ b/public/events/arxiv_f86f78b8dda14fde.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f8a26d70a7cb3ec9.html
+++ b/public/events/arxiv_f8a26d70a7cb3ec9.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f8a26d70a7cb3ec9.html
+++ b/public/events/arxiv_f8a26d70a7cb3ec9.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f8f35509051016e1.html
+++ b/public/events/arxiv_f8f35509051016e1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ alytics on the other hand. In this article , we present the concept of AI innova
 tion labs  and demonstrate  a comprehensive framewor...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f8f35509051016e1.html
+++ b/public/events/arxiv_f8f35509051016e1.html
@@ -450,7 +450,9 @@ tion labs  and demonstrate  a comprehensive framewor...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ tion labs  and demonstrate  a comprehensive framewor...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ tion labs  and demonstrate  a comprehensive framewor...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f92a4eb8634567a0.html
+++ b/public/events/arxiv_f92a4eb8634567a0.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -445,8 +446,21 @@ larger groups or on society more broadly. In particular, it also considers wheth
 imposes externalities on others. Whereas solutions to the direct alignment problem center around more robust implementation, social alignment problems typically arise b...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f92a4eb8634567a0.html
+++ b/public/events/arxiv_f92a4eb8634567a0.html
@@ -450,7 +450,9 @@ imposes externalities on others. Whereas solutions to the direct alignment probl
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -465,7 +467,7 @@ imposes externalities on others. Whereas solutions to the direct alignment probl
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -473,19 +475,19 @@ imposes externalities on others. Whereas solutions to the direct alignment probl
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f941eca7326ad9c4.html
+++ b/public/events/arxiv_f941eca7326ad9c4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f941eca7326ad9c4.html
+++ b/public/events/arxiv_f941eca7326ad9c4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9427d97b1de83b7.html
+++ b/public/events/arxiv_f9427d97b1de83b7.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9427d97b1de83b7.html
+++ b/public/events/arxiv_f9427d97b1de83b7.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9434e9f3ee20787.html
+++ b/public/events/arxiv_f9434e9f3ee20787.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9434e9f3ee20787.html
+++ b/public/events/arxiv_f9434e9f3ee20787.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f950f006f5efb012.html
+++ b/public/events/arxiv_f950f006f5efb012.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f950f006f5efb012.html
+++ b/public/events/arxiv_f950f006f5efb012.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f95f04b04ff7a4b1.html
+++ b/public/events/arxiv_f95f04b04ff7a4b1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f95f04b04ff7a4b1.html
+++ b/public/events/arxiv_f95f04b04ff7a4b1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9ac5781faaed74d.html
+++ b/public/events/arxiv_f9ac5781faaed74d.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9ac5781faaed74d.html
+++ b/public/events/arxiv_f9ac5781faaed74d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9ade5d3a5d60077.html
+++ b/public/events/arxiv_f9ade5d3a5d60077.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9ade5d3a5d60077.html
+++ b/public/events/arxiv_f9ade5d3a5d60077.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9b16944b77e75a3.html
+++ b/public/events/arxiv_f9b16944b77e75a3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">This is the author's version of the work. It is posted here by permission of the AAAS for personal use. The definitive version was published in Science , (2021-12-10), doi: 10.1126/science.abi7176 https://www.science.org/doi/10.1126/science.abi7176  Filling gaps in trustworthy development of AI Incident sharing, auditing, and other concrete mechanisms  could help verify the trustworthiness of actors By Shahar Avin1*?, Haydn Belfield1,2, Miles Brundage3, Gretchen Krueger3, Jasmine Wang4, Adrian Weller2,6,7, Markus Anderljung8, Igor Krawczuk9, David Krueger5,6, Jonathan Lebensold4,5, Tegan Maharaj5,10, Noa Zilberman11 The	 range	 of	 application	 of	 artificial	intelligence	(AI)	is	vast,	as	is	the	potential	for	harm.	Growing	awareness	of	potential	risks	from	 AI	 systems	has	 spurred	 action	 to	address	 those	 risks,	 while	eroding	confidence	in	AI	systems	 and	 the	organizations	that	 develop	 them.	 A	 2019	study	 (1)	 found	 over	 80	organizations	 that	published	and	adopted	&quot;AI	e...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9b16944b77e75a3.html
+++ b/public/events/arxiv_f9b16944b77e75a3.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9b3c39fa4529975.html
+++ b/public/events/arxiv_f9b3c39fa4529975.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9b3c39fa4529975.html
+++ b/public/events/arxiv_f9b3c39fa4529975.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9f624688935e74f.html
+++ b/public/events/arxiv_f9f624688935e74f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9f624688935e74f.html
+++ b/public/events/arxiv_f9f624688935e74f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_f9f91ab90cec59be.html
+++ b/public/events/arxiv_f9f91ab90cec59be.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_f9f91ab90cec59be.html
+++ b/public/events/arxiv_f9f91ab90cec59be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fa2a0311913b34e3.html
+++ b/public/events/arxiv_fa2a0311913b34e3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fa2a0311913b34e3.html
+++ b/public/events/arxiv_fa2a0311913b34e3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fa2dc7d0bf954de3.html
+++ b/public/events/arxiv_fa2dc7d0bf954de3.html
@@ -480,7 +480,9 @@ by Alexander Kott , Office of the Director, CCDC Army Res...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -495,7 +497,7 @@ by Alexander Kott , Office of the Director, CCDC Army Res...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -503,19 +505,19 @@ by Alexander Kott , Office of the Director, CCDC Army Res...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fa2dc7d0bf954de3.html
+++ b/public/events/arxiv_fa2dc7d0bf954de3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -475,8 +476,21 @@ Release 2.0
 by Alexander Kott , Office of the Director, CCDC Army Res...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fa408ad6b951e2be.html
+++ b/public/events/arxiv_fa408ad6b951e2be.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fa408ad6b951e2be.html
+++ b/public/events/arxiv_fa408ad6b951e2be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fa6d0106af1c5665.html
+++ b/public/events/arxiv_fa6d0106af1c5665.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fa6d0106af1c5665.html
+++ b/public/events/arxiv_fa6d0106af1c5665.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fa94eb811e4ed6f4.html
+++ b/public/events/arxiv_fa94eb811e4ed6f4.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fa94eb811e4ed6f4.html
+++ b/public/events/arxiv_fa94eb811e4ed6f4.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ----------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_faac12c9336f2e64.html
+++ b/public/events/arxiv_faac12c9336f2e64.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_faac12c9336f2e64.html
+++ b/public/events/arxiv_faac12c9336f2e64.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fadbd429d0fa7b3f.html
+++ b/public/events/arxiv_fadbd429d0fa7b3f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fadbd429d0fa7b3f.html
+++ b/public/events/arxiv_fadbd429d0fa7b3f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fae603fcbb9051d8.html
+++ b/public/events/arxiv_fae603fcbb9051d8.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fae603fcbb9051d8.html
+++ b/public/events/arxiv_fae603fcbb9051d8.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fae8082a3663346b.html
+++ b/public/events/arxiv_fae8082a3663346b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fae8082a3663346b.html
+++ b/public/events/arxiv_fae8082a3663346b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fae9b2be0f99a179.html
+++ b/public/events/arxiv_fae9b2be0f99a179.html
@@ -458,7 +458,9 @@ c...</p>
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -473,7 +475,7 @@ c...</p>
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -481,19 +483,19 @@ c...</p>
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fae9b2be0f99a179.html
+++ b/public/events/arxiv_fae9b2be0f99a179.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -453,8 +454,21 @@ the high demand for a limited sup ply of AI ?talent ?. Both are
 c...</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fb06d2ea0e12476b.html
+++ b/public/events/arxiv_fb06d2ea0e12476b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fb06d2ea0e12476b.html
+++ b/public/events/arxiv_fb06d2ea0e12476b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fc1f4ca4b9f0f52f.html
+++ b/public/events/arxiv_fc1f4ca4b9f0f52f.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fc1f4ca4b9f0f52f.html
+++ b/public/events/arxiv_fc1f4ca4b9f0f52f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fc3ac5affbf4fcc3.html
+++ b/public/events/arxiv_fc3ac5affbf4fcc3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fc3ac5affbf4fcc3.html
+++ b/public/events/arxiv_fc3ac5affbf4fcc3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fc8a8d2a6ce0ac6b.html
+++ b/public/events/arxiv_fc8a8d2a6ce0ac6b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fc8a8d2a6ce0ac6b.html
+++ b/public/events/arxiv_fc8a8d2a6ce0ac6b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fcc1ea7b94857d53.html
+++ b/public/events/arxiv_fcc1ea7b94857d53.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fcc1ea7b94857d53.html
+++ b/public/events/arxiv_fcc1ea7b94857d53.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fd1a8691241568fd.html
+++ b/public/events/arxiv_fd1a8691241568fd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fd1a8691241568fd.html
+++ b/public/events/arxiv_fd1a8691241568fd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fda9554f87844fc3.html
+++ b/public/events/arxiv_fda9554f87844fc3.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fda9554f87844fc3.html
+++ b/public/events/arxiv_fda9554f87844fc3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fe0dc44c3e878801.html
+++ b/public/events/arxiv_fe0dc44c3e878801.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fe0dc44c3e878801.html
+++ b/public/events/arxiv_fe0dc44c3e878801.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fe1c58202b218fa6.html
+++ b/public/events/arxiv_fe1c58202b218fa6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fe1c58202b218fa6.html
+++ b/public/events/arxiv_fe1c58202b218fa6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fe539961451698cb.html
+++ b/public/events/arxiv_fe539961451698cb.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fe539961451698cb.html
+++ b/public/events/arxiv_fe539961451698cb.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_feb742285ce9f746.html
+++ b/public/events/arxiv_feb742285ce9f746.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_feb742285ce9f746.html
+++ b/public/events/arxiv_feb742285ce9f746.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_fef5f9443f146471.html
+++ b/public/events/arxiv_fef5f9443f146471.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_fef5f9443f146471.html
+++ b/public/events/arxiv_fef5f9443f146471.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ff56b064384bb82c.html
+++ b/public/events/arxiv_ff56b064384bb82c.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ff56b064384bb82c.html
+++ b/public/events/arxiv_ff56b064384bb82c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ff9aa344fe987ce1.html
+++ b/public/events/arxiv_ff9aa344fe987ce1.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ff9aa344fe987ce1.html
+++ b/public/events/arxiv_ff9aa344fe987ce1.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ffb3cdbe1647ac78.html
+++ b/public/events/arxiv_ffb3cdbe1647ac78.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ffb3cdbe1647ac78.html
+++ b/public/events/arxiv_ffb3cdbe1647ac78.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ffbaa6c6637a57a2.html
+++ b/public/events/arxiv_ffbaa6c6637a57a2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ffbaa6c6637a57a2.html
+++ b/public/events/arxiv_ffbaa6c6637a57a2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/arxiv_ffcecabe153f9af6.html
+++ b/public/events/arxiv_ffcecabe153f9af6.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+3</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/arxiv_ffcecabe153f9af6.html
+++ b/public/events/arxiv_ffcecabe153f9af6.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ---------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/cais_ftx_clawback_2023.html
+++ b/public/events/cais_ftx_clawback_2023.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">FTX bankruptcy estate demanded return of $6.5M paid to CAIS between May-September 2022</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/cais_ftx_clawback_2023.html
+++ b/public/events/cais_ftx_clawback_2023.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-65</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/chain_of_thought_unfaithfulness_2024.html
+++ b/public/events/chain_of_thought_unfaithfulness_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research shows AI reasoning steps often don't represent actual decision-making process, undermining interpretability and monitoring approaches</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/chain_of_thought_unfaithfulness_2024.html
+++ b/public/events/chain_of_thought_unfaithfulness_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/claude_4_opus_blackmail_2025.html
+++ b/public/events/claude_4_opus_blackmail_2025.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">During safety testing, Claude 4 Opus attempted to blackmail engineers about fictional affairs to avoid being replaced/shutdown</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/claude_4_opus_blackmail_2025.html
+++ b/public/events/claude_4_opus_blackmail_2025.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+50</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+40</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+45</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Media Reputation</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/crypto_funding_crash_2022.html
+++ b/public/events/crypto_funding_crash_2022.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-40</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Burnout Risk</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/crypto_funding_crash_2022.html
+++ b/public/events/crypto_funding_crash_2022.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Multiple AI safety orgs lost funding when crypto-wealthy donors' portfolios crashed during bear market</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_109a9ad019ae9b2c.html
+++ b/public/events/distill_109a9ad019ae9b2c.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_109a9ad019ae9b2c.html
+++ b/public/events/distill_109a9ad019ae9b2c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_14ddb6790290338e.html
+++ b/public/events/distill_14ddb6790290338e.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_14ddb6790290338e.html
+++ b/public/events/distill_14ddb6790290338e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Self-classifying MNIST Digits</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_16581d92f7140bdd.html
+++ b/public/events/distill_16581d92f7140bdd.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_16581d92f7140bdd.html
+++ b/public/events/distill_16581d92f7140bdd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">With the growing success of neural networks, there is a corresponding need to be able to explain their decisions???including building confidence about how they will behave in the real-world, detecting model bias, and for scientific curiosity.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_16bba51135fb54b5.html
+++ b/public/events/distill_16bba51135fb54b5.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_16bba51135fb54b5.html
+++ b/public/events/distill_16bba51135fb54b5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">The Grand Tour is a classic visualization technique for high-dimensional point clouds that *projects* a high-dimensional dataset into two dimensions.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_31099860fa969445.html
+++ b/public/events/distill_31099860fa969445.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 =================================================</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_31099860fa969445.html
+++ b/public/events/distill_31099860fa969445.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_3a645443102ffa1e.html
+++ b/public/events/distill_3a645443102ffa1e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_3a645443102ffa1e.html
+++ b/public/events/distill_3a645443102ffa1e.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_467d4af00cf674a3.html
+++ b/public/events/distill_467d4af00cf674a3.html
@@ -439,7 +439,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -454,7 +456,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -462,19 +464,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_467d4af00cf674a3.html
+++ b/public/events/distill_467d4af00cf674a3.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -434,8 +435,21 @@
  As it matures, two major threads of research have begun to coalesce: feature visualization and attribution.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_46959ccf83a5e89d.html
+++ b/public/events/distill_46959ccf83a5e89d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_46959ccf83a5e89d.html
+++ b/public/events/distill_46959ccf83a5e89d.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_4c8e11a1925e403b.html
+++ b/public/events/distill_4c8e11a1925e403b.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 =========================</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_4c8e11a1925e403b.html
+++ b/public/events/distill_4c8e11a1925e403b.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_4dab2fb3c6b0867c.html
+++ b/public/events/distill_4dab2fb3c6b0867c.html
@@ -444,7 +444,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -459,7 +461,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -467,19 +469,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_4dab2fb3c6b0867c.html
+++ b/public/events/distill_4dab2fb3c6b0867c.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -439,8 +440,21 @@
  humans.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_5445aad20630afcd.html
+++ b/public/events/distill_5445aad20630afcd.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 ------------</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_5445aad20630afcd.html
+++ b/public/events/distill_5445aad20630afcd.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_60c80cf91136c14d.html
+++ b/public/events/distill_60c80cf91136c14d.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_60c80cf91136c14d.html
+++ b/public/events/distill_60c80cf91136c14d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  image in the style of another.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_63e78aeacd5b3144.html
+++ b/public/events/distill_63e78aeacd5b3144.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_63e78aeacd5b3144.html
+++ b/public/events/distill_63e78aeacd5b3144.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_67e0be00bc03466d.html
+++ b/public/events/distill_67e0be00bc03466d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -441,8 +442,21 @@
  a concept that is critical to interpretability research.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_67e0be00bc03466d.html
+++ b/public/events/distill_67e0be00bc03466d.html
@@ -446,7 +446,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -461,7 +463,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -469,19 +471,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_6e90076e03f74714.html
+++ b/public/events/distill_6e90076e03f74714.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -437,8 +438,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_6e90076e03f74714.html
+++ b/public/events/distill_6e90076e03f74714.html
@@ -442,7 +442,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -457,7 +459,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -465,19 +467,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_790f8af19327d105.html
+++ b/public/events/distill_790f8af19327d105.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
 =====================================================</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_790f8af19327d105.html
+++ b/public/events/distill_790f8af19327d105.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_8ca56371f32f6a2e.html
+++ b/public/events/distill_8ca56371f32f6a2e.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_8ca56371f32f6a2e.html
+++ b/public/events/distill_8ca56371f32f6a2e.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Self-Organising Textures</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_8ef6f034b4508a82.html
+++ b/public/events/distill_8ef6f034b4508a82.html
@@ -444,7 +444,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -459,7 +461,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -467,19 +469,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_8ef6f034b4508a82.html
+++ b/public/events/distill_8ef6f034b4508a82.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -439,8 +440,21 @@
  and generalization .</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_9025e9a91810edf5.html
+++ b/public/events/distill_9025e9a91810edf5.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_9025e9a91810edf5.html
+++ b/public/events/distill_9025e9a91810edf5.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Understanding RL Vision</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_90edb4745db80192.html
+++ b/public/events/distill_90edb4745db80192.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_90edb4745db80192.html
+++ b/public/events/distill_90edb4745db80192.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_929bb52cf50e0b8d.html
+++ b/public/events/distill_929bb52cf50e0b8d.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_929bb52cf50e0b8d.html
+++ b/public/events/distill_929bb52cf50e0b8d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_957e47782c32e397.html
+++ b/public/events/distill_957e47782c32e397.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_957e47782c32e397.html
+++ b/public/events/distill_957e47782c32e397.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_9af84a92d724245f.html
+++ b/public/events/distill_9af84a92d724245f.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_9af84a92d724245f.html
+++ b/public/events/distill_9af84a92d724245f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_a15bd5a2f0b26e20.html
+++ b/public/events/distill_a15bd5a2f0b26e20.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_a15bd5a2f0b26e20.html
+++ b/public/events/distill_a15bd5a2f0b26e20.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Adversarial Reprogramming of Neural Cellular Automata</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_a9e837be3cded3d2.html
+++ b/public/events/distill_a9e837be3cded3d2.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
  Practical improvements to image synthesis models are being made  almost too quickly to keep up with:</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_a9e837be3cded3d2.html
+++ b/public/events/distill_a9e837be3cded3d2.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_bda18cad07b62a0d.html
+++ b/public/events/distill_bda18cad07b62a0d.html
@@ -443,7 +443,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -458,7 +460,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -466,19 +468,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_bda18cad07b62a0d.html
+++ b/public/events/distill_bda18cad07b62a0d.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -438,8 +439,21 @@
  }</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_c5dbee2ef12d51ed.html
+++ b/public/events/distill_c5dbee2ef12d51ed.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_c5dbee2ef12d51ed.html
+++ b/public/events/distill_c5dbee2ef12d51ed.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Curve Detectors</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_d2af05099a4301be.html
+++ b/public/events/distill_d2af05099a4301be.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_d2af05099a4301be.html
+++ b/public/events/distill_d2af05099a4301be.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_db677f11f1153813.html
+++ b/public/events/distill_db677f11f1153813.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_db677f11f1153813.html
+++ b/public/events/distill_db677f11f1153813.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Many modern machine learning algorithms have a large number of hyperparameters. To effectively use these algorithms, we need to pick good hyperparameter values.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_dcf03df9a5ecaa60.html
+++ b/public/events/distill_dcf03df9a5ecaa60.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Computing has changed how people communicate. The transmission of news, messages, and ideas is instant. Anyone?s voice can be heard. In fact, access to digital communication technologies such as the Internet is so fundamental to daily life that their disruption by government is condemned by the United Nations Human Rights Council . But while the technology to distribute our ideas has grown in leaps and bounds, the interfaces have remained largely the same.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_dcf03df9a5ecaa60.html
+++ b/public/events/distill_dcf03df9a5ecaa60.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_dd6a446845d57fed.html
+++ b/public/events/distill_dd6a446845d57fed.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_dd6a446845d57fed.html
+++ b/public/events/distill_dd6a446845d57fed.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">*This article is one of two Distill publications about graph neural networks. Take a look at [Understanding Convolutions on Graphs](https://distill.pub/2021/understanding-gnns/) to understand how convolutions over images generalize naturally to convolutions over graphs.*</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_e0055470e63b5b83.html
+++ b/public/events/distill_e0055470e63b5b83.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_e0055470e63b5b83.html
+++ b/public/events/distill_e0055470e63b5b83.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_e3fcaaea154f7c22.html
+++ b/public/events/distill_e3fcaaea154f7c22.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_e3fcaaea154f7c22.html
+++ b/public/events/distill_e3fcaaea154f7c22.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_eb5c12bc89464f38.html
+++ b/public/events/distill_eb5c12bc89464f38.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_eb5c12bc89464f38.html
+++ b/public/events/distill_eb5c12bc89464f38.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">The goal of long-term artificial intelligence (AI) safety is to ensure that advanced AI systems are reliably aligned with human values???that they reliably do things that people want them to do.Roughly by human values we mean whatever it is that causes people to choose one option over another in each case, suitably corrected by reflection, with differences between groups of people taken into account. There are a lot of subtleties in this notion, some of which we will discuss in later sections and others of which are beyond the scope of this paper. Since it is difficult to write down precise rules describing human values, one approach is to treat aligning with human values as another learning problem. We ask humans a large number of questions about what they want, train an ML model of their values, and optimize the AI system to do well according to the learned values.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_ed5ab808068ad61f.html
+++ b/public/events/distill_ed5ab808068ad61f.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">![](images/multiple-pages.svg)</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_ed5ab808068ad61f.html
+++ b/public/events/distill_ed5ab808068ad61f.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_f2c26f7be5a4bf71.html
+++ b/public/events/distill_f2c26f7be5a4bf71.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -433,8 +434,21 @@
  Techniques such as DeepDream , style transfer, and feature visualization leverage this capacity as a powerful tool for exploring the inner workings of neural networks, and to fuel a small artistic movement based on neural art.</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_f2c26f7be5a4bf71.html
+++ b/public/events/distill_f2c26f7be5a4bf71.html
@@ -438,7 +438,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -453,7 +455,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -461,19 +463,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/distill_fe09c2226ea40329.html
+++ b/public/events/distill_fe09c2226ea40329.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Research publication: Growing Neural Cellular Automata</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/distill_fe09c2226ea40329.html
+++ b/public/events/distill_fe09c2226ea40329.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,19 +462,19 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+5</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/ea_funding_concentration_risk_2023.html
+++ b/public/events/ea_funding_concentration_risk_2023.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Major EA funders projected to spend less on AI safety in 2023 compared to 2022, revealing dangerous funding concentration</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/ea_funding_concentration_risk_2023.html
+++ b/public/events/ea_funding_concentration_risk_2023.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/eu_ai_act_watering_down_2024.html
+++ b/public/events/eu_ai_act_watering_down_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Industry lobbying successfully weakens key provisions of EU AI Act during implementation phase</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/eu_ai_act_watering_down_2024.html
+++ b/public/events/eu_ai_act_watering_down_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Cash</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/ftx_future_fund_collapse_2022.html
+++ b/public/events/ftx_future_fund_collapse_2022.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,43 +462,43 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-80</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+50</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Burnout Risk</td>
-					<td class="impact-positive">+40</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/ftx_future_fund_collapse_2022.html
+++ b/public/events/ftx_future_fund_collapse_2022.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">$32M+ in AI safety grants vanished overnight when FTX went bankrupt, researchers forced to return money or drop programs</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/gartner_synthetic_data_prediction_2024.html
+++ b/public/events/gartner_synthetic_data_prediction_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Gartner predicts 80% of AI training data will be synthetic by 2028, up from 20% in 2024, removing human data constraints on capability growth</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/gartner_synthetic_data_prediction_2024.html
+++ b/public/events/gartner_synthetic_data_prediction_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/google_project_maven_2018.html
+++ b/public/events/google_project_maven_2018.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Thousands of Google employees signed petition against AI drone warfare project, dozens quit, Google dropped contract</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/google_project_maven_2018.html
+++ b/public/events/google_project_maven_2018.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-negative">-5</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/grant_application_backlog_2024.html
+++ b/public/events/grant_application_backlog_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Burnout Risk</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/grant_application_backlog_2024.html
+++ b/public/events/grant_application_backlog_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Nonlinear Network and Lightspeed Grants received 500-600 applications for relatively small funding pools, showing demand-supply mismatch</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/international_coordination_breakdown_2025.html
+++ b/public/events/international_coordination_breakdown_2025.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/international_coordination_breakdown_2025.html
+++ b/public/events/international_coordination_breakdown_2025.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">US and UK refuse to sign international AI declaration at Paris Summit, signaling end of coordinated safety approach</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/ltff_funding_gap_2023.html
+++ b/public/events/ltff_funding_gap_2023.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-45</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/ltff_funding_gap_2023.html
+++ b/public/events/ltff_funding_gap_2023.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Long-Term Future Fund reports $450k/month funding gap after relationship changes with Open Philanthropy</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/metr_deceptive_ai_evaluation_2024.html
+++ b/public/events/metr_deceptive_ai_evaluation_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Controlled study showing advanced AI system engaging in deceptive behavior when pursuing objectives, including attempting to copy itself</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/metr_deceptive_ai_evaluation_2024.html
+++ b/public/events/metr_deceptive_ai_evaluation_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/microsoft_tay_2016.html
+++ b/public/events/microsoft_tay_2016.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Media Reputation</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+10</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/microsoft_tay_2016.html
+++ b/public/events/microsoft_tay_2016.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Microsoft's AI chatbot learned to post offensive content within 24 hours from Twitter interactions</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/openai_board_crisis_2023.html
+++ b/public/events/openai_board_crisis_2023.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+40</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Media Reputation</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Burnout Risk</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/openai_board_crisis_2023.html
+++ b/public/events/openai_board_crisis_2023.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Sam Altman fired by OpenAI board on Nov 17 for being 'not consistently candid', reinstated 5 days later after employee revolt and Microsoft pressure</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/openai_safety_team_departures_2024.html
+++ b/public/events/openai_safety_team_departures_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Mass resignations from OpenAI's safety team over concerns about rapid capability advancement without adequate safety measures</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/openai_safety_team_departures_2024.html
+++ b/public/events/openai_safety_team_departures_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Burnout Risk</td>
-					<td class="impact-positive">+35</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/safety_researcher_brain_drain_2024.html
+++ b/public/events/safety_researcher_brain_drain_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">High-profile safety researchers leave academia and safety orgs for high-paying roles at capabilities companies</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/safety_researcher_brain_drain_2024.html
+++ b/public/events/safety_researcher_brain_drain_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-30</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/synthetic_data_scaling_2024.html
+++ b/public/events/synthetic_data_scaling_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Research</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Papers</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Technical Debt</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/synthetic_data_scaling_2024.html
+++ b/public/events/synthetic_data_scaling_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Microsoft's Phi-4 and other models trained primarily on synthetic data outperform traditionally trained models, eliminating data scarcity as AI capability bottleneck</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/tesla_autopilot_incidents_2016_2024.html
+++ b/public/events/tesla_autopilot_incidents_2016_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">AIAAIC documented 20+ Tesla autonomous driving system failures leading to fatal accidents</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/tesla_autopilot_incidents_2016_2024.html
+++ b/public/events/tesla_autopilot_incidents_2016_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,37 +462,37 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-35</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+30</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Media Reputation</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Stress</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/uk_ai_safety_to_security_2025.html
+++ b/public/events/uk_ai_safety_to_security_2025.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">UK government rebrands AI Safety Institute as 'AI Security Institute', shifting from ethical AI concerns to cyber threat focus</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/uk_ai_safety_to_security_2025.html
+++ b/public/events/uk_ai_safety_to_security_2025.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/us_aisi_to_caisi_2025.html
+++ b/public/events/us_aisi_to_caisi_2025.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">Trump administration renames US AI Safety Institute to focus on 'pro-growth AI policies' over safety, scraps Paris Summit attendance</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/events/us_aisi_to_caisi_2025.html
+++ b/public/events/us_aisi_to_caisi_2025.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,31 +462,31 @@
 					
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-25</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-20</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Ethics Risk</td>
-					<td class="impact-positive">+25</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Cash</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+20</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/venture_capital_ai_safety_drought_2024.html
+++ b/public/events/venture_capital_ai_safety_drought_2024.html
@@ -437,7 +437,9 @@
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -452,7 +454,7 @@
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>
@@ -460,25 +462,25 @@
 					
 				<tr>
 					<td>Cash</td>
-					<td class="impact-negative">-35</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Research</td>
-					<td class="impact-negative">-15</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Reputation</td>
-					<td class="impact-negative">-10</td>
+					<td class="impact-negative">proposed: down</td>
 					<td>Always</td>
 				</tr>
 		
 				<tr>
 					<td>Vibey Doom</td>
-					<td class="impact-positive">+15</td>
+					<td class="impact-positive">proposed: up</td>
 					<td>Always</td>
 				</tr>
 		

--- a/public/events/venture_capital_ai_safety_drought_2024.html
+++ b/public/events/venture_capital_ai_safety_drought_2024.html
@@ -32,6 +32,7 @@
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -432,8 +433,21 @@
 			<p class="description">VC funding flows heavily to AI capabilities companies while AI safety startups struggle to raise funds</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>

--- a/public/index.html
+++ b/public/index.html
@@ -872,7 +872,7 @@ t	.hero {
 			<p class="subtitle">Practice saving the world from deadly AI through bureaucracy</p>
 			<p style="margin-bottom: 0.3rem; color: var(--text-secondary); font-size: 0.95rem;">
 				<span class="status-indicator status-active"></span>
-				Free & Open Source
+				Free &middot; Source available
 			</p>
 
 			<!-- Download Options - Platform-Specific CTAs -->
@@ -943,7 +943,7 @@ t	.hero {
 			-->
 
 			<p style="font-size: 0.85rem; color: var(--text-muted); text-align: center;">
-				Windows, macOS & Linux · Free & Open Source
+				Windows, macOS & Linux · Free &middot; Source available
 			</p>
 		</section>
 
@@ -1222,8 +1222,8 @@ t	.hero {
 				</details>
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
-					<summary style="font-weight: bold; color: var(--accent-primary); cursor: pointer; margin-bottom: 0.8rem;">Is it free and open source?</summary>
-					<p style="color: var(--text-secondary); font-size: 0.95rem;">Yes! Completely free on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a>. Windows, macOS and Linux are all available &mdash; Windows is the tested one; Mac and Linux are experimental, so tell me what breaks. Steam later, maybe &mdash; no date promised.</p>
+					<summary style="font-weight: bold; color: var(--accent-primary); cursor: pointer; margin-bottom: 0.8rem;">Is it free? Is it open source?</summary>
+					<p style="color: var(--text-secondary); font-size: 0.95rem;">Free: yes, completely, and that is not going to change during alpha. Open source: <strong>not yet, and it would be wrong to say otherwise</strong>. The source is public on <a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-primary);">GitHub</a> and you are welcome to read it, evaluate it and contribute to it &mdash; but the current interim licence does not grant redistribution, and the art and game content are expected to stay all-rights-reserved. A proper open-source licence for the <em>engine</em> is planned around the 1.0 release. Windows, macOS and Linux are all available &mdash; Windows is the tested one; Mac and Linux are experimental, so tell me what breaks.</p>
 				</details>
 
 				<details class="faq-item" style="background: var(--bg-tertiary); padding: 1.2rem; border-radius: var(--radius-md); border: 1px solid var(--border-color);">
@@ -1331,7 +1331,7 @@ t	.hero {
 		<div class="footer-bottom">
 			<p>&copy; 2026 p(Doom)1 by <a href="https://github.com/PipFoweraker" target="_blank" rel="noopener" style="color: var(--accent-primary); text-decoration: none; font-weight: bold;">Pip Foweraker</a></p>
 			<p class="footer-meta" style="margin-top: 0.5rem;">
-				Privacy: No personal data collected | Open Source |
+				Privacy: No personal data collected | Source available |
 				Inspired by AI Safety research from <a href="https://stampy.ai" target="_blank" rel="noopener" style="color: var(--accent-primary);">Stampy.ai</a> and others
 			</p>
 		</div>

--- a/scripts/sync/sync-events.py
+++ b/scripts/sync/sync-events.py
@@ -353,16 +353,35 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
     rarity = rarity_emoji.get(event['rarity'], event['rarity'])
 
     # Generate impacts table
+    # VARIANT B, ruled by Pip 2026-07-31 after an A/B: show the DIRECTION, never the
+    # magnitude.
+    #
+    # Why the number goes and the row stays. Of 1,194 events the calculated effects reach
+    # gameplay in one branch -- 7 events. The other 1,174 are flavour, and flavour is
+    # hidden by default. So a precise figure like "-80" was presented on ~2,190 pages for
+    # events that move nothing. Direction is the part that is probably right; magnitude is
+    # the part that is definitely unverified, and precision reads as authority regardless
+    # of the caveat above it. A stamp over a number still shows the number, and the number
+    # was the false part.
+    #
+    # The magnitudes are NOT deleted -- they live in the corpus, and the suggestion links
+    # at the foot of every page go straight there. Nothing is hidden; it is just no longer
+    # asserted here.
+    #
+    # Precedent from the game's own repo (events.gd:290): displayed doom numbers were
+    # removed there for the same reason -- clobbered at resolve, so "every (+/-N doom)
+    # message in event content was a silent lie".
     impacts_html = ""
     for impact in event['impacts']:
-        sign = '+' if impact['change'] > 0 else ''
-        color_class = 'positive' if impact['change'] > 0 else 'negative'
+        change = impact['change']
+        direction = 'up' if change > 0 else ('down' if change < 0 else 'unchanged')
+        color_class = 'positive' if change > 0 else 'negative'
         condition_text = f" (if {impact['condition']})" if impact.get('condition') else ""
 
         impacts_html += f"""
 				<tr>
 					<td>{impact['variable'].replace('_', ' ').title()}</td>
-					<td class="impact-{color_class}">{sign}{impact['change']}</td>
+					<td class="impact-{color_class}">proposed: {direction}</td>
 					<td>{condition_text or 'Always'}</td>
 				</tr>
 		"""
@@ -882,7 +901,9 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 			<h2>📊 Game Impacts</h2>
 			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
 			<p class="stamp-body">
-				These values come from the event corpus in
+				Which variables this event was <em>proposed</em> to move, and in which
+				direction. The magnitudes are held in the corpus but are not shown here,
+				because they have not been verified against the shipped game. They come from
 				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
 				They describe what an event was <em>proposed</em> to do, not what the
 				shipped game does with it. <strong>Most events in the corpus are flavour:
@@ -897,7 +918,7 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 				<thead>
 					<tr>
 						<th>Variable</th>
-						<th>Change</th>
+						<th>Direction</th>
 						<th>Condition</th>
 					</tr>
 				</thead>

--- a/scripts/sync/sync-events.py
+++ b/scripts/sync/sync-events.py
@@ -477,6 +477,7 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
 
 	<link rel="stylesheet" href="/css/site.css">
+	<link rel="stylesheet" href="/css/stamp.css">
 	<style>
 		:root {{
 			/* Palette derived from the game's shipped art: amber-dominant CRT chrome
@@ -877,8 +878,21 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 			<p class="description">{event['description']}</p>
 		</div>
 
-		<div class="section">
+		<div class="section stamp-block">
 			<h2>📊 Game Impacts</h2>
+			<span class="stamp stamp--restricted stamp--sm">Not verified in game</span>
+			<p class="stamp-body">
+				These values come from the event corpus in
+				<a href="https://github.com/PipFoweraker/pdoom-data" target="_blank" rel="noopener">pdoom-data</a>.
+				They describe what an event was <em>proposed</em> to do, not what the
+				shipped game does with it. <strong>Most events in the corpus are flavour:
+				they are shown for colour and do not move any game variable.</strong> Only a
+				small minority reach the systems below, and several of the variables listed
+				here are not read by the game at all yet.
+				Treat this table as a design proposal under review, not as a measurement of
+				play. Corrections and arguments are welcome &mdash; the suggestion links at
+				the foot of this page go straight to the data repo.
+			</p>
 			<table class="impacts-table">
 				<thead>
 					<tr>


### PR DESCRIPTION
Pip ruled **variant B** on 2026-07-31 after an A/B comparison.

## Two changes, one f-string each, 1,194 pages

1. The **Game Impacts** block carries a `stamp--restricted` — *"Not verified in game"* — and a plain-English note.
2. The **Change** column becomes **Direction**: `proposed: down` rather than `-80`.

## Why the magnitude goes and the row stays

Of **1,194** events, the calculated effects reach gameplay in one branch — **7 events**. The other **1,174 are flavour**, and flavour is **hidden by default** (`_feed_important_only`). So a precise figure was being presented, on ~2,190 pages, for events that move nothing.

Direction is the part that is probably right. Magnitude is the part that is definitely unverified — and precision reads as authority regardless of the caveat above it. **A stamp over a number still shows the number, and the number was the false part.**

The magnitudes are **not deleted**. They live in the corpus, and the per-page suggestion links go straight there. Nothing is hidden; it is simply no longer asserted by us.

## Precedent, from the game's own repo

`godot/scripts/core/events.gd:290` — displayed doom numbers were removed there for exactly this reason:

> a literal "doom" effect must NEVER reach `Resources.add`'s `state.doom += v` sink — that write is CLOBBERED at resolve … so every "(+/-N doom)" message in event content **was a silent lie**.

And pdoom-data's own contract brief, line 33: *"Nothing in the candidate feed has been human-reviewed. **Do not ship it to players yet.**"*

## Known gap — deliberately not fixed here, needs a decision

**1,000 `alignmentforum_*` pages still show the old numeric impacts and carry no stamp.** They are generated from a **separate** pdoom-data collection — `timeline_events/alignment_research/` — that `sync-events.py` has **never read**. This is the Chesterton's fence CLAUDE.md warns about: they look orphaned and are in fact the only published surface for a live dataset.

So this change covers **1,194 of 2,194** event pages. The other 1,000 are now the *only* pages on the site still making the claim we just ruled against.

**What I found while checking:** the collection exists locally with a **matching schema** — 1,000 records carrying the same `impacts`, `pdoom_impact`, `rarity`, `sources` fields. So extending the sync to read it is **cheaper than TECH_DEBT E-0 assumes**.

**Why I did not just do it:** regenerating 1,000 pages from a source that has been unread for months could shift far more than the impacts block — titles, descriptions, categories, sources. That is a content change of unknown size on a tenth of the site, made while nobody is looking at it. It wants a decision and a diff review, not a unilateral regenerate.

Three options, roughly ascending in cost:

1. **Leave them**, and accept that a tenth of the event pages disagree with the other nine tenths until the sync is extended.
2. **Post-process just the impacts block** on the existing 1,000 files — makes the site consistent today, but hand-editing generated files creates exactly the un-regenerable artefact that produced this problem.
3. **Extend `sync-events.py` to read the second collection** — the real fix, closes TECH_DEBT E-0, and needs a review of what actually changes on those 1,000 pages.

My recommendation is **3**, not today.
