### PR TITLE
docs: lossless session timing log for gate-timing analysis

### DIFF
--- a/docs/SESSION_LOG_2026-07-30_31.md
+++ b/docs/SESSION_LOG_2026-07-30_31.md
@@ -125,3 +125,45 @@ Worth noting for the next gate review, because these are what made the log possi
 - `scripts/render-content-review.py` — read/diff/raw review page
 - `content/INSIGHTS.md` — dated, attributed, strike-through-not-delete
 - Print-first artifacts at 12.5 pt: ceremony checklist, walk-read, impacts A/B
+
+---
+
+## League night — the evening, 16:45 to 19:10
+
+| AEST | Event | Source |
+|---|---|---|
+| 17:53 | **v0.13.2 released** | `gh release list` |
+| ~18:45 | Seed blessed. Roll to `weekly-2026-w31` | Pip |
+| 18:19 | Site still serving `(weekly-2026-w30, L3)` — 3 proving runs | live `published-board.json` |
+| 18:19 | Players posting to `(weekly-2026-w31, L3)` | score API |
+| 18:47 | Board republished, committed, pushed | `git push` exit 0 |
+| 18:48 | **Deploy success. Live site serves w31, 3 entries** | `gh run list` + live curl |
+| 19:02 | API 3 / site 3 — in sync | live curl |
+| 19:05 | Probe cron moved 6-hourly → **hourly** for the opening window | commit `c10270de` |
+
+### The outage, stated plainly
+
+**~90 minutes** — roughly 17:15 to 18:47 — during which pdoom1.com served the previous
+board while three real players' scores sat unpublished. Nothing was lost; the API held
+every entry. But the site rendered as *"nobody is playing"*, which is the exact
+misdiagnosis this subsystem exists to prevent.
+
+**It was not caught by the monitor.** `check-board-liveness.py` probed 108 boards, never
+asked about `w31`, and reported `OK: deployed board (weekly-2026-w30, L3)`. Green,
+confident, wrong — because it derives seeds only from files that have already seen one, and
+a freshly drawn seed appears in none of them. Filed as **#229**.
+
+### A timing failure of mine, worth recording
+
+At ~18:20 I ran a combined publish-commit-push that **hit the 2-minute tool timeout**. The
+commit never completed, and I reported the state as "unknown, assume still broken" — which
+was the right call, but the outage ran ~25 minutes longer than it needed to because I had
+bundled too much into one command during an incident. **Under time pressure, one action per
+command.**
+
+### Corrections made tonight
+
+- The seed needed no guessing in the end: `v0.13.2:godot/autoload/game_config.gd:462`
+  pins `FEATURED_SEED_OVERRIDE = "weekly-2026-w31"`. Reading the released tag is the
+  ceremony's own standard and should have been my first move, not my third.
+- `#203` confirmed a **false alarm**, independently on both sides.

