### PR TITLE
fix(data): the homepage has been advertising v0.11.0 since 2026-07-17

### DIFF
--- a/.github/workflows/auto-update-data.yml
+++ b/.github/workflows/auto-update-data.yml
@@ -68,6 +68,14 @@ jobs:
           fi
 
           git add public/data/version.json
+          # status.json is REWRITTEN by update-version-info.py's sync_status_json(), and
+          # was never staged -- so every run recomputed it and every run threw the result
+          # away. It froze on 2026-07-17 and the live site told visitors the latest
+          # release was v0.11.0 (2025-12-07) while version.json said v0.13.1. The
+          # homepage renders BOTH, so a reader saw two answers eight months apart.
+          # The script already refuses to write a fallback over it; the missing line was
+          # only ever this one.
+          git add public/data/status.json || true
           git add public/data/health-check.json || true
           git add public/monitoring/data/ || true
 

--- a/public/data/status.json
+++ b/public/data/status.json
@@ -9,17 +9,17 @@
     "status": "stable",
     "repository": "https://github.com/PipFoweraker/pdoom1",
     "latestRelease": {
-      "version": "v0.11.0",
-      "date": "2025-12-07",
+      "version": "v0.13.1",
+      "date": "2026-07-26",
       "downloadUrl": "https://github.com/PipFoweraker/pdoom1/releases/latest",
       "changelog": "See CHANGELOG.md for details"
     },
     "development": {
       "phase": "Ongoing feature development",
-      "progress": "v0.11.0 released",
+      "progress": "v0.13.1 released",
       "nextMilestone": "Steam release preparation"
     },
-    "lastUpdated": "2026-07-17T06:47:10.682842"
+    "lastUpdated": "2026-07-31T14:49:27.290341"
   },
   "api": {
     "bugReporting": "https://pdoom1-website-app.netlify.app/.netlify/functions/report-bug",


### PR DESCRIPTION
**Live bug, confirmed against production**, found by the issue triage:

```
curl https://pdoom1.com/data/status.json
  latestRelease: v0.11.0 | 2025-12-07
  progress:      "v0.11.0 released"
  nextMilestone: "Steam release preparation"
```

…while `version.json` says **v0.13.1**. `public/index.html` renders **both** — version.json in the download area, status.json in the About section — so **a visitor sees two answers eight months apart on one screen.** Two hours before the league is announced.

## Root cause: one missing line

`update-version-info.py::sync_status_json()` rewrites `status.json` on every run. `auto-update-data.yml` staged `version.json`, `health-check.json` and `monitoring/data/` — **but never `status.json`**. So every 6-hourly run recomputed it and threw the result away. Frozen since **2026-07-17**.

Safe to stage: the script already refuses to write a fallback over this file (it requires a real `/releases/tag/` URL), so a failed lookup leaves the last good values rather than clobbering them.

## Correcting myself

Earlier today I told Pip this finding was stale and that `status.json` now read v0.13.1. **It did — in my working tree, because I had just run the script.** The committed and deployed file said v0.11.0 the whole time. I checked the wrong artifact and dismissed a real bug. This is the same class as the audit findings I've been careful to mark `[verified]` vs `[reported]` — and I failed my own rule.

This is also why #147 and #139 must stay open: this ghost is the residue they were both tracking.