### PR TITLE
fix(board): publisher silently dropped its write when main moved

### DIFF
--- a/.github/workflows/board-liveness.yml
+++ b/.github/workflows/board-liveness.yml
@@ -235,7 +235,36 @@ jobs:
             exit 0
           fi
           git commit -m "chore(board): record live score-API observation and publish the live board"
-          git push
+          # Push with rebase-and-retry. A bare `git push` LOSES THE OBSERVATION whenever a
+          # human merges anything between this job's checkout and its push: on 2026-08-02
+          # 21:08 it hit `! [rejected] main -> main (fetch first)` because three PRs landed
+          # that morning, so the run went red and the board was never republished.
+          #
+          # This job is the leaderboard's publisher, so a dropped write is not cosmetic --
+          # it means the site keeps serving the previous board until the next run, which is
+          # the exact "I played and I am not on the board" misreading the subsystem exists
+          # to prevent. It self-heals in <=6h, which is precisely what makes it easy to
+          # ignore: a red square that always goes green on its own trains people to stop
+          # reading it.
+          #
+          # --rebase --autostash rather than a merge: this job's commits are a linear record
+          # of observations, and a merge bubble in that history makes `git log` on the board
+          # files unreadable. Nothing else writes these three files, so a genuine content
+          # conflict is not expected -- if one occurs the rebase fails loudly rather than
+          # resolving it, which is correct.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "::notice::push rejected (attempt $attempt) -- main moved; rebasing onto it and retrying."
+            git pull --rebase --autostash origin main || {
+              echo "::error::rebase onto origin/main failed. NOT force-pushing -- a human must look."
+              exit 1
+            }
+          done
+          echo "::error::Could not push the board observation after 3 attempts. The published board is STALE until the next run."
+          exit 1
 
       # Only NEW loss is red. `epoch-unknown` and `unreachable` are genuine unknowns and
       # stay green (they are already in the job summary above); the archived anomaly is


### PR DESCRIPTION
## What happened

`board-liveness` failed at **2026-08-02T21:08**:

```
! [rejected]        main -> main (fetch first)
error: failed to push some refs
```

A bare `git push` losing a race against this morning's merges. The job had **already** probed the live score API and rebuilt `published-board.json` — then discarded both.

## Why it is worth a PR

This job is the **leaderboard's publisher**. A dropped write means pdoom1.com keeps serving the *previous* board until the next run — which is the "I played and I am not on the board" misreading the subsystem exists to prevent. Same failure as league night, arriving by a different route.

It self-heals within 6 hours. That is precisely what makes it corrosive: **a red square that always goes green on its own teaches everyone to stop reading it.** Blocking-and-true or advisory-and-labelled — this was neither.

## The fix

Push with rebase-and-retry, three attempts.

- `--rebase --autostash`, not merge: these commits are a linear record of observations; a merge bubble makes `git log` on the board files unreadable.
- Nothing else writes those three files, so a real content conflict is not expected. If one occurs, **the rebase fails loudly and a human looks** — it does not resolve it.
- **No force-push anywhere in that path.** Forcing here would overwrite someone else's board data, which is strictly worse than a red run.
- Final failure after 3 attempts is explicit: *"The published board is STALE until the next run."*

## Not fixed here

**Every other committing workflow in this repo does a bare `git push` too**, so they all share this race — they just lose less when they hit it. That is a separate sweep. This one went first because it publishes player-facing data.

## Verified

YAML parses (`jobs: guards, probe, alert, resolve`); `generate-metabolism.py --check` still green, so no cited line moved.

Not verified: the retry path firing in anger. It needs a genuine concurrent push to trigger, which I cannot manufacture on a runner without racing production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)