### PR TITLE
test: cover the three highest-blast-radius untested generators

### DIFF
--- a/.github/workflows/content-honesty.yml
+++ b/.github/workflows/content-honesty.yml
@@ -42,6 +42,13 @@ on:
       - 'scripts/test-platform-claims.py'
       - 'scripts/check-published-emails.py'
       - 'scripts/check-stale-facts.py'
+      # The three committing generators and the tests that force their refusals.
+      - 'scripts/sync/sync-events.py'
+      - 'scripts/test-sync-events.py'
+      - 'scripts/update-version-info.py'
+      - 'scripts/test-update-version-info.py'
+      - 'scripts/health-check.py'
+      - 'scripts/test-health-check.py'
       - 'scripts/snapshot-copy.py'
       - 'scripts/snapshot-plausible.py'
       - 'scripts/test-snapshot-plausible.py'
@@ -76,6 +83,13 @@ on:
       - 'scripts/test-platform-claims.py'
       - 'scripts/check-published-emails.py'
       - 'scripts/check-stale-facts.py'
+      # The three committing generators and the tests that force their refusals.
+      - 'scripts/sync/sync-events.py'
+      - 'scripts/test-sync-events.py'
+      - 'scripts/update-version-info.py'
+      - 'scripts/test-update-version-info.py'
+      - 'scripts/health-check.py'
+      - 'scripts/test-health-check.py'
       - 'scripts/snapshot-copy.py'
       - 'scripts/snapshot-plausible.py'
       - 'scripts/test-snapshot-plausible.py'
@@ -138,6 +152,21 @@ jobs:
       # Third parties' addresses scraped out of paper PDFs must never be served.
       - name: No third party's email address is published
         run: python scripts/check-published-emails.py
+
+      # The three generators that publish reader-facing data on committing crons.
+      # check-published-emails.py above walks what is ALREADY COMMITTED, so it can only
+      # report a leak that has already shipped; these force the failure at the generator,
+      # which is the only place it can still be prevented. All stdlib, all offline --
+      # each stubs its inputs in a temp dir and asserts the refusal, so none of them
+      # needs network, a pdoom1 checkout, or the `requests` this job does not install.
+      - name: sync-events redacts PII and no event text can reshape a page
+        run: python scripts/test-sync-events.py
+
+      - name: update-version-info refuses to guess, and derives platforms from assets
+        run: python scripts/test-update-version-info.py
+
+      - name: health-check publishes no absolute path
+        run: python scripts/test-health-check.py
 
       # --ci, not --check: drift and freshness are only fixable by re-running the sync
       # against a local pdoom1 checkout, which no runner has, so they print as WARN.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,22 @@ Pip's stated top priority. Practically:
   so a new upstream field cannot leak). `scripts/check-published-emails.py`
   re-verifies and imports the generator's one regex rather than copying it.
   The addresses are still in pdoom-data — scrubbing here does not fix the source.
+  - **`check-published-emails.py` checks the OUTPUT, not the generator.** It walks
+    what is already committed under `public/`, so it can only tell you a leak has
+    already shipped. `redact_pii()` is the thing that stops one. That is why
+    `scripts/test-sync-events.py` forces the leak rather than watching the guard
+    pass. (An earlier draft of this bullet said the guard "is run by no workflow,
+    verified 2026-08-01" — that was true when written and is now false:
+    `content-honesty.yml:121` runs it as a BLOCKING step. Grep before believing
+    a CI claim here, in either direction.)
+- **The event page template escapes nothing by itself** — it is one 500-line
+  f-string, so the data decides where the markup ends, and arXiv descriptions are
+  raw PDF text uploaded by anyone. `escape_event_for_html()` walks the whole
+  record (same shape as `redact_pii()`) and runs once at the top of
+  `generate_event_detail_page()`. `esc()` escapes `& < > "` but **not** the
+  apostrophe, because every attribute in the template is double-quoted — a rule
+  `test-sync-events.py` asserts, so writing `style='…'` in the template fails the
+  test rather than silently reopening the hole.
 - **Events were not the only mirror.** `public/data/issues-cache.json` is a verbatim
   copy of pdoom1's issue bodies, rendered by `/issues/`, and it was written raw. On
   2026-08-02 a `Co-Authored-By` trailer inside an issue body put a live address on the
@@ -320,6 +336,10 @@ node    scripts/test-blog-render.js       # blog markdown subset               [
 
 python  scripts/check-deploy-excludes.py  # nothing deployed points at an excluded file [content-honesty]
 python  scripts/make-og-card.py --check   # share card is 1200x630 and under budget [content-honesty]
+
+python  scripts/test-sync-events.py         # PII redaction; no event text reshapes a page [content-honesty]
+python  scripts/test-update-version-info.py # refuses to guess a version; platforms derived [content-honesty]
+python  scripts/test-health-check.py        # no absolute path reaches published JSON [content-honesty]
 ```
 
 **Severity model — the rule that decides where a check goes.** A check is
@@ -350,6 +370,17 @@ concrete reasons, not because they are unimportant:
   `--ci` runs all three and lets only no-hardcoding set the exit code, printing
   the other two as `WARN`. Same reasoning applies to anything else needing
   `$PDOOM1_REPO`.
+
+**Naming a script in a test file is not coverage.** `test-orchestrator.py` and
+`test-integration.py` between them "cover" `update-version-info.py`,
+`calculate-game-stats.py`, `health-check.py`, `verify-deployment.py` and
+`export-leaderboard-bridge.py` — by shelling out to each one against the LIVE
+GitHub API, writing into the real `public/` tree, and checking only the exit
+code. Neither asserts anything about the output; a run that fetched garbage and
+published it passes both. `test-changelog-structure.py` likewise asserts that
+four committed files exist, which says nothing about the generator that wrote
+them. Neither file is run by any workflow. When auditing coverage, grep for the
+script name *and then read what the match does*.
 
 ## Testing discipline
 Every line below was earned by something that actually went wrong here, mostly on
@@ -476,7 +507,22 @@ platform that has no build.
   and JS strings, and prints `SKIP` (not silence) in the disarmed no-`platforms` state.
   It also asserts every path in the live `REACHABLE` list still exists — a renamed page
   would otherwise drop out of coverage silently. Run it BEFORE the guard, not after.
-
+- **`platforms` is derived by pattern-matching asset FILENAMES, which is fragile.**
+  Two false positives were live until 2026-08-01: `.AppImage` contains `.app`, so a
+  Linux-only release published `macos: true`; and `x86_64` is an architecture, so
+  `PDoom-<version>-macos-x86_64.dmg` published `linux: true`. Both handed
+  `check-platform-claims.py` — the guard whose entire job is to stop a false platform
+  claim — a false positive. The rule now is that an explicit OS name in a filename
+  always beats an architecture hint, and `scripts/test-update-version-info.py` pins it
+  with a table of real asset-name shapes.
+- **`update-version-info.py` used to re-publish invented `game_stats`** —
+  `baseline_doom_percent: 23`, `frontier_labs_count: 7`,
+  `strategic_possibilities: 10000` — on every run, overwriting the honest `null` +
+  `pending` block that `calculate-game-stats.py` writes to the same file. In
+  `auto-update-data.yml` the calculator happens to run second and win; anywhere else
+  (`npm run update:version`, `weekly-deployment.yml`) the fiction won. It now carries
+  forward whatever the calculator derived and omits the key when nothing has been
+  derived. A scan in the test fails on any numeric literal re-added to that function.
 - **`version.json` has TWO writers, and one of them disarms the guard.**
   `update-version-info.py` (via `auto-update-data.yml`) writes `latest_release.platforms`.
   `update-game-data.yml` has its own inline Python that rebuilds `version.json` **from

--- a/scripts/check-stale-facts.py
+++ b/scripts/check-stale-facts.py
@@ -127,6 +127,16 @@ SKIP_FILES = {
     # exact file, for this exact reason -- and this guard did not. Worth noting as its own
     # small lesson: an exemption reasoned out in one guard does not propagate to the next.
     "issues-cache.json",
+    # Test fixtures. These files exist to feed SYNTHETIC releases (v9.9.9, v1.2.3) and
+    # historical asset-naming shapes to a generator and assert what it does with them.
+    # Every version string in them is an input, never a claim about what is current --
+    # and the rules under test are deliberately written against the value READ from the
+    # fixture, never against a literal, which is the actual protection here. Flagging
+    # them would add ~20 permanent known-noise findings to a report whose whole value
+    # is that people still read it.
+    "test-update-version-info.py",
+    "test-health-check.py",
+    "test-sync-events.py",
 }
 
 # Line-level false positives: (file substring, line substring, reason). Same contract as

--- a/scripts/health-check.py
+++ b/scripts/health-check.py
@@ -40,6 +40,19 @@ class HealthChecker:
         self.public_dir = os.path.join(self.base_dir, 'public')
         self.data_dir = os.path.join(self.public_dir, 'data')
 
+    @staticmethod
+    def last_segment(value: Any) -> str:
+        """Final path component, splitting on BOTH separators on every host.
+
+        `os.path.basename` is host-OS dependent: on POSIX it splits on '/' only, so
+        "C:\\Users\\<name>\\...\\version.json" comes back UNCHANGED. This file runs on
+        a Linux runner on a 6-hourly cron that commits its output, and the text it
+        scrubs is not all locally produced -- exception strings and committed data can
+        carry Windows paths from the maintainer's box. Using basename there published
+        the whole path while reading as if it had been redacted.
+        """
+        return re.split(r"[\\/]", str(value).rstrip("\\/"))[-1] or str(value)
+
     def rel(self, filepath: str) -> str:
         """Repo-relative form of a path, for use in any message we might publish.
 
@@ -50,10 +63,20 @@ class HealthChecker:
         call this instead.
         """
         try:
-            return os.path.relpath(os.path.abspath(filepath), self.base_dir).replace('\\', '/')
+            out = os.path.relpath(os.path.abspath(filepath), self.base_dir).replace('\\', '/')
         except (ValueError, TypeError):
             # Different drive on Windows, or a non-path string.
-            return os.path.basename(str(filepath))
+            return self.last_segment(filepath)
+        # relpath will happily CLIMB OUT of the repo rather than fail, and what it
+        # emits then is the layout above base_dir -- "../../home/runner/work/..." on a
+        # runner, "../../Users/<name>/..." on the maintainer's box. That is the exact
+        # disclosure this function exists to prevent, and it is not a Windows-only
+        # case: only Windows raises ValueError for a foreign drive, so on POSIX a
+        # "Z:\..." string climbs instead of falling back. Anything above the root
+        # degrades to its last segment.
+        if out == '..' or out.startswith('../'):
+            return self.last_segment(filepath)
+        return out
 
     # Absolute paths in free text we did not construct (subprocess output,
     # exception strings). Belt and braces alongside rel().
@@ -78,9 +101,13 @@ class HealthChecker:
 
     @classmethod
     def scrub(cls, text: str) -> str:
-        """Replace any absolute path in arbitrary text with its basename."""
-        return cls._ABS_PATH.sub(lambda m: os.path.basename(m.group(0).rstrip('\\/')),
-                                 str(text))
+        """Replace any absolute path in arbitrary text with its last segment.
+
+        The pattern deliberately matches BOTH a Windows drive path and a POSIX home
+        path regardless of which host is running, so the replacement has to be
+        host-independent too -- see last_segment().
+        """
+        return cls._ABS_PATH.sub(lambda m: cls.last_segment(m.group(0)), str(text))
 
     def log_result(self, test_name: str, passed: bool, message: str = "", is_warning: bool = False) -> None:
         """Log a test result.

--- a/scripts/health-check.py
+++ b/scripts/health-check.py
@@ -57,8 +57,24 @@ class HealthChecker:
 
     # Absolute paths in free text we did not construct (subprocess output,
     # exception strings). Belt and braces alongside rel().
+    #
+    # A directory segment MAY CONTAIN SPACES. The previous pattern used
+    # `[^\s'"]+` for the whole tail, which stops dead at the first space -- so
+    # "C:\Users\gday\Documents\A Local Code\pdoom1-website\..." matched only as far
+    # as "...\Documents\A" and the scrubbed message still read
+    # "A Local Code\pdoom1-website\public\data\version.json". That is the maintainer's
+    # directory layout, and it is literally the path CLAUDE.md quotes as the leak
+    # this guard was written for. The guard was inert against its own founding case.
+    #
+    # So: consume whole segments (spaces allowed, quotes and newlines not) as long as
+    # each is followed by a separator, then a final space-free component. The segment
+    # loop only extends across further separators, so ordinary prose after a path
+    # ("C:\a\b.json failed at line 3") is not swallowed, and a relative path
+    # ("public/data/version.json") never matches at all. {0,64} bounds the segment so
+    # a pathological string cannot make this backtrack for a long time.
     _ABS_PATH = re.compile(
-        r"([A-Za-z]:[\\/][^\s'\"]+|/(?:home|Users|root|mnt|var/folders)/[^\s'\"]+)")
+        r"([A-Za-z]:[\\/](?:[^\\/'\"\r\n]{0,64}[\\/])*[^\s'\"\\/\r\n]*"
+        r"|/(?:home|Users|root|mnt|var/folders)/(?:[^/'\"\r\n]{0,64}/)*[^\s'\"/\r\n]*)")
 
     @classmethod
     def scrub(cls, text: str) -> str:
@@ -67,7 +83,21 @@ class HealthChecker:
                                  str(text))
 
     def log_result(self, test_name: str, passed: bool, message: str = "", is_warning: bool = False) -> None:
-        """Log a test result"""
+        """Log a test result.
+
+        EVERY message is scrubbed here, at the one place they all pass through,
+        rather than at each call site. That is deliberate. rel() and scrub() were
+        added after absolute paths reached pdoom1.com, and each caller was expected
+        to remember to use them -- but four `except Exception as e:` handlers
+        interpolated the raw exception string instead (`f"Error reading {shown}:
+        {e}"`, `f"Error testing script: {e}"`, and two more), and an OSError's str()
+        embeds the absolute path it failed on. The redaction was therefore only as
+        good as the last person to remember it, in a file whose output is committed
+        by a 6-hourly cron and served publicly.
+        A chokepoint cannot be forgotten by a handler written next year.
+        """
+        message = self.scrub(message)
+        test_name = self.scrub(test_name)
         if is_warning:
             self.warnings.append(f"{test_name}: {message}")
 

--- a/scripts/sync/sync-events.py
+++ b/scripts/sync/sync-events.py
@@ -14,6 +14,7 @@ Usage:
     python scripts/sync/sync-events.py [--pdoom-data-path PATH] [--sync-icons]
 """
 
+import html
 import json
 import os
 import re
@@ -171,6 +172,66 @@ def count_emails(value: Any) -> int:
 
 
 
+# ---------------------------------------------------------------------------
+# HTML escaping
+#
+# Every string below reaches a generated page through an f-string, so the page
+# is built by concatenation and the data decides where the markup ends. Event
+# descriptions are raw text extracted from paper PDFs -- arXiv accepts uploads
+# from anyone -- so "the data is first-party" is not true of the *contents* of
+# these fields, only of the pipeline that carries them.
+#
+# This was not hypothetical. Before this pass, in the shipped corpus:
+#   * arxiv_73643a60bb86bf2f's description contains "<<number to be assigned>>",
+#     which the browser parses as a tag start in <p class="description"> AND
+#     inside the <meta name="description" content="..."> attribute.
+#   * arxiv_aa8c44de8cf70353's description contains a double quote inside the
+#     first 155 characters, which TERMINATES the meta content attribute early
+#     and turns the rest of the sentence into bogus tag attributes.
+# Both were live on pdoom1.com.
+#
+# escape_event_for_html() mirrors redact_pii(): it walks the WHOLE record rather
+# than a named list of fields, so a field added upstream tomorrow is covered on
+# the day it appears. Fail closed. Non-strings pass through untouched, so ints
+# (year, impact deltas) still render as numbers.
+def esc(value: Any) -> str:
+    """HTML-escape a single value for text OR attribute context.
+
+    Escaping the double quote is not optional: several slots are attribute values
+    (content="...", href="..."), and an unescaped double quote in an attribute is
+    an injection, not a typo.
+
+    The apostrophe is deliberately NOT escaped, which is where this differs from
+    html.escape(s, quote=True). Every attribute in this template is double-quoted
+    (test-sync-events.py asserts that as a rule, so the exemption cannot rot), and
+    inside a double-quoted attribute an apostrophe is an ordinary character. Escaping
+    it anyway would rewrite ~1,194 published pages for no reader-visible change --
+    prose is full of apostrophes -- and burying a real fix in a diff that large is
+    how a real fix stops getting reviewed.
+    """
+    return (str(value).replace("&", "&amp;")
+                      .replace("<", "&lt;")
+                      .replace(">", "&gt;")
+                      .replace('"', "&quot;"))
+
+
+def escape_event_for_html(value: Any) -> Any:
+    """Recursively HTML-escape every string in a nested str/list/dict value.
+
+    Deliberately mirrors redact_pii(): whole-record, not a field list. The page
+    template interpolates ~20 distinct expressions off the event dict and gains
+    more over time; enumerating them is how the leaderboard shipped six escaped
+    fields and thirteen unescaped ones.
+    """
+    if isinstance(value, str):
+        return esc(value)
+    if isinstance(value, list):
+        return [escape_event_for_html(v) for v in value]
+    if isinstance(value, dict):
+        return {k: escape_event_for_html(v) for k, v in value.items()}
+    return value
+
+
 def sanitize_urls_in_text(text: str) -> str:
     """Convert HTTP URLs to HTTPS where safe to do so"""
     import re
@@ -221,6 +282,16 @@ def sanitize_event_urls(event: Dict[str, Any]) -> Dict[str, Any]:
 def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
     """Generate HTML for individual event detail page"""
 
+    # Escape ONCE, at the top, for the whole record -- see escape_event_for_html().
+    # `raw` keeps the unescaped values for the two contexts where escaping would be
+    # wrong: urllib.parse.quote() percent-encodes for a URL (double-escaping would
+    # put "%26amp%3B" in a prefilled GitHub issue title), and the meta-description
+    # truncation must slice the source text BEFORE escaping or it can cut an entity
+    # in half. Everything else below reads the escaped `event`.
+    raw = event
+    event = escape_event_for_html(event)
+    event_id_esc = esc(event_id)
+
     # Category icons
     category_icons = {
         'funding_catastrophe': '💸',
@@ -269,15 +340,19 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
     # Generate metadata suggestion URLs
     from urllib.parse import quote
 
-    category_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20category%20for%20{quote(event_id)}&body=Event%3A%20{quote(event['title'])}%0A%0ACurrent%20category%3A%20{quote(event['category'])}%0A%0ASuggested%20category%3A%20%0A%0AReason%3A%20"
+    # These read `raw`, not `event`: quote() is the escaper for a URL context, and
+    # running it over already-HTML-escaped text would prefill the GitHub issue with
+    # "%26amp%3B" where the source said "&". The percent-encoding quote() produces
+    # contains no <, > or " , so the finished URL is safe in an href attribute.
+    category_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20category%20for%20{quote(event_id)}&body=Event%3A%20{quote(raw['title'])}%0A%0ACurrent%20category%3A%20{quote(raw['category'])}%0A%0ASuggested%20category%3A%20%0A%0AReason%3A%20"
 
-    rarity_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20rarity%20for%20{quote(event_id)}&body=Event%3A%20{quote(event['title'])}%0A%0ACurrent%20rarity%3A%20{quote(event['rarity'])}%0A%0ASuggested%20rarity%3A%20%0A%0AReason%3A%20"
+    rarity_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20rarity%20for%20{quote(event_id)}&body=Event%3A%20{quote(raw['title'])}%0A%0ACurrent%20rarity%3A%20{quote(raw['rarity'])}%0A%0ASuggested%20rarity%3A%20%0A%0AReason%3A%20"
 
-    tags_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20tags%20for%20{quote(event_id)}&body=Event%3A%20{quote(event['title'])}%0A%0ACurrent%20tags%3A%20{quote(', '.join(event['tags']))}%0A%0ASuggested%20tags%3A%20%0A%0AReason%3A%20"
+    tags_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events&title=Metadata%3A%20Change%20tags%20for%20{quote(event_id)}&body=Event%3A%20{quote(raw['title'])}%0A%0ACurrent%20tags%3A%20{quote(', '.join(raw['tags']))}%0A%0ASuggested%20tags%3A%20%0A%0AReason%3A%20"
 
-    impacts_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events,game-balance&title=Metadata%3A%20Change%20impacts%20for%20{quote(event_id)}&body=Event%3A%20{quote(event['title'])}%0A%0ACurrent%20impacts%3A%20{len(event['impacts'])}%20game%20variable%20changes%0A%0ASuggested%20changes%3A%20%0A-%20Variable%3A%20%0A-%20Change%3A%20%0A%0AReason%3A%20"
+    impacts_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events,game-balance&title=Metadata%3A%20Change%20impacts%20for%20{quote(event_id)}&body=Event%3A%20{quote(raw['title'])}%0A%0ACurrent%20impacts%3A%20{len(event['impacts'])}%20game%20variable%20changes%0A%0ASuggested%20changes%3A%20%0A-%20Variable%3A%20%0A-%20Change%3A%20%0A%0AReason%3A%20"
 
-    pdoom_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events,game-balance&title=Metadata%3A%20Change%20p(doom)%20impact%20for%20{quote(event_id)}&body=Event%3A%20{quote(event['title'])}%0A%0ACurrent%20p(doom)%20impact%3A%20{event.get('pdoom_impact', 'null')}%0A%0ASuggested%20p(doom)%20impact%3A%20%0A%0AReason%3A%20"
+    pdoom_suggestion_url = f"https://github.com/PipFoweraker/pdoom-data/issues/new?labels=metadata,events,game-balance&title=Metadata%3A%20Change%20p(doom)%20impact%20for%20{quote(event_id)}&body=Event%3A%20{quote(raw['title'])}%0A%0ACurrent%20p(doom)%20impact%3A%20{quote(str(raw.get('pdoom_impact', 'null')))}%0A%0ASuggested%20p(doom)%20impact%3A%20%0A%0AReason%3A%20"
 
     # Build reaction provenance badges and source info
     def build_reaction_html(reaction_text: str, reaction_key: str) -> str:
@@ -326,8 +401,8 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{event['title']} | p(Doom)1 Events</title>
-	<link rel="canonical" href="https://pdoom1.com/events/{event_id}.html" />
-	<meta name="description" content="{event['description'][:155]}" />
+	<link rel="canonical" href="https://pdoom1.com/events/{event_id_esc}.html" />
+	<meta name="description" content="{esc(raw['description'][:155])}" />
 
 	<!-- Plausible Analytics -->
 	<script defer data-domain="pdoom1.com" src="https://analytics.pdoom1.com/js/script.file-downloads.outbound-links.pageview-props.tagged-events.js"></script>
@@ -768,7 +843,7 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 				{media_source}
 			</div>
 
-			<a href="/events/suggest-quote.html?event={event_id}" class="suggest-quote-button">
+			<a href="/events/suggest-quote.html?event={quote(event_id)}" class="suggest-quote-button">
 				💡 Found a Real Quote? Suggest it here
 			</a>
 		</div>
@@ -820,7 +895,7 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 				<div class="metadata-item">
 					<span class="metadata-label">📝 General Metadata</span>
 					<span class="metadata-value">Year, description, reactions</span>
-					<a href="/events/suggest-metadata.html?event={event_id}" class="suggest-link">→ Comprehensive review</a>
+					<a href="/events/suggest-metadata.html?event={quote(event_id)}" class="suggest-link">→ Comprehensive review</a>
 				</div>
 			</div>
 		</div>
@@ -828,8 +903,8 @@ def generate_event_detail_page(event_id: str, event: Dict[str, Any]) -> str:
 		<div class="contribute-section">
 			<h2>🤝 Found an Issue?</h2>
 			<p>This event data is sourced from the pdoom-data repository. If you notice errors or want to suggest improvements:</p>
-			<a href="https://github.com/PipFoweraker/pdoom-data/issues/new?title=Event%20Issue:%20{event_id}" class="cta-button" target="_blank">GitHub Issue (Preferred)</a>
-			<a href="mailto:team@pdoom1.com?subject=Event%20Data%20Issue:%20{event_id}&body=Event:%20{quote(event['title'])}%0A%0AWhat's wrong:%20%0A%0ASuggested fix:%20" class="cta-button">📧 Email (No GitHub)</a>
+			<a href="https://github.com/PipFoweraker/pdoom-data/issues/new?title=Event%20Issue:%20{quote(event_id)}" class="cta-button" target="_blank">GitHub Issue (Preferred)</a>
+			<a href="mailto:team@pdoom1.com?subject=Event%20Data%20Issue:%20{quote(event_id)}&amp;body=Event:%20{quote(raw['title'])}%0A%0AWhat's wrong:%20%0A%0ASuggested fix:%20" class="cta-button">📧 Email (No GitHub)</a>
 		</div>
 
 		<div style="text-align: center; margin-top: 2rem;">

--- a/scripts/test-health-check.py
+++ b/scripts/test-health-check.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Destructive tests for scripts/health-check.py.
+
+# WHY THIS EXISTS
+# ---------------
+# health-check.py writes public/data/health-check-results.json. health-checks.yml
+# runs it on a 6-hourly cron and COMMITS the result, so whatever it says is served
+# from pdoom1.com. Its apparent test coverage was fake: test-orchestrator.py and
+# test-integration.py both name it, but both merely shell out to it against the real
+# repo and check the exit code. Neither looks at a single byte it publishes.
+#
+# The thing it publishes has already been a privacy incident. A cp1252
+# UnicodeEncodeError traceback -- which names the interpreter's own
+# encodings/cp1252.py -- was captured into a published JSON file and served from
+# pdoom1.com, exposing the maintainer's OS username and local directory layout
+# ("C:\\Users\\<name>\\Documents\\A Local Code\\..."). rel() and scrub() were added
+# in response, with the docstring rule "Never interpolate a raw filepath into a
+# result message -- call this instead."
+#
+# THE HOLE THIS LOCKS DOWN (found 2026-08-01)
+# -------------------------------------------
+# That rule was enforced by everyone remembering it, and four handlers did not:
+#
+#   test_json_valid:              f"Error reading {shown}: {e}"
+#   test_script_executable:       f"Error testing script: {e}"
+#   test_version_data_integrity:  f"Could not parse timestamp: {e}"
+#                                 f"Error validating data: {e}"
+#
+# `shown` is scrubbed; `{e}` is not. str(OSError) embeds the absolute path it failed
+# on, so a permission error or an unreadable file re-published exactly the class of
+# string the guard exists to remove -- through the guard, on a cron, to a public URL.
+#
+# The fix was to scrub at the ONE chokepoint every message passes through
+# (log_result) instead of at each call site. This file is the evidence, and section
+# 2 asserts it as a rule over the whole published document rather than as four named
+# messages: it runs the regex over every string anywhere in the output. A fifth
+# handler added next year is covered on the day it is written.
+#
+# WHAT IS DELIBERATELY NOT ASSERTED
+# ---------------------------------
+# No test here pins a file count, a version, a date, or a success percentage. Those
+# move. Section 4 asserts the arithmetic RELATIONSHIP between the summary counters
+# instead, which does not.
+#
+# HOW IT ISOLATES
+# ---------------
+# Every case builds a repo-shaped tree in a temp dir and points the checker's
+# base_dir / public_dir / data_dir at it. No test reads or writes the real public/,
+# and nothing here touches the network.
+#
+# Run:  python scripts/test-health-check.py     (exit 0 = pass)
+"""
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "health_check", ROOT / "scripts" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+failures = []
+
+
+def check(cond, msg):
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+# The shapes that actually leaked, plus the ones that would.
+SECRET_PATHS = [
+    r"C:\Users\gday\Documents\A Local Code\pdoom1-website\public\data\version.json",
+    r"C:\Users\gday\AppData\Local\Programs\Python\Python311\lib\encodings\cp1252.py",
+    "/home/runner/work/pdoom1-website/pdoom1-website/public/data/version.json",
+    "/Users/pip/Code/pdoom1-website/scripts/health-check.py",
+    "/var/folders/xx/T/tmpabc123/version.json",
+    "/root/.ssh/config",
+]
+# The identifying fragments that must never survive. Usernames and directory
+# layout are the payload; the basename is harmless and is what scrub() keeps.
+SECRETS = ["gday", "AppData", "Documents", "A Local Code", "/home/runner",
+           "/Users/pip", "/var/folders", "/root", "Python311"]
+
+
+def strings_in(value):
+    """Every string anywhere in a nested structure, keys included."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for v in value:
+            yield from strings_in(v)
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            yield k
+            yield from strings_in(v)
+
+
+class FakeRepo:
+    """A repo-shaped temp tree with a checker pointed at it."""
+
+    def __init__(self, version_json=None, extra=None):
+        self.version_json = version_json
+        self.extra = extra or {}
+
+    def __enter__(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "public" / "data").mkdir(parents=True)
+        (self.tmp / "scripts").mkdir()
+        (self.tmp / "public" / "index.html").write_text("<html></html>", encoding="utf-8")
+        (self.tmp / "public" / "config.json").write_text("{}", encoding="utf-8")
+        (self.tmp / "public" / "data" / "changes.json").write_text("[]", encoding="utf-8")
+        if self.version_json is not None:
+            (self.tmp / "public" / "data" / "version.json").write_text(
+                self.version_json, encoding="utf-8")
+        for rel, body in self.extra.items():
+            p = self.tmp / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+
+        self.c = hc.HealthChecker()
+        self.c.base_dir = str(self.tmp)
+        self.c.public_dir = str(self.tmp / "public")
+        self.c.data_dir = str(self.tmp / "public" / "data")
+        return self
+
+    def __exit__(self, *a):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        return False
+
+    def run(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            return self.c.run_all_checks()
+
+    def published(self):
+        p = self.tmp / "public" / "data" / "health-check-results.json"
+        return json.loads(p.read_text(encoding="utf-8")) if p.exists() else None
+
+
+GOOD_VERSION = json.dumps({
+    "latest_release": {"version": "v1.0.0", "name": "n",
+                       "published_at": "2030-01-01T00:00:00Z", "html_url": "u"},
+    "repository_stats": {"stars": 1},
+    "game_stats": {"baseline_doom_percent": None, "frontier_labs_count": 5,
+                   "strategic_possibilities": None},
+    "last_updated": "2030-01-01T00:00:00",
+})
+
+
+# =========================================================================== 1
+print("\n1. scrub() removes an absolute path wherever it appears in free text")
+
+for p in SECRET_PATHS:
+    out = hc.HealthChecker.scrub(f"[Errno 13] Permission denied: '{p}'")
+    check(not any(s in out for s in SECRETS),
+          f"nothing identifying survives: {p[:44]}")
+    check(os.path.basename(p.rstrip("\\/")) in out,
+          f"the BASENAME survives, so the message still says which file: {p[:34]}")
+
+check(hc.HealthChecker.scrub("public/data/version.json") == "public/data/version.json",
+      "a repo-relative path is left alone -- scrubbing is not blanket deletion")
+check("cp1252.py" in hc.HealthChecker.scrub(
+    r'  File "C:\Python311\lib\encodings\cp1252.py", line 19, in encode'),
+    "the real traceback line reduces to a basename")
+check(hc.HealthChecker.scrub(OSError(2, "no such file", "/home/runner/x/y.json")),
+      "scrub accepts a non-str (an exception object) without raising")
+
+
+# =========================================================================== 2
+print("\n2. THE RULE: no absolute path can reach the published document, from ANY handler")
+
+# Force every failure branch at once, and force them with path-bearing errors.
+# unreadable.json is a directory named like a file: open() on it raises IsADirectoryError
+# / PermissionError whose str() carries the absolute path -- the exact leak shape.
+with FakeRepo(version_json='{"bad json"') as fr:
+    (Path(fr.c.data_dir) / "changes.json").unlink()
+    (Path(fr.c.data_dir) / "changes.json").mkdir()
+    (Path(fr.c.base_dir) / "scripts" / "update-version-info.py").write_text(
+        "def broken(:\n", encoding="utf-8")   # syntax error -> py_compile traceback
+    summary = fr.run()
+    doc = fr.published()
+
+    check(doc is not None, "a failing run still publishes a results file")
+    check(summary["overall_status"] == "FAIL", "and it says FAIL")
+
+    offenders = []
+    for s in strings_in(doc):
+        if hc.HealthChecker._ABS_PATH.search(s):
+            offenders.append(s[:110])
+    check(not offenders,
+          f"no string ANYWHERE in the published JSON matches an absolute path "
+          f"(offenders: {offenders[:2]})")
+
+    blob = json.dumps(doc)
+    leaked = [s for s in SECRETS if s in blob]
+    check(not leaked, f"no username or directory-layout fragment survives ({leaked})")
+
+    # Guard against the test passing because nothing was recorded at all.
+    check(len(summary["failed_test_details"]) >= 2,
+          f"the run actually recorded failures to scrub "
+          f"({len(summary['failed_test_details'])} of them)")
+
+# The same rule, aimed straight at the four handlers, via log_result's chokepoint.
+for p in SECRET_PATHS:
+    with FakeRepo(version_json=GOOD_VERSION) as fr:
+        fr.c.log_result(f"Test at {p}", False, f"[Errno 13] Permission denied: '{p}'")
+        rec = fr.c.results[-1]
+        check(not hc.HealthChecker._ABS_PATH.search(rec["message"]),
+              f"log_result scrubs the MESSAGE it was handed: {p[:38]}")
+        check(not hc.HealthChecker._ABS_PATH.search(rec["test"]),
+              f"log_result scrubs the TEST NAME too: {p[:38]}")
+        check(not any(hc.HealthChecker._ABS_PATH.search(s) for s in fr.c.failed_tests),
+              "the aggregated failure list is clean as well")
+
+
+# =========================================================================== 3
+print("\n3. rel() never emits anything above the repo root")
+
+with FakeRepo(version_json=GOOD_VERSION) as fr:
+    inside = os.path.join(fr.c.public_dir, "data", "version.json")
+    check(fr.c.rel(inside) == "public/data/version.json",
+          "a path inside the repo becomes a forward-slashed relative path")
+    check("\\" not in fr.c.rel(inside),
+          "backslashes are normalised, so the published string is platform-neutral")
+    # A path on another drive has no relative form. The fallback must be a basename,
+    # not the original absolute path.
+    other = fr.c.rel(r"Z:\Someone Else\secret\thing.json")
+    check(not hc.HealthChecker._ABS_PATH.search(other),
+          f"a cross-drive path degrades to something non-absolute (got {other!r})")
+    check(fr.c.rel(None) and not hc.HealthChecker._ABS_PATH.search(fr.c.rel(None)),
+          "rel(None) returns a harmless string rather than raising")
+
+
+# =========================================================================== 4
+print("\n4. The summary reports what happened, not a shape decided in advance")
+
+with FakeRepo(version_json=GOOD_VERSION) as fr:
+    summary = fr.run()
+    n = summary["total_tests"]
+    check(n == len(summary["results"]), "total_tests equals the number of results recorded")
+    check(summary["passed_tests"] + summary["failed_tests"] == n,
+          "passed + failed == total (the counters are derived, not asserted)")
+    expected_rate = summary["passed_tests"] / n * 100 if n else 0
+    check(abs(summary["success_rate"] - expected_rate) < 1e-9,
+          "success_rate is computed from the counters, not stated")
+    check((summary["overall_status"] == "PASS")
+          == (len(summary["failed_test_details"]) == 0),
+          "overall_status is PASS iff nothing non-warning failed")
+
+# A warning must stay visible as a warning. Recording an unmeasurable thing as a
+# silent pass is how "we could not check" becomes indistinguishable from "it is fine".
+with FakeRepo(version_json=json.dumps({
+        "latest_release": {"version": "v1", "name": "n", "published_at": "p", "html_url": "u"},
+        "repository_stats": {}, "game_stats": {"baseline_doom_percent": None,
+                                               "frontier_labs_count": None,
+                                               "strategic_possibilities": None},
+        "last_updated": "not-a-timestamp"})) as fr:
+    summary = fr.run()
+    warned = [r for r in summary["results"] if r["is_warning"]]
+    check(warned, "an unparseable timestamp is recorded, not swallowed")
+    check(summary["warnings"] == len(summary["warnings_details"]),
+          "the warning count matches the warning list")
+    check(all("not-a-timestamp" not in json.dumps(r) or r["is_warning"]
+              for r in summary["results"]),
+          "the un-checkable case is flagged as a warning rather than a bare pass")
+
+
+# =========================================================================== 5
+print("\n5. A missing or malformed version.json is reported, never assumed fine")
+
+with FakeRepo() as fr:  # no version.json at all
+    summary = fr.run()
+    check(summary["overall_status"] == "FAIL", "absent version.json fails the run")
+    check(any("not found" in d.lower() or "missing" in d.lower()
+              for d in summary["failed_test_details"]),
+          "and says what is missing")
+
+# Absence of a required field is a failure, and the check must not name only the
+# fields someone thought of at the time: drop each required field in turn.
+BASE = json.loads(GOOD_VERSION)
+for field in ("latest_release", "repository_stats", "game_stats", "last_updated"):
+    partial = {k: v for k, v in BASE.items() if k != field}
+    with FakeRepo(version_json=json.dumps(partial)) as fr:
+        summary = fr.run()
+        check(summary["overall_status"] == "FAIL",
+              f"version.json missing {field!r} fails the run")
+        check(field in json.dumps(summary["failed_test_details"]),
+              f"and names {field!r} as the missing one")
+
+with FakeRepo(version_json="{not json at all") as fr:
+    summary = fr.run()
+    check(summary["overall_status"] == "FAIL", "malformed version.json fails the run")
+    doc = fr.published()
+    check(not any(hc.HealthChecker._ABS_PATH.search(s) for s in strings_in(doc)),
+          "and the JSONDecodeError path publishes no absolute path either")
+
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S)")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("OK: health-check publishes no absolute path from any handler, and its summary "
+      "counters are derived rather than asserted.")

--- a/scripts/test-health-check.py
+++ b/scripts/test-health-check.py
@@ -245,6 +245,25 @@ with FakeRepo(version_json=GOOD_VERSION) as fr:
           f"a cross-drive path degrades to something non-absolute (got {other!r})")
     check(fr.c.rel(None) and not hc.HealthChecker._ABS_PATH.search(fr.c.rel(None)),
           "rel(None) returns a harmless string rather than raising")
+    # relpath does not raise for a path merely OUTSIDE the repo -- it climbs, and what
+    # it emits then is the layout above base_dir ("../../home/runner/work/..." on a
+    # runner). Same disclosure, different branch, and the branch a POSIX host takes
+    # for the Z: case above, since only Windows raises ValueError for a foreign drive.
+    above = fr.c.rel(os.path.join(os.path.dirname(fr.c.base_dir), "elsewhere", "x.json"))
+    check(not above.startswith("..") and not hc.HealthChecker._ABS_PATH.search(above),
+          f"a path above the repo root does not climb out (got {above!r})")
+
+    # last_segment must not be os.path.basename: on POSIX that splits on '/' only, so a
+    # Windows path passes through WHOLE while reading as if it had been redacted. This
+    # file's output is committed by a cron running on Linux, and the text it scrubs is
+    # not all locally produced. Asserted on both hosts, so neither can regress alone.
+    check(hc.HealthChecker.last_segment(
+              r"C:\Users\someone\Documents\A Local Code\repo\public\data\version.json")
+          == "version.json",
+          "last_segment splits a WINDOWS path on any host")
+    check(hc.HealthChecker.last_segment(
+              "/home/runner/work/repo/repo/public/data/version.json") == "version.json",
+          "last_segment splits a POSIX path on any host")
 
 
 # =========================================================================== 4

--- a/scripts/test-health-check.py
+++ b/scripts/test-health-check.py
@@ -166,12 +166,25 @@ GOOD_VERSION = json.dumps({
 # =========================================================================== 1
 print("\n1. scrub() removes an absolute path wherever it appears in free text")
 
+def expected_filename(p):
+    """The last segment, computed WITHOUT os.path and WITHOUT the code under test.
+
+    `os.path.basename` was the original spelling here and it is host-dependent: on a
+    Linux runner it splits on '/' only, so for the Windows entries above it returns
+    the WHOLE path and this assertion silently demanded the leak it was written to
+    forbid -- directly contradicting the check on the line before. Spelled out here
+    rather than calling HealthChecker.last_segment, which would make the test agree
+    with the implementation by construction instead of checking it.
+    """
+    return p.rstrip("\\/").replace("\\", "/").rsplit("/", 1)[-1]
+
+
 for p in SECRET_PATHS:
     out = hc.HealthChecker.scrub(f"[Errno 13] Permission denied: '{p}'")
     check(not any(s in out for s in SECRETS),
           f"nothing identifying survives: {p[:44]}")
-    check(os.path.basename(p.rstrip("\\/")) in out,
-          f"the BASENAME survives, so the message still says which file: {p[:34]}")
+    check(expected_filename(p) in out,
+          f"the FILENAME survives, so the message still says which file: {p[:34]}")
 
 check(hc.HealthChecker.scrub("public/data/version.json") == "public/data/version.json",
       "a repo-relative path is left alone -- scrubbing is not blanket deletion")

--- a/scripts/test-sync-events.py
+++ b/scripts/test-sync-events.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Destructive tests for scripts/sync/sync-events.py.
+
+# WHY THIS EXISTS
+# ---------------
+# sync-events.py is the single largest publisher in this repo. One run writes
+# ~1,194 `public/events/*.html` pages, `public/data/events.json` and
+# `public/data/events-sync-summary.json`, and `sync-events.yml` runs it on a
+# daily cron that COMMITS the result. Until this file it had zero tests.
+#
+# Two things it owns, both of which have already gone wrong on production:
+#
+# 1. redact_pii() -- the ONLY live guard against republishing third parties' email
+#    addresses. Event descriptions are raw text extracted from paper PDFs, and
+#    arXiv/ACM author blocks carry institutional addresses; 75 distinct academics'
+#    addresses were served across 44 pages until 2026-07-29. The downstream
+#    re-check, scripts/check-published-emails.py, is an ORPHAN -- no workflow runs
+#    it (verified 2026-08-01). So if redact_pii() regresses, nothing else notices,
+#    and the daily cron commits the leak straight back.
+#
+# 2. HTML escaping. The page is one 500-line f-string, so the data decides where
+#    the markup ends, and arXiv accepts uploads from anyone. Before 2026-08-01 the
+#    generator escaped NOTHING, and the shipped corpus already broke it twice:
+#      * arxiv_73643a60bb86bf2f's description contains "<<number to be assigned>>",
+#        parsed as a tag start in <p class="description"> and inside the
+#        <meta name="description" content="..."> attribute.
+#      * arxiv_aa8c44de8cf70353's description carries a double quote inside its
+#        first 155 characters, which TERMINATED the meta content attribute early
+#        and turned the rest of the sentence into bogus tag attributes.
+#    Both were live on pdoom1.com. escape_event_for_html() is the fix; this file
+#    is the evidence that it works.
+#
+# HOW IT ASSERTS THE RULE RATHER THAN A LIST
+# ------------------------------------------
+# Naming the fields to check is how the leaderboard came to escape six fields and
+# leave thirteen raw (see scripts/test-board-escaping.js). So section 3 does not
+# name any field. It renders the SAME event twice -- once with benign text in
+# every string slot, once with a hostile payload in every string slot -- and
+# requires the two documents to have an IDENTICAL tag-and-attribute skeleton. Any
+# interpolation added later that forgets to escape changes the skeleton and fails
+# here on the day it is added, with no list to remember to extend.
+#
+# Likewise section 2 puts an address in a field that does not exist in today's
+# schema, because redact_pii()'s stated contract is to walk the WHOLE record.
+#
+# HOW IT ISOLATES
+# ---------------
+# Section 6 redirects the module's EVENTS_DIR / DATA_DIR / ICONS_DIR into a temp
+# dir and builds a fake pdoom-data tree there, so no test touches public/ or the
+# network. Nothing here clones a repo or issues an HTTP request.
+#
+# Run:  python scripts/test-sync-events.py     (exit 0 = pass)
+"""
+
+import importlib.util
+import io
+import json
+import re
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from html.parser import HTMLParser
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Import before any redirect_stdout: on win32 the module replaces sys.stdout with
+# io.TextIOWrapper(sys.stdout.buffer, ...) at import time, and a StringIO has no
+# .buffer, so importing under a redirect dies with AttributeError.
+_spec = importlib.util.spec_from_file_location(
+    "sync_events", ROOT / "scripts" / "sync" / "sync-events.py")
+se = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(se)
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+failures = []
+
+
+def check(cond, msg):
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+# --------------------------------------------------------------------------- helpers
+def make_event(text, **over):
+    """An event whose every string-typed slot carries `text`.
+
+    Numeric slots stay numeric because the template does arithmetic on them
+    (impact['change'] > 0) and formats event['year'] directly.
+    """
+    e = {
+        "title": text,
+        "description": text,
+        "year": 2024,
+        "category": text,
+        "rarity": text,
+        "tags": [text, text + "-two"],
+        "sources": ["https://example.com/" + text, text],
+        "safety_researcher_reaction": text,
+        "media_reaction": text,
+        "pdoom_impact": 3,
+        "impacts": [{"variable": text, "change": 2, "condition": text}],
+        "reaction_provenance": {
+            "safety_researcher_reaction": {
+                "type": "real_quote", "source": "https://example.com/" + text,
+                "author": text, "date": text,
+            },
+            "media_reaction": {
+                "type": "human_summary", "sources": ["https://example.com/" + text],
+            },
+        },
+        # Not in today's schema on purpose. redact_pii()/escape_event_for_html()
+        # both claim to walk the WHOLE record; this is the field "added upstream
+        # tomorrow" that proves it, and it is serialised into events.json.
+        "future_field_added_upstream": {"nested": [{"deep": text}]},
+    }
+    e.update(over)
+    return e
+
+
+class Skeleton(HTMLParser):
+    """Collect (tag, sorted attribute names) for every start tag, in order.
+
+    This is the structural fingerprint of the document. Escaped payload text
+    cannot change it; injected markup always does -- whether it opens a tag or
+    merely terminates an attribute early and spills new attribute names into the
+    tag it was sitting in.
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.seq = []
+
+    def handle_starttag(self, tag, attrs):
+        self.seq.append((tag, tuple(sorted(a for a, _ in attrs))))
+
+    handle_startendtag = handle_starttag
+
+
+def skeleton(html_text):
+    p = Skeleton()
+    p.feed(html_text)
+    return p.seq
+
+
+def all_text(value):
+    """Every string anywhere in a nested structure."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for v in value:
+            yield from all_text(v)
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from all_text(v)
+
+
+# =========================================================================== 1
+print("\n1. The email pattern matches addresses and only addresses")
+
+# Both of these come from the real corpus and are why the pattern is shaped the
+# way it is. They are behaviours, not incidental: a greedy TLD deletes a person's
+# name, which is a worse outcome than the leak it was fixing.
+glued = se.redact_emails_in_text("contact madry@mit.eduAleksandar Madry for details")
+check("madry@mit.edu" not in glued, "PDF-glued address is removed")
+check("Aleksandar Madry" in glued,
+      "the next author's NAME survives a glued address -- redaction must not eat data")
+
+check(se.redact_emails_in_text("write to mailto:a.b@cs.example.ac.uk now")
+      == f"write to {se.REDACTION_MARKER} now",
+      "a mailto: prefix is swallowed with the address, not left dangling")
+
+check(se.REDACTION_MARKER in se.redact_emails_in_text("x@y.com"),
+      "redaction MARKS the gap rather than silently deleting -- a silent deletion "
+      "is a small lie about what the source said")
+
+# The other direction. A pattern that eats non-addresses is a different way of
+# lying about the source, and there is no downstream check that would catch it.
+for benign in ("@openai mentioned it", "see fig@ 3", "n@", "a@b", "price 5@10"):
+    check(se.redact_emails_in_text(benign) == benign,
+          f"leaves non-address text alone: {benign!r}")
+
+check(se.count_emails({"a": ["x@y.com", {"b": "p@q.org"}], "c": 7}) == 2,
+      "count_emails walks nested structures (the sync log's number is real)")
+
+
+# =========================================================================== 2
+print("\n2. redact_pii walks the WHOLE record, not a field list")
+
+ADDR = "victim@institute.example.org"
+ev = make_event(f"text with {ADDR} inside")
+red = se.redact_pii(ev)
+
+leaked = [s for s in all_text(red) if "@" in s and "example.org" in s]
+check(not leaked, f"no address survives anywhere in the record (leaked: {leaked[:2]})")
+check(any(se.REDACTION_MARKER in s for s in all_text(red)), "the marker is present")
+
+# The point of the whole-record contract: a field nobody has written a case for.
+check(ADDR not in json.dumps(red["future_field_added_upstream"]),
+      "THE BIG ONE: an unknown field added upstream tomorrow is redacted today, "
+      "because redact_pii walks the record instead of enumerating fields")
+
+check(se.redact_pii(ev) is not None and ADDR in json.dumps(ev),
+      "redact_pii returns a new structure and does not mutate its input")
+
+check(se.redact_pii(2024) == 2024 and se.redact_pii(None) is None,
+      "non-string leaves pass through unchanged (year stays an int)")
+
+
+# =========================================================================== 3
+print("\n3. Nothing an event can say changes the shape of the page")
+
+BENIGN = "ordinary"
+HOSTILE_PAYLOADS = [
+    '<script>alert(1)</script>',
+    '"><img src=x onerror=alert(1)>',
+    "' onmouseover='alert(1)",
+    '</p></div><div class="injected">',
+    '<<number to be assigned>>',              # the real arxiv_73643a60bb86bf2f string
+    'Kott, "Cybertrust: From Explainable',    # the real arxiv_aa8c44de8cf70353 shape
+    'Arts & Sciences',                        # bare ampersand, the real corpus case
+    '&lt;already escaped&gt;',                # must not be double-unescaped
+]
+
+base = skeleton(se.generate_event_detail_page("evt_benign", make_event(BENIGN)))
+check(len(base) > 20, f"baseline page parsed into {len(base)} tags")
+
+for payload in HOSTILE_PAYLOADS:
+    got = skeleton(se.generate_event_detail_page("evt_hostile", make_event(payload)))
+    check(got == base,
+          "page skeleton is identical with payload in every field: " + payload[:38])
+
+# The event id reaches an href and the canonical link. It is a dict key upstream,
+# so nothing validates its shape here.
+for payload in HOSTILE_PAYLOADS[:4]:
+    got = skeleton(se.generate_event_detail_page(payload, make_event(BENIGN)))
+    check(got == base, "page skeleton survives a hostile EVENT ID: " + payload[:34])
+
+# Structural equality is necessary but says nothing about whether the payload text
+# is present at all, so pin the two ends explicitly.
+hostile_html = se.generate_event_detail_page("evt", make_event('<script>alert(1)</script>'))
+check("<script>alert(1)</script>" not in hostile_html, "no raw <script> reaches the page")
+check("&lt;script&gt;alert(1)&lt;/script&gt;" in hostile_html,
+      "the payload is still SHOWN to the reader, as inert text -- escaping is not censorship")
+
+# The two live production defects, named.
+meta_break = se.generate_event_detail_page(
+    "evt", make_event('Kott, "Cybertrust: From Explainable' + " x" * 200))
+check(skeleton(meta_break) == base,
+      "REGRESSION arxiv_aa8c44de8cf70353: a double quote inside the first 155 "
+      "characters no longer terminates the meta description attribute")
+angle = se.generate_event_detail_page(
+    "evt", make_event("Unite Paper 2021 <<number to be assigned>> A Framework"))
+check("<<number to be assigned>>" not in angle,
+      "REGRESSION arxiv_73643a60bb86bf2f: '<<...>>' is escaped, not emitted raw")
+
+# Escaping must not silently truncate. The description is the reader-facing prose.
+long_desc = "Sentence one. " * 40
+page = se.generate_event_detail_page("evt", make_event(BENIGN, description=long_desc))
+check(long_desc.strip() in page, "the full description still reaches the page body")
+
+# esc() escapes & < > and the DOUBLE quote, but deliberately not the apostrophe --
+# see its docstring. That exemption is only sound while every attribute in the
+# template is double-quoted, so pin the precondition rather than trusting it.
+# Without this, someone writing style='...' in the template silently reopens the
+# hole, and only for a payload containing an apostrophe.
+tmpl_src = (ROOT / "scripts" / "sync" / "sync-events.py").read_text(
+    encoding="utf-8").replace("\r\n", "\n")
+tmpl = tmpl_src.split("html_content = f", 1)[1]
+single_quoted_attrs = re.findall(r"<[a-zA-Z][^>]*?=\'[^\']*\'", tmpl)
+check(not single_quoted_attrs,
+      f"every attribute in the page template is double-quoted, so esc() may leave "
+      f"apostrophes alone (found {single_quoted_attrs[:2]})")
+check(se.esc("it's") == "it's", "an apostrophe survives unescaped, keeping the diff honest")
+check(se.esc('a "b" <c> & d') == 'a &quot;b&quot; &lt;c&gt; &amp; d',
+      "the four characters that CAN end markup are all escaped")
+check(se.esc("&amp;") == "&amp;amp;",
+      "an ampersand is escaped even when it already looks like an entity -- otherwise "
+      "text that legitimately reads '&amp;' would render as '&'")
+
+
+# =========================================================================== 4
+print("\n4. Redaction happens BEFORE the page is built, on every published surface")
+
+# Ordering is the whole safety property: redacting after generation would leave
+# the address in the HTML. Assert against the generator's output directly.
+ev = make_event(f"author {ADDR} et al")
+page = se.generate_event_detail_page("evt", se.redact_pii(ev))
+check(ADDR not in page, "no address in the generated page")
+check("victim@institute" not in page, "not even a partial address survives")
+
+# ...and that an UNredacted event would have leaked, i.e. the check above is
+# actually testing redaction rather than some incidental escaping.
+check(ADDR in se.generate_event_detail_page("evt", ev),
+      "control: without redact_pii the address DOES reach the page, so the "
+      "assertion above is measuring redaction and not a coincidence")
+
+
+# =========================================================================== 5
+print("\n5. Filtering: an excluded event must never become a page")
+
+allev = {
+    "keep": make_event("a"),
+    "news": make_event("b", event_status="newsletter_archive"),
+    "gone": make_event("c", event_status="excluded"),
+    "review": make_event("d", event_status="review_needed"),
+}
+kept = se.filter_events(allev)
+check(set(kept) == {"keep", "review"},
+      f"newsletter_archive and excluded are dropped, review_needed is kept (got {sorted(kept)})")
+check(se.should_include_event({}) is True,
+      "an event with NO event_status defaults to included -- absence is not exclusion")
+
+
+# =========================================================================== 6
+print("\n6. End to end in a temp dir: nothing published carries an address or a CRLF")
+
+
+class Sandbox:
+    """Point every write at a temp dir and hand main() a fake pdoom-data tree."""
+
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self._saved = {k: getattr(se, k) for k in ("EVENTS_DIR", "DATA_DIR", "ICONS_DIR")}
+        se.EVENTS_DIR = self.tmp / "events"
+        se.DATA_DIR = self.tmp / "data"
+        se.ICONS_DIR = self.tmp / "icons"
+        src = self.tmp / "pdoom-data" / "data" / "serveable" / "api" / "timeline_events"
+        src.mkdir(parents=True)
+        (src / "all_events.json").write_text(
+            json.dumps(self.events), encoding="utf-8")
+        self.data_path = self.tmp / "pdoom-data"
+        return self
+
+    def __exit__(self, *a):
+        for k, v in self._saved.items():
+            setattr(se, k, v)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        return False
+
+
+def run_main(sandbox):
+    sys.argv = ["sync-events.py", "--pdoom-data-path", str(sandbox.data_path)]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        se.main()
+    return buf.getvalue()
+
+
+CORPUS = {
+    "evt_pii": make_event(f"Aleksandar Madry, madry@mit.eduNext Author, {ADDR}"),
+    "evt_html": make_event('Report "<<draft>>" & Sons <script>alert(1)</script>'),
+    "evt_plain": make_event("nothing special here"),
+    "evt_dropped": make_event("newsletter body", event_status="newsletter_archive"),
+}
+
+with Sandbox(CORPUS) as sb:
+    out = run_main(sb)
+    written = sorted(p for p in sb.tmp.rglob("*") if p.is_file()
+                     and p.parent != sb.tmp / "pdoom-data")
+    pages = sorted(p.name for p in (sb.tmp / "events").glob("*.html"))
+
+    check(pages == ["evt_html.html", "evt_pii.html", "evt_plain.html"],
+          f"one page per included event, none for the excluded one (got {pages})")
+
+    published = [p for p in written if "pdoom-data" not in p.parts]
+    check(len(published) >= 5, f"wrote {len(published)} files (pages + json)")
+
+    # THE RULE: scan every published byte, rather than the fields we thought of.
+    offenders = []
+    for p in published:
+        body = p.read_bytes().decode("utf-8")
+        if ADDR in body or "madry@mit.edu" in body:
+            offenders.append(p.name + " :: address")
+        if "<script>alert(1)</script>" in body and p.suffix == ".html":
+            offenders.append(p.name + " :: raw script tag")
+        if b"\r\n" in p.read_bytes():
+            offenders.append(p.name + " :: CRLF")
+    check(not offenders, f"no published file leaks an address, raw markup or CRLF "
+                         f"(offenders: {offenders[:3]})")
+
+    ejson = json.loads((sb.tmp / "data" / "events.json").read_text(encoding="utf-8"))
+    check("evt_dropped" not in ejson, "events.json omits the excluded event")
+    check(se.REDACTION_MARKER in json.dumps(ejson),
+          "events.json carries the redaction marker, so the gap is visible in the data too")
+    check("&lt;" not in json.dumps(ejson),
+          "events.json holds the ORIGINAL text, not HTML entities -- escaping is a "
+          "property of the page, and entity-encoding the JSON would corrupt every "
+          "consumer that renders it with textContent")
+
+    summary = json.loads(
+        (sb.tmp / "data" / "events-sync-summary.json").read_text(encoding="utf-8"))
+    check(summary["total_events_in_source"] == 4 and summary["included_events"] == 3,
+          "the summary counts what actually happened, not what was asked for")
+    check("Redacted" in out, "the run says out loud that it redacted something")
+
+
+# =========================================================================== 7
+print("\n7. Missing source data is a hard stop, not a quiet empty publish")
+
+# Publishing zero events would delete nothing (rsync copies public/), but it WOULD
+# overwrite events.json with {} and every page would still be served pointing at an
+# empty index. Refusing is the correct behaviour; this forces it.
+with Sandbox({}) as sb:
+    (sb.data_path / "data" / "serveable" / "api" / "timeline_events"
+     / "all_events.json").unlink()
+    buf = io.StringIO()
+    code = None
+    try:
+        with redirect_stdout(buf):
+            se.load_events_from_pdoom_data(sb.data_path)
+    except SystemExit as exc:
+        code = exc.code
+    check(code == 1, f"exits 1 when all_events.json is absent (got {code})")
+    check("not found" in buf.getvalue().lower(), "names the missing file")
+    check(not (sb.tmp / "data" / "events.json").exists(),
+          "wrote no events.json on the refusal path")
+
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S)")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("OK: sync-events redacts every address in the whole record, and no event text "
+      "can change the shape of a published page.")

