### PR TITLE
ops: kill three manufactured reds

### DIFF
--- a/.github/workflows/board-liveness.yml
+++ b/.github/workflows/board-liveness.yml
@@ -63,7 +63,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       verdict: ${{ steps.probe.outputs.verdict }}
-      orphaned: ${{ steps.probe.outputs.orphaned }}
+      # The probe step writes `new_orphans` and `archived` (see the GITHUB_OUTPUT lines
+      # below). This previously mapped `steps.probe.outputs.orphaned`, which is never
+      # written -- and the alert then read `needs.probe.outputs.new_orphans`, which did
+      # not exist either. Both ends wrong, so every alert rendered "**? score entries**"
+      # and every follow-up comment said "(? orphaned entries)". An alarm that cannot
+      # state its own magnitude is barely an alarm.
+      new_orphans: ${{ steps.probe.outputs.new_orphans }}
+      archived: ${{ steps.probe.outputs.archived }}
     steps:
       - uses: actions/checkout@v4
 
@@ -245,3 +252,70 @@ jobs:
                 title, body, labels: [label, 'automation', 'priority:high'],
               });
             }
+
+  # ---------------------------------------------------------------------------------
+  # CLOSE THE ROLLING ISSUE WHEN THE CONDITION CLEARS.
+  #
+  # This did not exist, and its absence is why #149, #204 and #230 all sat open
+  # describing conditions that had already resolved. The alert opened an issue or
+  # commented "Still true" on it, and NOTHING ever closed it -- so an alarm that was
+  # correct once stayed lit forever, and reading it told you nothing about now.
+  #
+  # That is exactly the failure Pip named this week: he had trained himself to ignore
+  # red because the redness never forced him to slow down. A rolling alert with no
+  # close path manufactures precisely that.
+  #
+  # De-dupes the same way the alert does (open + label + exact title), so the two
+  # halves cannot disagree about which issue they are managing.
+  # ---------------------------------------------------------------------------------
+  resolve:
+    name: Close the rolling issue when the board is clean
+    needs: probe
+    if: needs.probe.outputs.verdict == 'live' || needs.probe.outputs.verdict == 'genuinely-empty'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          VERDICT: ${{ needs.probe.outputs.verdict }}
+          ARCHIVED: ${{ needs.probe.outputs.archived }}
+        with:
+          script: |
+            const label = 'board-liveness';
+            const title = 'NEW scores are landing on a board nobody can see';
+            const runUrl = process.env.GITHUB_SERVER_URL + '/' + process.env.GITHUB_REPOSITORY +
+                           '/actions/runs/' + process.env.GITHUB_RUN_ID;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 10,
+            });
+            const found = existing.data.find(i => i.title === title);
+            if (!found) { core.info('No open rolling issue to close.'); return; }
+
+            const lines = [
+              '**Resolved automatically** -- verdict is `' + process.env.VERDICT + '` as of ' +
+                new Date().toUTCString() + '.',
+              '',
+              'Every populated board outside the anomaly archive is one this site publishes.',
+              'The archive still holds ' + process.env.ARCHIVED + ' acknowledged entries; those',
+              'are known history, are never failed on, and are not what this issue tracked.',
+              '',
+              'Run: ' + runUrl,
+              '',
+              '_Closed by the same workflow that opened it. If the condition recurs a FRESH',
+              'issue is filed rather than this one reopened -- so an open issue here always',
+              'describes a live condition, never a historical one._',
+            ];
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: found.number, body: lines.join('\n'),
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: found.number, state: 'closed', state_reason: 'completed',
+            });
+            core.info('Closed #' + found.number + '.');

--- a/.github/workflows/post-issue-to-forum.yml.disabled
+++ b/.github/workflows/post-issue-to-forum.yml.disabled
@@ -1,3 +1,31 @@
+# ============================================================================
+# DISABLED 2026-08-01 by renaming to .yml.disabled, so GitHub stops registering
+# it as a workflow.
+#
+# WHY: GitHub rejected this file at workflow-CREATION time -- it displayed the
+# path instead of the `name:` field, produced a run with ZERO jobs, and reported
+# "This run likely failed because of a workflow file issue" on EVERY push to
+# EVERY branch. It was the single largest manufactured-red source in the repo,
+# and a permanently red check is how a team learns to ignore red.
+#
+# WHAT I COULD NOT DO: pin the exact schema violation. The YAML parses cleanly,
+# every step has a valid shape, and GitHub's API gives no detail beyond
+# "workflow file issue". One clue is recorded in case someone picks this up: the
+# failing runs report "Triggered via push" although the only declared trigger is
+# workflow_dispatch -- so GitHub is not reading the `on:` block. Running
+# `actionlint` against this file is the obvious next step and I did not have it.
+#
+# WHY RENAMED RATHER THAN DELETED: the header below is genuinely valuable -- it
+# records why the issues trigger was removed, that NodeBB is live on a host with
+# no DNS record and no TLS, that the API secrets are unset, and that restoring
+# the trigger without fixing permissions would be WORSE than the current state
+# because it would succeed at stamping a scary automated banner onto every issue.
+# That knowledge should survive; the red X should not.
+#
+# TO RESTORE: fix the schema issue, rename back to .yml, and satisfy the two
+# preconditions in the original header first.
+# ============================================================================
+
 name: Post GitHub Issue to Forum
 
 # ISSUES TRIGGER REMOVED 2026-07-22. This fired on EVERY issue opened, hung for


### PR DESCRIPTION
Everything here removes a signal that was firing without information. **None of it changes what the site does.**

### 1. `post-issue-to-forum.yml` → `.yml.disabled`

GitHub rejected this at workflow-**creation** time — it displayed the file *path* instead of the `name:` field, produced runs with **zero jobs**, and reported *"workflow file issue"* on **every push to every branch**. The single largest manufactured-red source in the repo.

**I could not pin the exact schema violation, and the file says so.** The YAML parses, every step has a valid shape, and GitHub's API gives no detail. One clue recorded: the failing runs say *"Triggered via push"* although the only declared trigger is `workflow_dispatch` — so GitHub isn't reading the `on:` block. `actionlint` is the obvious next step.

**Renamed, not deleted**, because the header is valuable: it records why the issues trigger was pulled, that NodeBB is live on a host with no DNS and no TLS, that the secrets are unset, and that restoring the trigger without fixing permissions would be *worse* than today — it would succeed at stamping a scary banner onto every issue.

### 2. The alert could never state its own magnitude

The probe step writes `new_orphans`; the job declared `orphaned: ${{ steps.probe.outputs.orphaned }}` — **never written**; the alert then read `needs.probe.outputs.new_orphans` — **doesn't exist**. Both ends wrong, so every alert rendered **"? score entries"**. That's why #230 woke Pip up unable to tell him it was 3.

### 3. Rolling issues now close when the condition clears

There was **no close path**. That's why #149, #204 and #230 all sat open describing conditions that had already resolved — the workflow could open and comment *"Still true"*, and nothing ever closed it. An alarm correct once stayed lit forever.

On recurrence it files a **fresh** issue rather than reopening, so **an open issue here always describes a live condition, never a historical one.**

Verified: YAML parses, three jobs, outputs wired, embedded script passes `node --check`.