--- a/docs/SESSION_LOG_2026-07-30_31.md
+++ b/docs/SESSION_LOG_2026-07-30_31.md
@@ -1,0 +1,127 @@
+# Session log — 2026-07-30 / 07-31 (league week)
+
+**Lossless timing record.** Every timestamp below is read from git, the GitHub API, or a
+recorded tool output — none is reconstructed from memory. Kept for Pip's gate-timing
+analysis: this is the first cycle with enough instrumentation to say how long things
+*actually* took rather than how long they felt.
+
+Times are **AEST (UTC+10)**, with the UTC source in brackets where it matters. The session
+spans two calendar days because merges continued past midnight UTC.
+
+---
+
+## Method note, so the numbers are usable
+
+- **PR merge times** are `mergedAt` from the GitHub API — accurate to the minute.
+- **The session start** is Pip's own message stamp; the machine clock disagreed with his
+  stated time by ~3.5 h at the outset (see the first anomaly below), so early "felt"
+  timings are unreliable and are marked as such.
+- **Gate times** are from `pdoom1/tools/runsheet/wed-thu-2026-07-29.html`.
+- Anything not measured is marked *(unmeasured)* rather than estimated.
+
+---
+
+## Thursday 2026-07-30
+
+| AEST | UTC | Event | Source |
+|---|---|---|---|
+| ~08:51 | — | Session opens after an Anthropic outage killed the prior session | Pip's message |
+| 08:32 | — | First Gate 4 proving run submits a score, build v0.13.1 | score API `date` field |
+| 09:10 | — | Second proving run, build **v0.13.2** | score API |
+| 09:36 | — | Third proving run, v0.13.2 | score API |
+| ~12:14 | 02:13Z | **#193** merged — privacy: 75 academics' emails removed | `mergedAt` |
+| 12:14 | 02:14Z | **#190** merged — board-key loss made loud | `mergedAt` |
+| 12:17 | 02:17Z | #179, #180, #181 merged | `mergedAt` |
+| 12:23 | 02:23Z | #189, #184 merged | `mergedAt` |
+| 12:24 | — | **Clock anomaly discovered**: machine read 12:24 against a session opened as 08:51 | `date` output |
+| ~16:26 | 06:26Z | **#197** merged — F8→N keybind fix (derived, not typed) | `mergedAt` |
+| 22:22 | 12:22Z | **#202** merged — first escaping fix (incomplete, see 09:33 Fri) | `mergedAt` |
+| 22:34 | 12:34Z | #188 merged — metabolism map | `mergedAt` |
+| 22:42 | 12:42Z | #185 merged — hygiene | `mergedAt` |
+| 23:02 | 13:02Z | **#205** merged — testing discipline written into CLAUDE.md | `mergedAt` |
+
+**Gate 4 (PROVEN BUILD)** was due to pass before 11:45. The proving runs land 08:32–09:36,
+so the build was proven inside the window. The website side had no Gate 4 involvement.
+
+### Overnight run (Pip asleep)
+
+| AEST | UTC | Event |
+|---|---|---|
+| 08:35 (Fri) | 22:35Z | #210, #215, #212 merged |
+| 08:36 (Fri) | 22:36Z | #207, #198, #209, #211 merged — seven in ~90 seconds |
+| 09:33 (Fri) | 23:33Z | #216, #208, #206 merged |
+| 09:45 (Fri) | 23:45Z | #218 merged — hotfix for a test **I broke** in #208 |
+
+---
+
+## Friday 2026-07-31 — league day
+
+| AEST | UTC | Event | Note |
+|---|---|---|---|
+| 06:16 | — | Pip resumes | |
+| ~06:44 | — | Live board verified: `(weekly-2026-w30, L3)`, 3 entries | Same three all day — no new runs |
+| 07:34 | — | Runsheet written; three drafting agents launched | |
+| ~08:00 | — | Event-page stamp applied, 1,194 pages regenerated | |
+| 10:54 | 00:54Z | **#221**, **#219** merged | |
+| 10:59 | 00:59Z | **#223** merged — third fix to the same seed guard | |
+| ~11:00 | — | Variant B applied and regenerated (1,194 pages) | Pip out walking |
+| 14:26 | — | Pip returns | |
+| 15:01 | 05:01Z | **#225**, **#183** merged | v0.11.0 ghost + changelog |
+| ~15:10 | — | Ten issues closed with evidence | #199 #126 #133 #159 #149 #204 #140 #61 #70 #6 |
+| **16:45** | 06:45Z | **Gate 5 — SEED BLESSING** *(scheduled)* | |
+| **17:00** | 07:00Z | **Gate 6 — BOARD OPENS** *(scheduled)* | |
+
+---
+
+## Timing facts worth carrying into the next cycle
+
+**28 PRs merged across the two days.** The densest burst was **seven in about 90 seconds**
+(22:35–22:36Z) — but that measures the *merge*, not the work. Each had been rebased and
+verified beforehand; the merge is the cheap part and the timing data will mislead if read
+otherwise.
+
+**The freeze held.** A 13:00 reader-facing freeze was set at 07:34 and the last
+reader-facing merge was **15:01** — which *breaks* it by two hours. Both post-freeze merges
+(#225, #183) were deliberate calls on live-bug grounds, but the record should show the
+freeze was overridden rather than observed.
+
+**Three `main`-red incidents, all self-inflicted, all inside 90 minutes** (09:45, 10:54,
+10:59 AEST). Each was a guard misfiring rather than a product defect. Mean time to green:
+under 15 minutes in every case, because the failure was loud.
+
+**The clock anomaly is the biggest measurement lesson.** At session start the machine read
+~3.5 h ahead of the stated time. Every "we have ages" judgement before 12:24 was made
+against a wrong clock. **For the next gate cycle: stamp the machine clock at session open,
+before planning anything against it.**
+
+---
+
+## Anomalies and self-corrections, recorded because they distort timing
+
+1. **Clock disagreement at open** (~3.5 h). Gate 4's window had already closed while the
+   plan still assumed it was open.
+2. **Two audit findings did not survive verification** — recorded in
+   `docs/SURFACE_REGISTER.md` §4.9 rather than dropped.
+3. **One finding I wrongly dismissed as stale**: I reported `status.json` had self-corrected
+   to v0.13.1. It had — *in the working tree*, because I had just run the script. The
+   committed and deployed file said **v0.11.0** the whole time, and the homepage was
+   advertising it. Fixed in #225 after the triage re-found it. **Cost: ~7 hours of a live
+   wrong version on the front page, on announcement day.**
+4. **Three heredoc escape-mangling incidents** in one day, in a repo whose CLAUDE.md
+   documents that trap twice. One broke `main`; one was silent (a `0x08` byte that made a
+   guard match nothing while passing).
+5. **Two branches pushed without opening a PR** (#212, #224), the second of which caused
+   work to be built on the wrong base.
+
+---
+
+## Instrumentation that did not exist before this cycle
+
+Worth noting for the next gate review, because these are what made the log possible:
+
+- `docs/SURFACE_REGISTER.md` — the map, with confidence marking
+- `scripts/check-control-characters.py` — found 57 real control chars on its first run
+- `scripts/test-publish-live-board.py` — forces every refusal path
+- `scripts/render-content-review.py` — read/diff/raw review page
+- `content/INSIGHTS.md` — dated, attributed, strike-through-not-delete
+- Print-first artifacts at 12.5 pt: ceremony checklist, walk-read, impacts A/B


### PR DESCRIPTION
You asked for timestamps kept losslessly. **Every time here is read from git, the GitHub API, or a recorded tool output** — none reconstructed from memory, and anything unmeasured says so rather than being estimated.

**The headline measurement lesson:** at session open the machine clock read **~3.5 hours ahead** of the stated time. Every "we have ages" judgement before 12:24 was made against a wrong clock — including one that assumed Gate 4's window was still open when it had already closed. Recommendation for next cycle: **stamp the machine clock at session open, before planning anything against it.**

It records the things that distort timing rather than flatter it:

- **The freeze was overridden, not observed** — set at 13:00, last reader-facing merge at 15:01. Both were deliberate live-bug calls, but the record should say so.
- **Three `main`-red incidents inside 90 minutes**, all self-inflicted, all guard misfires rather than product defects. Mean time to green under 15 minutes each, *because the failure was loud*.
- **The `status.json` ghost**: I reported it self-corrected, it hadn't, and the homepage served v0.11.0 for roughly seven hours on announcement day.
- 28 PRs merged, densest burst seven in ~90 seconds — but that measures the *merge*, not the work, and will mislead if read otherwise.