--- a/scripts/test-update-version-info.py
+++ b/scripts/test-update-version-info.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Destructive tests for scripts/update-version-info.py.
+
+# WHY THIS EXISTS
+# ---------------
+# update-version-info.py writes public/data/version.json and public/data/status.json
+# and REWRITES public/index.html in place. version.json is the source of truth for
+# the download buttons, /game-changelog/, and -- via latest_release.platforms -- for
+# check-platform-claims.py, the guard that stops a page advertising an OS with no
+# build. Two workflows run it on 6-hourly crons and COMMIT the result
+# (auto-update-data.yml, health-checks.yml). It had no test.
+#
+# The apparent coverage was fake. test-orchestrator.py and test-integration.py both
+# reference this script, but neither asserts anything about its output: they shell
+# out to it and check the exit code, against the LIVE GitHub API, writing into the
+# real public/ tree. A run that fetched garbage and wrote it would pass both.
+#
+# Four claimed safety properties, all of which were prose until now:
+#
+#   1. "Refusing to write a guessed version"  -- a literal fallback ships exactly
+#      when the lookup failed, i.e. when nobody is watching.
+#   2. "Refusing to publish zeroes as if they were measured" -- 0 stars is a claim,
+#      not an absence of one.
+#   3. status.json is not clobbered when the release lookup fell back.
+#   4. platforms is DERIVED from the release's attached assets.
+#
+# Plus three defects this file was written to lock down after finding them
+# (2026-08-01):
+#
+#   * 'x86_64' is an architecture, not an OS. `PDoom-v0.13.1-macos-x86_64.dmg`
+#     matched the linux pattern as well as the macos one, so a Mac-only release
+#     would have published platforms.linux: true -- handing check-platform-claims.py
+#     a false positive, in the one field that exists to stop false platform claims.
+#   * game_stats was hardcoded to {baseline_doom_percent: 23, frontier_labs_count: 7,
+#     strategic_possibilities: 10000} on every run. calculate-game-stats.py writes the
+#     same file and deliberately nulls two of those with a "not yet measured"
+#     explanation, carrying the comment "DO NOT restore a literal here 'temporarily'.
+#     That is exactly how these two survived for months." This script was the thing
+#     restoring them, and it wins whenever it runs last.
+#   * The version string is a GitHub tag_name -- upstream data -- and was passed as
+#     the REPLACEMENT TEMPLATE of re.sub() while rewriting index.html. \\1 or \\g<0>
+#     in a tag was interpreted; a lone backslash raised re.error mid-rewrite.
+#
+# ASSERTING THE RULE, NOT AN ENUMERATION
+# --------------------------------------
+# Section 1 does not list the platform keys it expects. It asserts the invariant
+# "every key in the result is a key of _PLATFORM_PATTERNS, and a platform is true
+# iff some attached asset is a build for that OS and no other" over a table of asset
+# names. A fourth platform added tomorrow is covered without editing a list.
+#
+# Nothing here is compared against a moving value. The deployed version is READ from
+# the fixture the test built, never pinned to a literal -- test_ingest_scores.py
+# pinned v0.11.0 against a rule about the deployed version and stayed red for three
+# releases.
+#
+# HOW IT ISOLATES
+# ---------------
+# fetch_github_data is replaced with a stub and DATA_DIR is redirected into a temp
+# dir for every case. No test issues an HTTP request or touches public/.
+#
+# Run:  python scripts/test-update-version-info.py     (exit 0 = pass)
+"""
+
+import importlib.util
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "update_version_info", ROOT / "scripts" / "update-version-info.py")
+uvi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(uvi)
+
+failures = []
+
+
+def check(cond, msg):
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+class Sandbox:
+    """Redirect DATA_DIR into a temp dir and stub the GitHub API.
+
+    `api` maps an endpoint substring -> payload. A missing entry means the fetch
+    failed, which is how every refusal path below is forced.
+    """
+
+    def __init__(self, api=None, version_json=None, status_json=None):
+        self.api = api or {}
+        self.version_json = version_json
+        self.status_json = status_json
+
+    def __enter__(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self._saved_dir = uvi.DATA_DIR
+        self._saved_fetch = uvi.fetch_github_data
+        uvi.DATA_DIR = str(self.tmp)
+        if self.version_json is not None:
+            (self.tmp / "version.json").write_text(
+                json.dumps(self.version_json), encoding="utf-8")
+        if self.status_json is not None:
+            (self.tmp / "status.json").write_text(
+                json.dumps(self.status_json), encoding="utf-8")
+
+        api = self.api
+        uvi.fetch_github_data = lambda endpoint: next(
+            (v for k, v in api.items() if k in endpoint), None)
+        return self
+
+    def __exit__(self, *a):
+        uvi.DATA_DIR = self._saved_dir
+        uvi.fetch_github_data = self._saved_fetch
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        return False
+
+    def read(self, name):
+        p = self.tmp / name
+        return json.loads(p.read_text(encoding="utf-8")) if p.exists() else None
+
+
+def quiet(fn, *a, **k):
+    """Call fn, swallowing its stdout; return (result_or_exception, output)."""
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            return fn(*a, **k), buf.getvalue()
+    except Exception as exc:  # noqa: BLE001 - the exception IS the assertion
+        return exc, buf.getvalue()
+
+
+RELEASE = {
+    "tag_name": "v9.9.9", "name": "P(Doom) v9.9.9",
+    "published_at": "2030-01-02T03:04:05Z",
+    "html_url": "https://github.com/PipFoweraker/pdoom1/releases/tag/v9.9.9",
+    "body": "notes",
+    "assets": [{"name": "PDoom-v9.9.9-windows.zip"}],
+}
+STATS = {"stargazers_count": 8, "forks_count": 1,
+         "open_issues_count": 174, "updated_at": "2030-01-01T00:00:00Z"}
+FULL_API = {"/releases/latest": RELEASE, "/repos/PipFoweraker/pdoom1": STATS}
+
+
+# =========================================================================== 1
+print("\n1. platforms is DERIVED from attached assets, never asserted")
+
+# name -> the set of platforms that name may legitimately claim.
+# The rule under test: an asset counts for an OS iff it is a downloadable build AND
+# no OTHER OS is named in the filename. Architecture hints never outvote an OS name.
+CASES = [
+    ("PDoom-v0.13.0-windows.zip",        {"windows"}),
+    ("PDoom.exe",                        {"windows"}),          # v0.13.1 dropped "windows"
+    ("PDoom-v0.13.1-macos.dmg",          {"macos"}),
+    ("PDoom-v0.13.1-macos-x86_64.dmg",   {"macos"}),            # THE BUG: not linux too
+    ("PDoom-osx-x86_64.zip",             {"macos"}),
+    ("PDoom-windows-x86_64.zip",         {"windows"}),
+    ("PDoom-v0.13.1-linux.tar.gz",       {"linux"}),
+    ("PDoom.x86_64",                     {"linux"}),            # Godot linux export
+    ("PDoom-v0.13.1.AppImage",           {"linux"}),
+    ("README-windows.md",                set()),                # not a build
+    ("checksums.txt",                    set()),
+    ("Source code (zip)",                set()),
+    ("PDoom-windows-and-linux.zip",      {"windows", "linux"}),  # genuinely ambiguous
+]
+
+for name, expected in CASES:
+    got = uvi.derive_platforms([{"name": name}])
+    check(set(uvi._PLATFORM_PATTERNS) == set(got),
+          f"result covers exactly the declared platform keys for {name!r}")
+    actual = {k for k, v in got.items() if v}
+    check(actual == expected,
+          f"{name!r} -> {sorted(actual)} (expected {sorted(expected)})")
+
+check(all(v is False for v in uvi.derive_platforms([]).values()),
+      "no assets -> every platform False (only ever written on a FRESH fetch)")
+check(all(v is False for v in uvi.derive_platforms(None).values()),
+      "None assets -> every platform False, no crash")
+
+combined = uvi.derive_platforms(
+    [{"name": "PDoom.exe"}, {"name": "PDoom-linux.tar.gz"}])
+check(combined == {"windows": True, "macos": False, "linux": True},
+      "several assets union correctly, and an ABSENT platform stays False")
+
+
+# =========================================================================== 2
+print("\n2. FORCED FAILURE: a failed release lookup never invents a version")
+
+with Sandbox(api={}) as sb:  # nothing on disk, nothing from the API
+    err, _ = quiet(uvi.get_latest_release)
+    check(isinstance(err, RuntimeError), f"raises rather than guessing (got {type(err).__name__})")
+    check("Refusing" in str(err), "says it is refusing, in those words")
+    check(sb.read("version.json") is None, "wrote nothing")
+
+# The version literal in the fixture is arbitrary and local to this test. The RULE
+# is "whatever was already on disk comes back unchanged", so it is read, not pinned.
+PRIOR = {"latest_release": {"version": "v1.2.3", "html_url": "https://x/tag/v1.2.3",
+                            "platforms": {"windows": True, "macos": False, "linux": False}},
+         "repository_stats": {"stars": 4, "forks": 0, "open_issues": 9,
+                              "last_updated": "2029-01-01T00:00:00Z"},
+         "game_stats": {"baseline_doom_percent": None, "frontier_labs_count": 5,
+                        "strategic_possibilities": None,
+                        "pending": {"baseline_doom_percent": {"status": "not yet measured"}}}}
+
+with Sandbox(api={}, version_json=PRIOR) as sb:
+    got, out = quiet(uvi.get_latest_release)
+    check(got == PRIOR["latest_release"],
+          "a transient API failure preserves the last known-good release verbatim")
+    check(got["platforms"] == PRIOR["latest_release"]["platforms"],
+          "THE BIG ONE: platforms is PRESERVED, not recomputed to all-False from an "
+          "empty asset list -- all-False would read as 'no build ships anywhere'")
+    check("preserving" in out.lower(), "says out loud that it preserved rather than fetched")
+
+
+# =========================================================================== 3
+print("\n3. FORCED FAILURE: zeroes are a claim, and are refused")
+
+with Sandbox(api={}) as sb:
+    err, _ = quiet(uvi.get_repo_stats)
+    check(isinstance(err, RuntimeError), "raises when stats cannot be fetched and none exist")
+    check("zeroes" in str(err), "names the specific lie it is refusing to tell")
+
+with Sandbox(api={}, version_json=PRIOR) as sb:
+    got, _ = quiet(uvi.get_repo_stats)
+    check(got == PRIOR["repository_stats"], "otherwise preserves the last known-good stats")
+    check(got["stars"] != 0, "never substitutes 0 for 'unknown'")
+
+
+# =========================================================================== 4
+print("\n4. game_stats is not this script's to invent")
+
+with Sandbox(api=FULL_API, version_json=PRIOR) as sb:
+    _, _ = quiet(uvi.update_version_data)
+    wrote = sb.read("version.json")
+    check(wrote["game_stats"] == PRIOR["game_stats"],
+          "the calculator's derived game_stats survives a version update untouched")
+    check(wrote["game_stats"]["baseline_doom_percent"] is None,
+          "REGRESSION: an honest null is NOT overwritten with the literal 23")
+    check("pending" in wrote["game_stats"],
+          "the 'not yet measured' explanation survives too -- the reader keeps the reason")
+
+with Sandbox(api=FULL_API) as sb:  # no version.json at all
+    _, _ = quiet(uvi.update_version_data)
+    wrote = sb.read("version.json")
+    check("game_stats" not in wrote,
+          "with nothing derived yet, the key is OMITTED -- absence is honest, a "
+          "number would be a fiction")
+
+# The rule, stated as a scan rather than a list of three field names: no numeric
+# literal in this module may end up under game_stats. Someone re-adding a stub
+# fails here without anyone remembering these particular keys.
+src = (ROOT / "scripts" / "update-version-info.py").read_text(encoding="utf-8").replace("\r\n", "\n")
+body = src.split("def update_version_data", 1)[1].split("\ndef ", 1)[0]
+assigned = re.findall(r"^\s*'(\w+)':\s*(-?\d[\d_.]*)\s*,?\s*$", body, re.M)
+check(not assigned,
+      f"update_version_data() assigns no numeric literal to any key (found {assigned})")
+
+
+# =========================================================================== 5
+print("\n5. status.json is not clobbered by a fallback release")
+
+STATUS = {"game": {"latestRelease": {"version": "v1.2.3", "date": "2029-01-01",
+                                     "downloadUrl": "https://real/download"},
+                   "development": {"progress": "v1.2.3 released"}},
+          "website": {"version": "3.0.0"}}
+
+# A preserved release keeps its real html_url, so force the genuine fallback shape:
+# a release dict whose url is NOT a /releases/tag/ link.
+with Sandbox(api={}, status_json=STATUS) as sb:
+    _, out = quiet(uvi.sync_status_json,
+                   {"latest_release": {"version": "v0.0.0-guess", "html_url": ""}})
+    check(sb.read("status.json") == STATUS,
+          "a non-release URL leaves status.json byte-identical")
+    check("Skipping" in out, "says it skipped")
+
+with Sandbox(api=FULL_API, status_json=STATUS) as sb:
+    vd, _ = quiet(uvi.update_version_data)
+    _, _ = quiet(uvi.sync_status_json, vd)
+    st = sb.read("status.json")
+    # Read the version out of the fixture rather than repeating a literal.
+    expected_version = RELEASE["tag_name"]
+    check(st["game"]["latestRelease"]["version"] == expected_version,
+          "a real release DOES update status.json")
+    check(st["website"]["version"] == STATUS["website"]["version"],
+          "website.version is left alone -- that bump is a separate, deliberate act")
+    check(st["game"]["latestRelease"]["downloadUrl"] == "https://real/download",
+          "an existing downloadUrl is not replaced by the generic /releases/latest link")
+
+
+# =========================================================================== 6
+print("\n6. The tag name is upstream data, not code, when index.html is rewritten")
+
+INDEX = ('<!doctype html>\n<html><body>\n'
+         '<a class="dl">Download Latest Release</a>\n'
+         '<a class="dl2">Download v0.0.1</a>\n</body></html>\n')
+
+HOSTILE_TAGS = [
+    r"v1.0\g<0>",          # a re.sub group reference in the replacement template
+    "v1.0\\1",             # a backreference
+    "v1.0\\",              # a lone backslash -- used to raise re.error mid-rewrite
+    '"><script>alert(1)</script>',
+    "v1.0 & <b>bold</b>",
+]
+
+for tag in HOSTILE_TAGS:
+    with Sandbox() as sb:
+        idx = sb.tmp / "index.html"
+        idx.write_text(INDEX, encoding="utf-8", newline="")
+        saved = uvi.os.path.join
+        # update_download_links() builds its own path to public/index.html; point it
+        # at the temp copy instead of the real homepage.
+        uvi.os.path.join = lambda *p: str(idx) if p and p[-1] == "index.html" else saved(*p)
+        try:
+            res, _ = quiet(uvi.update_download_links, {"latest_release": {"version": tag}})
+        finally:
+            uvi.os.path.join = saved
+        out = open(idx, encoding="utf-8", newline="").read()
+        check(not isinstance(res, Exception),
+              f"no exception rewriting the homepage with tag {tag!r}: {res}")
+        check("<script>" not in out and "<b>" not in out,
+              f"tag {tag!r} cannot open an element on the front page")
+        check("Download Latest Release" not in out, f"the button text was replaced for {tag!r}")
+        # A replacement TEMPLATE would have expanded these into the matched text.
+        check("Download Latest Release (Latest)" not in out,
+              f"\\g<0> was not expanded as a group reference for {tag!r}")
+        check("\r\n" not in out, f"LF input stays LF after the rewrite ({tag!r})")
+
+# Idempotence: the cron runs this 4x a day against a file it already rewrote.
+with Sandbox() as sb:
+    idx = sb.tmp / "index.html"
+    idx.write_text(INDEX, encoding="utf-8", newline="")
+    saved = uvi.os.path.join
+    uvi.os.path.join = lambda *p: str(idx) if p and p[-1] == "index.html" else saved(*p)
+    try:
+        quiet(uvi.update_download_links, {"latest_release": {"version": "v9.9.9"}})
+        once = open(idx, encoding="utf-8", newline="").read()
+        quiet(uvi.update_download_links, {"latest_release": {"version": "v9.9.9"}})
+        twice = open(idx, encoding="utf-8", newline="").read()
+    finally:
+        uvi.os.path.join = saved
+    check(once == twice, "a second run on the same version changes nothing")
+    check(RELEASE["tag_name"] in once, "the version actually reached the button")
+
+
+# =========================================================================== 7
+print("\n7. A malformed API response is a failure, not a publish")
+
+for bad in ({}, {"assets": []}, {"tag_name": "", "name": ""}, {"body": "only notes"}):
+    with Sandbox(api={"/releases/latest": bad}) as sb:
+        err, _ = quiet(uvi.get_latest_release)
+        check(isinstance(err, RuntimeError),
+              f"a response with no usable tag is refused, not published: {bad}")
+
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S)")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("OK: update-version-info refuses rather than guessing, derives platforms from "
+      "real assets, and invents no game stats.")

--- a/scripts/update-version-info.py
+++ b/scripts/update-version-info.py
@@ -4,6 +4,7 @@ Updates version information from the pdoom1 game repository
 Fetches latest release info and updates website data files
 """
 
