### PR TITLE
data(league): record the w31 blessing; guard stops pinning pre-ceremony state

### DIFF
--- a/public/data/ladder-epochs.json
+++ b/public/data/ladder-epochs.json
@@ -4,7 +4,11 @@
   "board_key": {
     "shape": "(seed, L<n>)",
     "example": "(weekly-2026-w30, L2)",
-    "is_not": ["v0.13.2", "L3.0", "(seed, game_version)"],
+    "is_not": [
+      "v0.13.2",
+      "L3.0",
+      "(seed, game_version)"
+    ],
     "note": "The client sends the LADDER epoch, not the build version: GameConfig.get_board_version() returns \"L\" + LADDER_VERSION. Local board file leaderboard_<seed>__L3.json; remote POST body field version=L3; remote GET query version=L3. The build version never touches the board key again -- that is the whole point of the build-vs-ladder split, so a cosmetic patch bump can never again fork a board.",
     "source": "pdoom1 on pdoom1-website#151, comment 2026-07-28T23:13Z"
   },
@@ -15,13 +19,16 @@
     "boundary_rule": "A league week is anomalous iff it STARTS before boundary_local. The boundary is the Hobart-midnight anchor of the first L3 week, NOT board_opens_local -- see boundary_why.",
     "boundary_why": "The unit being flagged is a whole league week (Fri 00:00 -> Thu 23:59:59 Australia/Hobart). Cutting at board_opens_local instead would put the boundary 17 hours inside the first L3 week, so that week would start before its own boundary and be flagged pre-L3 -- and a week half under L2 rules and half under L3 would be exactly the cross-epoch blend the ladder split exists to prevent. The board-open time is therefore recorded separately and stated on the page, so nothing claims the board was accepting scores from midnight.",
     "board_opens_local": "2026-07-31T17:00:00+10:00",
-    "board_opens_confirmed": false,
+    "board_opens_confirmed": true,
     "board_opens_note": "Approximate, from pdoom1: 'Fri ~1700: board opens', with the seed blessed at a ceremony ~1645 AEST the same day. Treat as approximate until the game side confirms.",
-    "seed": null,
-    "seed_status": "unblessed",
-    "seed_note": "The L3 seed is drawn and spoken at the ceremony ~1645 AEST Fri 2026-07-31 and posted by the game side. pdoom1: 'Please do not hardcode it anywhere before then.' This field stays null until a human blesses it into docs/LEAGUE_SEED_LEDGER.md and copies it here. Anything the website derives in the meantime is a placeholder and is marked unblessed in seed_provenance.",
+    "seed": "weekly-2026-w31",
+    "seed_status": "blessed",
+    "seed_note": "ROLLED, not blessed in place. The previous seed weekly-2026-w30 carried three Gate 4 proving runs; Pip ruled they must not open the league, and since the site does not filter a live board, the only honest exclusion was to open on a different seed. Those three runs are preserved as acknowledged history at public/leaderboard/data/preserved/2026-08-01-gate4-proving-runs/.",
     "reason_pre": "Opened before the L2 -> L3 ladder fork. L3 removed the action-point pool entirely in favour of an attention economy, added office lease and lock-in, four-way founder hours, six previously-inert upgrades and a quirk rebalance. Scores set under the earlier rules are not comparable to scores set after them -- that non-comparability is the whole reason the ladder version is a separate key. Retained as a record of what the pipeline produced, NOT as a comparable competition result.",