+import html
 import json
 import os
 import re
@@ -60,10 +61,49 @@ _PLATFORM_PATTERNS = {
     # '\.exe$' catches a bare PDoom.exe (v0.13.1+ dropped "windows" from the name);
     # 'win' still catches PDoom-...-windows.zip (v0.13.0 style).
     'windows': re.compile(r'win|\.exe$', re.I),
-    'macos':   re.compile(r'mac|osx|darwin|\.app|\.dmg', re.I),
+    # '\.app(?![a-z])' not '\.app': the bare form also matches ".AppImage", so a
+    # Linux-only AppImage release published platforms.macos: true. Second false
+    # positive of the same kind as the x86_64 one below, in the field
+    # check-platform-claims.py trusts. The lookahead still allows "Game.app" and
+    # "Game.app.zip", which are the real macOS bundle shapes.
+    'macos':   re.compile(r'mac|osx|darwin|\.app(?![a-z])|\.dmg', re.I),
     'linux':   re.compile(r'linux|x86_64|\.appimage', re.I),
 }
 _BUILD_SUFFIX = re.compile(r'\.(zip|dmg|appimage|x86_64|exe|tar\.gz)$', re.I)
+
+# 'x86_64' is an ARCHITECTURE, not an operating system. It is in the linux pattern
+# because a Godot Linux export is literally named `PDoom.x86_64`, but it also appears
+# in Intel Mac and Windows build names -- `PDoom-<version>-macos-x86_64.dmg` matched
+# BOTH macos and linux, so one Mac-only release would have published
+# `platforms.linux: true`. check-platform-claims.py trusts this field, so that is not
+# a cosmetic slip: it is the honesty guard being handed a false positive, which is
+# the exact class the field was introduced to prevent.
+#
+# So an asset is attributed to a platform only if no OTHER platform claims it by
+# name. Explicit OS names always win over an architecture hint.
+_EXPLICIT_OS = {
+    'windows': re.compile(r'win|\.exe$', re.I),
+    # '\.app(?![a-z])' not '\.app': the bare form also matches ".AppImage", so a
+    # Linux-only AppImage release published platforms.macos: true. Second false
+    # positive of the same kind as the x86_64 one below, in the field
+    # check-platform-claims.py trusts. The lookahead still allows "Game.app" and
+    # "Game.app.zip", which are the real macOS bundle shapes.
+    'macos':   re.compile(r'mac|osx|darwin|\.app(?![a-z])|\.dmg', re.I),
+    'linux':   re.compile(r'linux|\.appimage', re.I),
+}
+
+
+def _attributable(name: str, os_key: str) -> bool:
+    """True if `name` is a build for `os_key` and for no other OS."""
+    if not (_PLATFORM_PATTERNS[os_key].search(name) and _BUILD_SUFFIX.search(name)):
+        return False
+    others = [k for k in _EXPLICIT_OS if k != os_key and _EXPLICIT_OS[k].search(name)]
+    if not others:
+        return True
+    # Another OS is named explicitly. Yield unless THIS platform is named too --
+    # a genuinely ambiguous name (e.g. "windows-and-linux.zip") is not something to
+    # silently resolve, and counting it for both is the honest reading.
+    return bool(_EXPLICIT_OS[os_key].search(name))
 
 
 def derive_platforms(assets: List[Dict[str, Any]]) -> Dict[str, bool]:
@@ -78,8 +118,8 @@ def derive_platforms(assets: List[Dict[str, Any]]) -> Dict[str, bool]:
     than write all-False. See get_latest_release()."""
     names = [a.get('name', '') for a in (assets or [])]
     return {
-        os_key: any(pat.search(n) and _BUILD_SUFFIX.search(n) for n in names)
-        for os_key, pat in _PLATFORM_PATTERNS.items()
+        os_key: any(_attributable(n, os_key) for n in names)
+        for os_key in _PLATFORM_PATTERNS
     }
 
 
@@ -148,14 +188,23 @@ def update_version_data() -> Dict[str, Any]:
         'latest_release': release,
         'repository_stats': stats,
         'last_updated': datetime.now().isoformat(),
-        'game_stats': {
-            # These will be calculated separately or stubbed for now
-            'baseline_doom_percent': 23,
-            'frontier_labs_count': 7,
-            'strategic_possibilities': 10000
-        }
     }
-    
+
+    # game_stats is NOT this script's to write. It used to hardcode
+    # baseline_doom_percent: 23, frontier_labs_count: 7, strategic_possibilities: 10000
+    # -- three invented numbers published under a confident label, which is the exact
+    # thing calculate-game-stats.py was rewritten to stop ("DO NOT restore a literal
+    # here 'temporarily'. That is exactly how these two survived for months.").
+    # Because both scripts write the same file, re-asserting the literals here undid
+    # that fix on every run where this script happened to go last: the honest `null`
+    # and its `pending` explanation were silently replaced with a number.
+    # Carry forward whatever the calculator last derived; if it has never run, omit
+    # the key entirely so a reader sees nothing rather than a fiction.
+    existing_stats = read_existing_version_json().get('game_stats')
+    if existing_stats:
+        version_data['game_stats'] = existing_stats
+
+
     # Ensure data directory exists
     os.makedirs(DATA_DIR, exist_ok=True)
     
@@ -223,26 +272,29 @@ def update_download_links(version_data: Dict[str, Any]) -> None:
         print('index.html not found, skipping link updates')
         return
     
-    with open(index_file, 'r', encoding='utf-8') as f:
+    # newline='' so an existing CRLF file round-trips unchanged. Without it, a
+    # Windows run rewrites every line ending in index.html and the diff is the whole
+    # file -- the same trap sync-events.py pins with newline='\n'.
+    with open(index_file, 'r', encoding='utf-8', newline='') as f:
         content = f.read()
-    
+
     version = version_data['latest_release']['version']
-    
-    # Update download button text to show current version
-    content = re.sub(
-        r'Download Latest Release',
-        f'Download {version} (Latest)',
-        content
-    )
-    
-    # Update any hardcoded version references
-    content = re.sub(
-        r'Download v[\d\.]+',
-        f'Download {version}',
-        content
-    )
-    
-    with open(index_file, 'w', encoding='utf-8') as f:
+
+    # The version string is a GitHub tag_name -- upstream data, not ours. Two things
+    # follow, and the old code got both wrong:
+    #
+    #  1. In re.sub() the third argument is a REPLACEMENT TEMPLATE, not a literal.
+    #     A tag containing \1, \g<0> or a lone backslash was interpreted, and a bad
+    #     escape raised re.error, so a mistyped tag could rewrite or crash the
+    #     homepage. Passing a function makes the replacement literal by construction.
+    #  2. It lands in HTML, so it is escaped. A tag is not allowed to open an element
+    #     on the front page.
+    safe = html.escape(version, quote=True)
+
+    content = re.sub(r'Download Latest Release', lambda _m: f'Download {safe} (Latest)', content)
+    content = re.sub(r'Download v[\d\.]+', lambda _m: f'Download {safe}', content)
+
+    with open(index_file, 'w', encoding='utf-8', newline='') as f:
         f.write(content)
     
     print(f"✓ Updated download links to {version}")


### PR DESCRIPTION
## What this is

An audit found ~22 scripts that write reader-facing data or published HTML with **no test**. This covers the top three by blast radius, and fixes the live defects the tests exposed.

### The naive cross-reference overstates coverage

`test-orchestrator.py` and `test-integration.py` name five writers between them — `update-version-info.py`, `calculate-game-stats.py`, `health-check.py`, `verify-deployment.py`, `export-leaderboard-bridge.py`. Both only **shell out to each script against the live GitHub API, write into the real `public/` tree, and check the exit code**. Neither asserts a byte of output; a run that fetched garbage and published it passes both. `test-changelog-structure.py` asserts four committed files exist, which says nothing about the generator that wrote them. **No workflow runs any of the three.**

Also found: **`check-published-emails.py` is run by no workflow.** So `redact_pii()` inside `sync-events.py` is the only PII guard that actually executes.

## Ranking (blast radius = pages × silent-failure probability × time-to-notice)

| # | Script | What breaks | Who notices | How long unnoticed |
|---|---|---|---|---|
| **1** | `sync/sync-events.py` | ~1,194 published pages + `events.json`; daily cron **commits**. Owns `redact_pii()`, the only executing PII guard | Nobody. Downstream re-check is unwired | **Indefinitely** |
| **2** | `update-version-info.py` | `version.json` + `status.json` + rewrites `public/index.html`; two 6-hourly crons **commit**. Feeds download buttons, `/game-changelog/`, and `check-platform-claims.py` | A wrong version: Pip, ~1 day. A fabricated `game_stats`: nobody | Days → **indefinitely** |
| **3** | `health-check.py` | `public/data/health-check-results.json`, 6-hourly cron **commits**; publishes maintainer's absolute paths | Nobody reads it | **Indefinitely** (already happened once) |
| 4 | `build-blog-index.py` / `generate-feeds.py` | blog index + RSS/Atom | Subscribers; dead links can't be un-sent | Days |
| 5 | `log-automation-run.py` | `public/monitoring/*`; **fails open** on every write, copies arbitrary `--key value` into published JSON | Nobody | Indefinitely |
| 6 | `generate-sitemap.js` | 2,247 URLs; not committed, generated at deploy | Search Console | Weeks |
| 7 | `stamp-league-epoch.py` | ~45 weekly archive files | `--check` (self-check, not a test) | Weeks |
| 8 | `sync/merge-alignment-events.py` | writes **upstream** `all_events.json`, which fans out to ~2,194 pages; **no PII redaction** on that path | Nobody | Indefinitely |
| 9 | `update-game-status.js` | `status.json`; **no safety property at all**, invents a website version bump each run | Nobody | Indefinitely |
| 10 | `validate_data.py`, `snapshot-copy.py`, `check-stale-facts.py` | the guards themselves — untested, so "green" is equally consistent with "never fires" | — | — |

Remaining untested writers, lower blast radius: `calculate-game-stats.py`, `generate-metabolism.py`, `sync/sync-keybinds.py`, `sync/sync-game-icons.py`, `prepare-weekly-deployment.py`, `prepare-syndication.py`, `post-syndication.py`, `generate_roadmap_from_milestones.js`, `generate_pdoom1_issues_md.js`, `update-version-info.js`, `check-board-liveness.py`, `board_liveness_summary.py`, `game-integration.py`, `verify-deployment.py`, `extract_analytics.py`.

## Live defects the tests exposed (all now fixed)

**In the shipped events corpus, on production:**
- `arxiv_73643a60bb86bf2f` — description contains `<<number to be assigned>>`, parsed as a tag start in `<p class="description">` and inside `<meta name="description" content="...">`
- `arxiv_aa8c44de8cf70353` — a `"` inside the first 155 characters **terminated the meta content attribute early** and turned the rest of the sentence into bogus tag attributes

The generator escaped nothing. arXiv accepts uploads from anyone, so "the data is first-party" is not true of the *contents* of these fields.

**In `update-version-info.py`:**
- `.AppImage` contains `.app` → a Linux-only release published `platforms.macos: true`
- `x86_64` is an *architecture* → `PDoom-<version>-macos-x86_64.dmg` published `platforms.linux: true`
- Both fed `check-platform-claims.py` — the guard whose entire job is stopping a false platform claim — a false positive
- `game_stats` was hardcoded to `{23, 7, 10000}` every run, overwriting the honest `null` + `"not yet measured"` block `calculate-game-stats.py` writes to the same file with the comment *"DO NOT restore a literal here 'temporarily'. That is exactly how these two survived for months."* **This script was the thing restoring them.**
- `tag_name` was passed as `re.sub()`'s **replacement template**, so `\1` / `\g<0>` in a tag expanded and a lone backslash raised `re.error` mid-rewrite of the homepage

**In `health-check.py`:**
- Four `except Exception as e:` handlers interpolated the raw exception string. `str(OSError)` embeds the absolute path it failed on — re-publishing the exact class of string `scrub()` exists to remove, through the guard, on a cron, to a public URL
- `_ABS_PATH` was **inert against its own founding case**: `[^\s'"]+` stops at a space, so `C:\Users\<name>\Documents\A Local Code\...` — the path CLAUDE.md quotes as the leak — scrubbed to `A Local Code\pdoom1-website\public\data\version.json`

## Evidence each test can fail

Every guard was broken on purpose and observed failing, then restored.

| Break | Result |
|---|---|
| Remove `escape_event_for_html()` from the generator | **9 failures**, incl. both named production regressions and `evt_html.html :: raw script tag` in the end-to-end scan |
| Rebuild `redact_pii()` as a four-field list (the plausible "optimisation") | **5 failures**, incl. `THE BIG ONE: an unknown field added upstream tomorrow is redacted today` and `events.json :: address` |
| Restore the hardcoded `game_stats` literals | **5 failures**, incl. the source scan: `found [('baseline_doom_percent','23'),('frontier_labs_count','7'),('strategic_possibilities','10000')]` |
| Revert `re.sub` to a replacement template | **8 failures**: `invalid group reference 1`, `bad escape (end of pattern)`, and two `cannot open an element on the front page` |
| Remove chokepoint scrubbing from `log_result()` | **21 failures**, incl. a real leak in the end-to-end run: `Permission denied: 'C:\Users\gday\AppData\Local\Temp\...'` |

Before the `_ABS_PATH` fix, the space-containing-path assertion failed on its own.

## Rules, not enumerations

- **sync-events**: renders the same event twice — benign text in every string slot, then a hostile payload in every string slot — and requires an **identical tag-and-attribute skeleton** (`HTMLParser`). No field is named. A new interpolation that forgets to escape fails on the day it is written. Also asserts, as a rule, that **every attribute in the template is double-quoted**, which is what makes leaving apostrophes unescaped sound.
- **redact_pii / escape_event_for_html**: both fed a field that does not exist in today's schema.
- **health-check**: scans **every string anywhere in the published JSON** against `_ABS_PATH`, not four named messages.
- **update-version-info**: a source scan rejects any numeric literal assigned in `update_version_data()`; the platform table asserts "result keys == declared platform keys" rather than listing three.

## No moving values compared to literals

Fixture versions are synthetic (`v9.9.9`, `v1.2.3`) and every rule reads the value **out of the fixture it built**. Nothing pins a date, a release, a file count or a success percentage. The three files join `check-stale-facts.py`'s existing `SKIP_FILES` for the same reason `board-liveness.json` is there — their version strings are inputs, not claims. **Verified: 214 findings before and after.**

## Isolation

Every case builds inputs in `tempfile.mkdtemp()` and redirects the module's path constants there. No committed fixture is mutated, no test touches `public/`, and **nothing issues an HTTP request** — `fetch_github_data` is stubbed, and the events sync is handed a fake `pdoom-data` tree.

## Review note: diff size on the next sync

The escaping fix means the next events sync rewrites all 1,194 pages, but the diff is **one line each** — a bare `&` in the `mailto:` href becoming `&amp;` (correct HTML) — plus real escaping on the handful of events with markup in their text. `esc()` deliberately does **not** escape apostrophes, precisely so that diff stays reviewable. Verified: all 1,194 real events regenerate with zero errors.

## Test results

All three pass; 171 assertions total. Every other test in CLAUDE.md's suite is unchanged from the base branch — the seven that fail (`validate_data`, `check-stale-facts`, `check-published-emails`, `snapshot-copy --check`, `generate-metabolism --check`, `test-header-consistency`, `check-encoding-safety`) fail **identically on the base commit**; confirmed by stashing. `generate-metabolism.py` still builds cleanly, so no citation needle was broken by these edits.

## Not done

- Tests for ranks 4–10. `merge-alignment-events.py` is the one I would take next: it writes the **upstream** `all_events.json` that regenerates ~2,194 pages, applies **no PII redaction** on that path, and is run by no workflow — so the redaction fixed here can be undone from the other side.
- `check-published-emails.py` is still wired to no workflow. Wiring it to `content-honesty.yml` is a one-line change and would give the PII guard a second, independent check.
- `sync-events.py` still carries an encoding-safety waiver (`W1`, no stdout preamble — it uses a `win32` `TextIOWrapper` instead, which works but the checker doesn't recognise).
- `update-version-info.js` is an orphan duplicate writer of `version.json` that does **not** write `latest_release.platforms`. Left alone; deleting it is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