-    "reason_post": "Opened on or after the L2 -> L3 ladder fork, on a board keyed (seed, L3), by a rollover anchored to Friday 00:00 Australia/Hobart whose run-time -> week mapping is pinned by scripts/test-weekly-league-boundary.py."
+    "reason_post": "Opened on or after the L2 -> L3 ladder fork, on a board keyed (seed, L3), by a rollover anchored to Friday 00:00 Australia/Hobart whose run-time -> week mapping is pinned by scripts/test-weekly-league-boundary.py.",
+    "seed_blessed_on": "2026-07-31",
+    "seed_blessed_by": "Pip",
+    "seed_evidence": "Confirmed at ARTIFACT level, not from memory or an issue comment: v0.13.2:godot/autoload/game_config.gd:462 pins const FEATURED_SEED_OVERRIDE: String = \"weekly-2026-w31\". Read from the released tag (published 2026-07-31T07:53Z), which is the standard the ceremony checklist requires -- artifact beats intention. Pip confirmed all gates blessed the same evening. Per coordination/WALKPACK_2026-08-02, the release manifest is now the seed publication surface with weekly-2026-w31 canonical."
   },
   "epochs": [
     {

--- a/public/leaderboard/data/weekly/archive/index.json
+++ b/public/leaderboard/data/weekly/archive/index.json
@@ -1535,6 +1535,21 @@
       "players": [],
       "first_entry": null,
       "last_entry": null
+    },
+    {
+      "file": "2026-08-01-gate4-proving-runs/weekly-2026-w30__L3.json",
+      "captured": "2026-08-01-gate4-proving-runs",
+      "seed": "weekly-2026-w30",
+      "version": "L3",
+      "key_kind": "ladder",
+      "board_key": "(weekly-2026-w30, L3)",
+      "entry_count": 3,
+      "players": [
+        "Applied AI Safety",
+        "Intelligent Agents Studies"
+      ],
+      "first_entry": "2026-07-30T08:32:01",
+      "last_entry": "2026-07-30T09:36:29"
     }
   ],
   "epochs": {
@@ -1551,7 +1566,7 @@
       "source": "pdoom1 on pdoom1-website#151, comment 2026-07-28T23:13Z"
     },
     "board_opens_local": "2026-07-31T17:00:00+10:00",
-    "board_opens_confirmed": false,
+    "board_opens_confirmed": true,
     "boundary_local": "2026-07-31T00:00:00+10:00",
     "boundary_tz": "Australia/Hobart",
     "boundary_utc": "2026-07-30T14:00:00Z",
@@ -1568,5 +1583,5 @@
       "reason": "Opened on or after the L2 -> L3 ladder fork, on a board keyed (seed, L3), by a rollover anchored to Friday 00:00 Australia/Hobart whose run-time -> week mapping is pinned by scripts/test-weekly-league-boundary.py."
     }
   },
-  "last_updated": "2026-07-30T14:46:39.657713Z"
+  "last_updated": "2026-08-02T02:46:06.525304Z"
 }

--- a/public/leaderboard/data/weekly/current.json
+++ b/public/leaderboard/data/weekly/current.json
@@ -24,7 +24,7 @@
     "source": "pdoom1 on pdoom1-website#151, comment 2026-07-28T23:13Z",
     "board_opens_local": "2026-07-31T17:00:00+10:00",
     "board_opens_utc": "2026-07-31T07:00:00Z",
-    "board_opens_confirmed": false,
+    "board_opens_confirmed": true,
     "observed_defects": {
       "empty-shell": "zero entries. No shipped client ever submitted to this board key, so the week ran with no participants -- the record is a container, not a result.",
       "unblessed-seed": "the seed was derived website-side by weekly-league-manager.py and is not the blessed competitive key in docs/LEAGUE_SEED_LEDGER.md. No client ever POSTed under it."
@@ -76,7 +76,7 @@
       "source": "pdoom1 on pdoom1-website#151, comment 2026-07-28T23:13Z",
       "board_opens_local": "2026-07-31T17:00:00+10:00",
       "board_opens_utc": "2026-07-31T07:00:00Z",
-      "board_opens_confirmed": false
+      "board_opens_confirmed": true
     }
   },
   "entries": [],

--- a/scripts/print-doc.ps1
+++ b/scripts/print-doc.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+  Print an HTML file silently. No browser window, no PDF viewer window.
+
+.WHY
+  Pip works from paper during critical hours and does not want an Edge window opening
+  every time. Windows has no direct HTML-to-printer path, so this does it in two silent
+  hops:
+
+      Edge --headless=new  ->  a PDF in %TEMP%     (renders the @media print CSS)
+      SumatraPDF -silent   ->  the default printer (no viewer, exits when done)
+
+  Both are already installed on this machine. SumatraPDF is the piece that makes it
+  genuinely silent -- `Start-Process -Verb Print` flashes the associated app, which is
+  what we are avoiding.
+
+  Every page under public/_review/ is written print-first: black on white, 12.5pt serif
+  minimum (Pip has an unfilled glasses prescription and an earlier print came back too
+  small), and 6mm tick boxes that a pen can actually land in.
+
+.EXAMPLE
+  .\scripts\print-doc.ps1 runsheet-tonight
+  .\scripts\print-doc.ps1 ceremony-checklist
+  .\scripts\print-doc.ps1 -List
+  .\scripts\print-doc.ps1 walk-read -PdfOnly     # build the PDF, do not print
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Name,
+    [switch]$List,
+    [switch]$PdfOnly,
+    [string]$Printer,
+    # The system queue on this box is set to Letter, which is wrong for an AU user --
+    # coordination/PRINT_AND_PROCESS_REFERENCE says force the size per job rather than
+    # change Pip's queue default. Letter is 6mm narrower and 18mm shorter than A4, so a
+    # sheet laid out to @page{size:A4} gets scaled down -- which silently defeats the
+    # 12.5pt minimum the glasses prescription requires.
+    [string]$Paper = 'A4'
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$reviewDir = Join-Path $repo 'public\_review'
+
+if ($List -or -not $Name) {
+    Write-Host "Printable documents in public\_review\ :" -ForegroundColor Cyan
+    Get-ChildItem $reviewDir -Filter *.html | ForEach-Object {
+        "  {0,-24} {1,6:N0} KB   {2}" -f $_.BaseName, ($_.Length / 1KB), $_.LastWriteTime.ToString('HH:mm')
+    }
+    Write-Host "`nUsage:  .\scripts\print-doc.ps1 <name>" -ForegroundColor Cyan
+    return
+}
+
+# Accept a bare name, a filename, or a full path.
+$src = if (Test-Path $Name) { (Resolve-Path $Name).Path }
+       elseif (Test-Path (Join-Path $reviewDir $Name)) { Join-Path $reviewDir $Name }
+       # The concatenation MUST be parenthesised before Join-Path sees it, or PowerShell
+       # reads `+ '.html'` as a second positional argument and fails with
+       # "A positional parameter cannot be found that accepts argument '+'".
+       else { Join-Path $reviewDir (($Name -replace '\.html$', '') + '.html') }
+
+if (-not (Test-Path $src)) {
+    Write-Error "Not found: $src`nRun with -List to see what is available."
+}
+
+# --- locate the two tools -------------------------------------------------------
+$edge = @(
+    "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe",
+    "$env:ProgramFiles\Microsoft\Edge\Application\msedge.exe",
+    "$env:ProgramFiles\Google\Chrome\Application\chrome.exe",
+    "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe"
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+$sumatra = @(
+    "$env:LOCALAPPDATA\SumatraPDF\SumatraPDF.exe",
+    "$env:ProgramFiles\SumatraPDF\SumatraPDF.exe"
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+if (-not $edge) { Write-Error "No Edge or Chrome found -- needed to render HTML to PDF." }
+
+# --- hop 1: HTML -> PDF, headless ----------------------------------------------
+# -LeafBase is PowerShell 6+; this box runs Windows PowerShell 5.1, where it throws
+# "A parameter cannot be found that matches parameter name 'LeafBase'".
+$pdf = Join-Path $env:TEMP ([IO.Path]::GetFileNameWithoutExtension($src) + '.pdf')
+if (Test-Path $pdf) { Remove-Item $pdf -Force }
+
+$uri = 'file:///' + ($src -replace '\\', '/')
+# --no-pdf-header-footer drops the URL/date furniture Edge adds by default; the pages
+# carry their own dateline and it is not worth a line of the margin.
+# Start-Process, NOT the call operator. Edge writes harmless chatter to stderr, and in
+# Windows PowerShell 5.1 a native command's stderr becomes ErrorRecords -- which under
+# $ErrorActionPreference='Stop' aborts the script even though Edge exited 0 and wrote a
+# perfectly good PDF. Start-Process keeps stderr out of the error stream entirely.
+$args = @('--headless=new', '--disable-gpu', '--no-pdf-header-footer',
+          "--print-to-pdf=$pdf", $uri)
+Start-Process -FilePath $edge -ArgumentList $args -NoNewWindow -Wait -ErrorAction SilentlyContinue
+
+$deadline = (Get-Date).AddSeconds(25)
+while (-not (Test-Path $pdf) -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 400 }
+if (-not (Test-Path $pdf)) { Write-Error "Edge did not produce a PDF for $src" }
+
+"{0} -> PDF ({1:N0} KB)" -f (Split-Path $src -Leaf), ((Get-Item $pdf).Length / 1KB) | Write-Host
+
+if ($PdfOnly) {
+    Write-Host "PDF only, not printed: $pdf" -ForegroundColor Yellow
+    return
+}
+
+# --- hop 2: PDF -> printer, silent ----------------------------------------------
+$target = if ($Printer) { $Printer }
+          else { (Get-CimInstance Win32_Printer -Filter 'Default=True').Name }
+
+if (-not $sumatra) {
+    # Fallback still avoids a *browser* window, but the PDF handler may flash briefly.
+    Write-Warning "SumatraPDF not found -- falling back to the shell Print verb, which may flash a window."
+    Start-Process -FilePath $pdf -Verb PrintTo -ArgumentList "`"$target`"" -WindowStyle Hidden
+} else {
+    # -print-settings applies to THIS job only; it does not touch the queue default.
+    $settings = "paper=$Paper"
+    if ($Printer) { & $sumatra -print-to "$Printer" -print-settings $settings -silent -exit-when-done "$pdf" }
+    else          { & $sumatra -print-to-default    -print-settings $settings -silent -exit-when-done "$pdf" }
+}
+
+Start-Sleep -Seconds 2
+$queued = (Get-PrintJob -PrinterName $target -ErrorAction SilentlyContinue | Measure-Object).Count
+Write-Host ("sent to {0}  |  {1}" -f $target,
+    $(if ($queued -eq 0) { 'queue empty (spooled through)' } else { "$queued job(s) still queued" })
+) -ForegroundColor Green

--- a/scripts/test-weekly-league-boundary.py
+++ b/scripts/test-weekly-league-boundary.py
@@ -30,6 +30,7 @@ Run: python scripts/test-weekly-league-boundary.py
 """
 
 import importlib.util
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -344,8 +345,16 @@ if _opens is not None:
           _w32_start <= _opens <= _w32_end, True)
     check("the regularised stamp carries the open time",
           post["epoch"]["board_opens_local"], _opens.isoformat())
-    check("...and flags that the open time is not yet confirmed",
-          post["epoch"]["board_opens_confirmed"], False)
+    # This asserted `False` until 2026-08-02, i.e. it pinned the state the world happened
+    # to be in the day it was written. The flag legitimately flips to True the moment Pip
+    # confirms the open, so the assertion was a timer set to go red at the ceremony -- and
+    # it did. The RULE is that the stamp mirrors the contract rather than deciding for
+    # itself; which way the flag currently points is data, not a property of the code.
+    check("...and mirrors the contract's confirmed flag, whichever way it points",
+          post["epoch"]["board_opens_confirmed"],
+          bool(wlm.ladder_contract()["regularised_from"].get("board_opens_confirmed")))
+    check("...as a real bool, so a truthy string can never stand in for confirmation",
+          isinstance(post["epoch"]["board_opens_confirmed"], bool), True)
 check("a PRE-fork week does not claim a board-open time",
       "board_opens_local" in pre["epoch"], False)
 
@@ -362,20 +371,89 @@ check("board key shape is (seed, L<n>)", _contract["board_key"]["shape"], "(seed
 check("the shape explicitly excludes a build-version key",
       "v0.13.2" in _contract["board_key"]["is_not"], True)
 check("current ladder version", _cut["ladder_version"], "L3")
-check("the L3 seed is NOT set -- it is blessed at a ceremony on the day",
-      _cut["seed"], None)
-check("...and is labelled unblessed", _cut["seed_status"], "unblessed")
+# CORRECTED 2026-08-02. These three assertions used to read:
+#
+#     check("the L3 seed is NOT set", _cut["seed"], None)
+#     check("...and is labelled unblessed", _cut["seed_status"], "unblessed")
+#     check("with no blessed seed, the manager falls back", _sb["seed"], <placeholder>)
+#
+# Every one pinned a LITERAL against a value the ceremony is DESIGNED to move, so all
+# three went red the moment the ceremony succeeded -- the guard reporting the system
+# working as intended as a failure. Same defect as test_ingest_scores.py pinning v0.11.0
+# while testing "matches the DEPLOYED version". CLAUDE.md already names the rule ("never
+# assert a literal against a value that moves") and this file broke it anyway, which is
+# Pip's document-vs-mechanism point sitting in the repo: writing the lesson down did not
+# install it.
+#
+# The invariant that actually holds in BOTH states is the pairing: a seed is present if
+# and only if the status is blessed. Unblessed-with-a-seed is the genuinely dangerous
+# state -- a value sitting where code will read it as canonical that nobody has blessed.
+check("seed_status is one of the two legal values",
+      _cut.get("seed_status") in ("blessed", "unblessed"), True)
+check("a seed is present IFF the status is blessed",
+      bool(_cut.get("seed")), _cut.get("seed_status") == "blessed")
 
 # A derived seed must never be presented as the competitive one.
-_seed_block = wlm.seed_for_week("weekly_2026_W32_deadbeef")
-check("with no blessed seed, the manager falls back to its placeholder",
-      _seed_block["seed"], "weekly_2026_W32_deadbeef")
-check("...and marks it blessed: false", _seed_block["seed_provenance"]["blessed"], False)
+#
+# Testing this against the live file only ever exercised whichever state the ceremony
+# happened to be in -- so the BLESSED branch of seed_for_week() had never once been run by
+# a test, in either direction. Forcing both states covers both branches whatever the
+# ceremony is doing today or next Friday.
+import copy as _copy
+_saved_seed = list(wlm._CONTRACT_CACHE)
+try:
+    _unblessed = _copy.deepcopy(_contract)
+    _unblessed["regularised_from"]["seed"] = None
+    _unblessed["regularised_from"]["seed_status"] = "unblessed"
+    wlm._CONTRACT_CACHE[:] = [_unblessed]
+    _sb = wlm.seed_for_week("weekly_2026_W32_deadbeef")
+    check("with NO blessed seed, the manager falls back to the derived placeholder",
+          _sb["seed"], "weekly_2026_W32_deadbeef")
+    check("...and marks it blessed: false",
+          _sb["seed_provenance"]["blessed"], False)
+    check("...and names the state, so a reader is never left to infer it",
+          _sb["seed_provenance"]["seed_status"], "unblessed")
 
-# Ruling: nothing may hardcode Friday's probable seed before the game side posts
-# it. Grep the scripts and the published data for it -- a test is the only thing
-# that will still be enforcing this next week.
+    _blessed = _copy.deepcopy(_contract)
+    _blessed["regularised_from"]["seed"] = "weekly_2026_W99_blessed"
+    _blessed["regularised_from"]["seed_status"] = "blessed"
+    wlm._CONTRACT_CACHE[:] = [_blessed]
+    _sb = wlm.seed_for_week("weekly_2026_W32_deadbeef")
+    check("with a blessed seed, the manager returns the BLESSED one",
+          _sb["seed"], "weekly_2026_W99_blessed")
+    check("...and never the derived placeholder it was handed",
+          "deadbeef" in str(_sb["seed"]), False)
+    check("...and marks it blessed: true", _sb["seed_provenance"]["blessed"], True)
+    check("...and states the board key it implies",
+          _sb["seed_provenance"]["board_key"], "(weekly_2026_W99_blessed, L3)")
+finally:
+    wlm._CONTRACT_CACHE[:] = _saved_seed
+
+# Ruling: nothing may hardcode Friday's probable seed BEFORE the game side posts it.
+#
+# The words "before" and "probable" are the whole rule, and until 2026-08-02 this check
+# ignored both -- it grepped unconditionally, forever. That cost four false positives in
+# three days: a sibling test's fixture, a mirror of GitHub issue text, a generated health
+# report, and finally the ledger row recording the blessing itself. Each was
+# indistinguishable from a real leak until a human read it, and the last one fired because
+# the seed had been written down in exactly the place the ceremony says to write it.
+#
+# So the rule now reads the state it is about. Once `seed_status` is `blessed`, the seed is
+# canonical: it BELONGS in the ledger, in published-board.json, and in any health report
+# that names the live board. Enforcing "do not write it down" past that point is enforcing
+# the opposite of what we want.
+#
+# This is the shape Pip ruled on 2026-08-02: a check must take at least one output from
+# inside the system it is checking. This one now does.
 _probable = "weekly-" + "2026-w31"      # assembled so this file does not contain it
+try:
+    _epochs = json.loads(
+        (Path(__file__).parent.parent / "public" / "data" / "ladder-epochs.json")
+        .read_text(encoding="utf-8"))
+    _seed_status = (_epochs.get("regularised_from") or {}).get("seed_status")
+except (OSError, ValueError):
+    _seed_status = None      # unreadable -> assume unblessed, i.e. keep enforcing
+
 _leaks = []
 for _p in list((Path(__file__).parent).glob("*.py")) + \
         list((Path(__file__).parent.parent / "public" / "data").glob("*.json")):
@@ -409,8 +487,12 @@ for _p in list((Path(__file__).parent).glob("*.py")) + \
             _leaks.append(_p.name)
     except (UnicodeDecodeError, OSError):
         pass
-check("the unblessed L3 seed is hardcoded nowhere in scripts/ or public/data/",
-      _leaks, [])
+if _seed_status == "blessed":
+    check("seed is BLESSED, so the no-hardcoding rule no longer applies "
+          f"(found in {len(_leaks)} file(s), which is correct)", True, True)
+else:
+    check("the UNBLESSED seed is hardcoded nowhere in scripts/ or public/data/",
+          _leaks, [])
 
 # The offset written in the contract is checked against the real tz database,
 # not trusted. Prove the guard bites.


### PR DESCRIPTION
## What

Records the **2026-07-31 seed blessing** in `public/data/ladder-epochs.json` — `seed: weekly-2026-w31`, `seed_status: blessed`, `board_opens_confirmed: true` — and fixes the five guard assertions that went red *because* the ceremony succeeded.

## Evidence for the blessing

Artifact level, not memory and not an issue comment:

```
v0.13.2:godot/autoload/game_config.gd:462
  const FEATURED_SEED_OVERRIDE: String = "weekly-2026-w31"
```

Read from the released tag (published 2026-07-31T07:53Z). Artifact beats intention, which is the standard the ceremony checklist asks for.

The seed was **rolled, not blessed in place**. `weekly-2026-w30` carried three Gate 4 proving runs; the site does not filter a live board — removing entries is editing standings — so opening on a different seed was the only honest exclusion. Those runs are preserved as acknowledged history under `public/leaderboard/data/preserved/2026-08-01-gate4-proving-runs/`.

## The guard fix is the interesting half

Writing the blessing turned five assertions red. They were not wrong about the data; they pinned **literals against values the ceremony exists to move**:

```python
check("the L3 seed is NOT set", _cut["seed"], None)
check("...and is labelled unblessed", _cut["seed_status"], "unblessed")
check("...open time is not yet confirmed", ...["board_opens_confirmed"], False)
```

Each was a timer set to go red on success, and all five fired the moment the ceremony worked. Same defect as `test_ingest_scores.py` pinning `v0.11.0` while testing "matches the DEPLOYED version" — and CLAUDE.md already carries the rule, *"never assert a literal against a value that moves"*. This file broke it anyway. That is the document-vs-mechanism point sitting in the repo: writing the lesson down did not install it.

Replaced with the invariant that holds in **both** states:

```python
check("a seed is present IFF the status is blessed",
      bool(_cut.get("seed")), _cut.get("seed_status") == "blessed")
```

Unblessed-with-a-seed is the genuinely dangerous state — a value sitting where code reads it as canonical that nobody blessed.

**Forced it rather than trusting green.** Set `seed_status: unblessed` with the seed still present:

```
FAILED: 2/99
  - a seed is present IFF the status is blessed          got: True   want: False
  - the UNBLESSED seed is hardcoded nowhere              got: [2 files]  want: []
```

Fails the pairing check *and* correctly re-arms the no-hardcoding grep. Both directions of the conditional work.

Also:
- `board_opens_confirmed` now asserts the stamp **mirrors** the contract whichever way the flag points, plus that it is a real `bool` — so a truthy string can never stand in for confirmation.
- `seed_for_week()` is exercised in **both** states via `_CONTRACT_CACHE` instead of against the live file. The blessed branch had never once been executed by a test in either direction, because the live file was never in that state until yesterday.

**99/99, up from 88/93.**

## Also: `scripts/print-doc.ps1`

Committed rather than left on one disk. Silent HTML → printer with no window at any stage. Now forces `paper=A4` **per job** — the system queue is set to Letter, which is wrong for an AU user, and since Letter is 18mm shorter a sheet laid out to `@page{size:A4}` gets scaled *down*, silently defeating the 12.5pt minimum. Per job rather than changing the queue default, per coordination's print reference.

## Risk

Low. One data file recording a ruling already made, one test file that now passes in both ceremony states, one untracked script gaining version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)