### PR TITLE
feat(blog): tables in the post renderer, and test what it actually supports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,9 +274,31 @@ Pip's stated top priority. Practically:
 ## Blog & feeds
 - Posts are `.md` in `public/blog/`, listed in `public/blog/index.json` (keys:
   filename, title, date, tags, summary, commit, featured). `public/blog/post.html`
-  renders client-side with a **very** limited markdown parser: links, images,
-  inline code, bold, italic. **No tables, no fenced code blocks, no headings.**
-  Anything else renders as raw text. Links go to `/blog/post.html?p=<file>`.
+  renders client-side with a small hand-written markdown parser. Links go to
+  `/blog/post.html?p=<file>`.
+- **CORRECTED 2026-08-03.** This file said the parser handled only "links, images,
+  inline code, bold, italic — **no tables, no fenced code blocks, no headings**".
+  That had been wrong since **cf38e315**, which replaced the parser: headings, fenced
+  code, lists, blockquotes and `hr` all already worked, and the note steered content
+  work away from constructs that were fine. Tables were the one true gap; they now
+  work too (2026-08-03). Supported set: `#`–`######`, `**bold**`, `*i*`/`_i_`,
+  `[link]()`, `![img]()`, `` `code` ``, ```` ``` ```` fences, `-`/`1.` lists,
+  `>` quotes, `---`, GitHub-style pipe tables.
+  **Still unsupported** (renders as literal text): nested lists, reference links,
+  footnotes, escaped pipes `\|` inside a table cell, and raw HTML — which is escaped
+  on purpose, not missing.
+  **Do not trust this paragraph over the test.** `scripts/test-blog-render.js` asserts
+  each construct against its output tag; that list is the source of truth, and it is
+  what should be edited when the parser changes. The stale bullet above survived
+  because nothing tested the positive direction — the test only asserted that tables
+  did *not* work.
+- **The renderer is a markdown → `innerHTML` path.** It uses the site's ONE escaper
+  (`public/assets/js/escape.js`, loaded by a plain blocking `<script src>`) plus
+  `isSafeUrl()` for link/image schemes — do **not** give this page its own escaper
+  again; it had one covering `& < >` and not quotes, while feeding `alt=""` and
+  `href=""`. `scripts/test-escaping.js` runs a hostile corpus through
+  `renderMarkdown()` and `escaping.yml` gates it. Table cells route through the same
+  `inline()` as a paragraph, so tables added no new sink.
 - `scripts/generate-feeds.py` emits `feed.xml` (RSS) and `atom.xml` from
   `index.json`; `generate-feeds.yml` keeps them current and verifies on PRs.
   Feeds are the **privacy-first** subscribe option — no account, no address, no
@@ -316,6 +338,7 @@ node    scripts/test-changelog-render.js  # /game-changelog/ derives         [co
 python  scripts/check-published-emails.py # no third party's address served  [content-honesty]
 python  scripts/snapshot-copy.py --check  # reader-facing prose drift        [content-honesty ADVISORY]
 python  scripts/generate-feeds.py --check # feeds in step with the blog      [generate-feeds]
+node    scripts/test-blog-render.js       # blog markdown -> the right tags  [generate-feeds]
 python  scripts/generate-metabolism.py --check # /metabolism/ in step        [metabolism-map]
 python  scripts/test-snapshot-plausible.py # analytics backup fails loudly   [content-honesty, snapshot-analytics]
 node    scripts/test-header-consistency.js # nav contract + emoji            [content-honesty ADVISORY]

--- a/public/blog/post.html
+++ b/public/blog/post.html
@@ -37,6 +37,11 @@
             margin: 0 0 1.2rem; border-bottom: 2px solid var(--border-color); padding-bottom: 0.8rem; }
         article h2 { color: var(--accent-primary); font-size: 1.4rem; margin: 2rem 0 0.8rem; }
         article h3 { color: var(--text-primary); font-size: 1.15rem; margin: 1.6rem 0 0.6rem; }
+        /* h4-h6 were EMITTED by the renderer but had no rule, so a #### heading was
+           visually indistinguishable from body text -- a structural promise the page
+           did not keep. */
+        article h4, article h5, article h6 { color: var(--text-primary); font-size: 1rem;
+            margin: 1.3rem 0 0.5rem; text-transform: uppercase; letter-spacing: 0.04em; }
         article p { margin: 0 0 1rem; color: var(--text-secondary); }
         article a { color: var(--accent-secondary); }
         article strong { color: var(--text-primary); }
@@ -52,6 +57,13 @@
         article blockquote { border-left: 3px solid var(--accent-primary); margin: 0 0 1rem;
             padding: 0.2rem 0 0.2rem 1rem; color: var(--text-muted); font-style: italic; }
         article hr { border: none; border-top: 1px solid var(--border-color); margin: 1.6rem 0; }
+        /* The WRAPPER scrolls, not the table -- a wide table must never make the whole
+           page scroll sideways on a phone. */
+        .table-wrap { overflow-x: auto; margin: 0 0 1rem; }
+        article table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+        article th, article td { border: 1px solid var(--border-color);
+            padding: 0.45rem 0.7rem; text-align: left; color: var(--text-secondary); }
+        article th { color: var(--text-primary); background: var(--bg-tertiary); }
         .post-error { color: var(--accent-secondary); text-align: center; padding: 3rem 1rem; }
     </style>
 	<!-- The site's ONE HTML escaper (escapeHTML / safeUrl / toNumber). Deliberately a
@@ -135,6 +147,37 @@
                 }
                 const h = line.match(/^(#{1,6})\s+(.*)$/);
                 if (h) { flushPara(); closeList(); const n = h[1].length; out.push('<h' + n + '>' + inline(h[2]) + '</h' + n + '>'); i++; continue; }
+                // GitHub-style pipe table (added 2026-08-03; before that a table shipped
+                // its literal pipe characters at the reader).
+                //
+                // The DELIMITER ROW is what makes a table a table, and requiring it is the
+                // whole safety of this rule: several existing posts contain a `|` in prose
+                // and in shell pipelines, and treating those as tables would silently
+                // restructure published pages. So the next line must consist of nothing but
+                // pipes, dashes, colons and spaces, AND contain at least one of each of `|`
+                // and `-`. Alignment colons are accepted and ignored -- honouring them would
+                // mean a style="" attribute built from post text, and this page has no
+                // business generating one.
+                //
+                // Every cell goes through inline(), so cell content is escaped by the site's
+                // one escaper on exactly the same path as a paragraph. There is no second
+                // sink here. Not supported, deliberately: escaped pipes (\|) inside a cell.
+                if (line.indexOf('|') !== -1 && i + 1 < lines.length
+                    && lines[i + 1].indexOf('|') !== -1 && /-/.test(lines[i + 1])
+                    && /^[\s|:-]+$/.test(lines[i + 1])) {
+                    flushPara(); closeList();
+                    const cells = (s) => s.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|').map((c) => c.trim());
+                    const head = cells(line);
+                    i += 2;
+                    const body = [];
+                    while (i < lines.length && lines[i].indexOf('|') !== -1 && !/^\s*$/.test(lines[i])) { body.push(cells(lines[i])); i++; }
+                    out.push('<div class="table-wrap"><table><thead><tr>'
+                        + head.map((c) => '<th>' + inline(c) + '</th>').join('')
+                        + '</tr></thead><tbody>'
+                        + body.map((r) => '<tr>' + r.map((c) => '<td>' + inline(c) + '</td>').join('') + '</tr>').join('')
+                        + '</tbody></table></div>');
+                    continue;
+                }
                 if (/^\s*(---+|\*\*\*+)\s*$/.test(line)) { flushPara(); closeList(); out.push('<hr>'); i++; continue; }
                 const bq = line.match(/^>\s?(.*)$/);
                 if (bq) { flushPara(); closeList(); out.push('<blockquote>' + inline(bq[1]) + '</blockquote>'); i++; continue; }

--- a/scripts/test-blog-render.js
+++ b/scripts/test-blog-render.js
@@ -87,10 +87,110 @@ if (orphans.length) {
               (orphans.length > 3 ? ', ...' : ''));
 }
 
-console.log('\nconstructs the renderer cannot handle (would ship as raw text)');
+// ---------------------------------------------------------------------------
+// WHAT THE RENDERER SUPPORTS, ASSERTED CONSTRUCT BY CONSTRUCT
+// ---------------------------------------------------------------------------
+// Added 2026-08-03. Until then this file tested front-matter stripping and one
+// NEGATIVE fact (tables unsupported) -- nothing asserted that `##` produces an <h2>.
+// CLAUDE.md meanwhile described the parser as handling "links, images, inline code,
+// bold, italic -- no tables, no fenced code blocks, no headings", which had been wrong
+// since cf38e315. A documented capability with no test is a claim; this is the list.
+//
+// So: if you are here to find out what you may write in a post, read THIS, not prose.
+console.log('\nblock constructs render to the right tag');
+const tag = (md, re, label) => ok(label, re.test(render(md)), render(md).slice(0, 150));
+tag('# One', /<h1>One<\/h1>/, '# -> <h1>');
+tag('## Two', /<h2>Two<\/h2>/, '## -> <h2>');
+tag('### Three', /<h3>Three<\/h3>/, '### -> <h3>');
+tag('#### Four', /<h4>Four<\/h4>/, '#### -> <h4>');
+tag('##### Five', /<h5>Five<\/h5>/, '##### -> <h5>');
+tag('###### Six', /<h6>Six<\/h6>/, '###### -> <h6>');
+ok('a # with no space is NOT a heading (a hashtag in prose survives)',
+   /<p>#NotAHeading<\/p>/.test(render('#NotAHeading')), render('#NotAHeading'));
+tag('```\nx = 1\n```', /<pre><code>x = 1<\/code><\/pre>/, 'fenced code -> <pre><code>');
+tag('```python\nx = 1\n```', /<pre><code>x = 1<\/code><\/pre>/, 'fenced code with a language tag');
+tag('- a\n- b', /<ul>\n<li>a<\/li>\n<li>b<\/li>\n<\/ul>/, '- -> <ul><li>');
+tag('1. a\n2. b', /<ol>\n<li>a<\/li>\n<li>b<\/li>\n<\/ol>/, '1. -> <ol><li>');
+tag('> quoted', /<blockquote>quoted<\/blockquote>/, '> -> <blockquote>');
+tag('---', /<hr>/, '--- -> <hr>');
+tag('plain line', /<p>plain line<\/p>/, 'bare line -> <p>');
+
+console.log('\ninline constructs render to the right tag');
+ok('[x](url) -> <a>', /<a href="https:\/\/pdoom1\.com" rel="noopener">site<\/a>/.test(render('[site](https://pdoom1.com)')), render('[site](https://pdoom1.com)'));
+ok('![x](url) -> <img>', /<img src="\/a\.png" alt="cap"/.test(render('![cap](/a.png)')), render('![cap](/a.png)'));
+ok('`x` -> <code>', /<code>x<\/code>/.test(render('`x`')));
+ok('**b** -> <strong>', /<strong>b<\/strong>/.test(render('**b**')));
+ok('*i* -> <em>', /<em>i<\/em>/.test(render('*i*')));
+ok('_i_ -> <em>', /<em>i<\/em>/.test(render('_i_')));
+ok('inline formatting works INSIDE a heading',
+   /<h2><strong>b<\/strong> and <a href="\/x" rel="noopener">l<\/a><\/h2>/.test(render('## **b** and [l](/x)')),
+   render('## **b** and [l](/x)'));
+
+console.log('\ntables (added 2026-08-03; previously shipped literal pipes at the reader)');
 const tableOut = render('| a | b |\n|---|---|\n| 1 | 2 |\n');
-ok('tables are still unsupported -- do not use them in a post',
-   tableOut.includes('| a | b |'), 'if this fails, tables now work: update the docs');
+ok('header cells -> <th>',
+   /<table><thead><tr><th>a<\/th><th>b<\/th><\/tr><\/thead>/.test(tableOut), tableOut);
+ok('body cells -> <td>',
+   /<tbody><tr><td>1<\/td><td>2<\/td><\/tr><\/tbody>/.test(tableOut), tableOut);
+ok('the table is wrapped so IT scrolls, not the page body',
+   /<div class="table-wrap">/.test(tableOut));
+ok('alignment colons are accepted and ignored',
+   /<th>a<\/th>/.test(render('| a | b |\n|:--|--:|\n| 1 | 2 |')));
+ok('inline formatting works inside a cell',
+   /<td><strong>x<\/strong><\/td>/.test(render('| a |\n|---|\n| **x** |')));
+ok('a row shorter than the header does not throw or invent cells',
+   /<tr><td>1<\/td><\/tr>/.test(render('| a | b |\n|---|---|\n| 1 |')));
+
+// THE OVER-EAGERNESS GUARD, and the reason the delimiter row is mandatory.
+// Existing posts contain pipes in prose and in shell pipelines. If the detector fired
+// on any line containing `|`, this change would silently restructure PUBLISHED pages --
+// a content regression dressed as a feature. These assert it does not.
+ok('prose containing a pipe with NO delimiter row stays a paragraph',
+   /<p>a \| b<\/p>/.test(render('a | b')), render('a | b'));
+ok('a shell pipeline in prose is not eaten as a table',
+   /<p>run cat x \| grep y<\/p>/.test(render('run cat x | grep y')), render('run cat x | grep y'));
+ok('a pipe line followed by a bare --- is an hr, not a table',
+   /<hr>/.test(render('a | b\n---\n')), render('a | b\n---\n'));
+ok('a delimiter-shaped line with no pipes above it is not a table',
+   !/<table>/.test(render('text\n\n|---|---|\n')), render('text\n\n|---|---|\n'));
+
+// A table cell is a NEW block context, so it needs its own escaping evidence.
+// scripts/test-escaping.js runs the hostile corpus through this renderer, but that
+// corpus predates tables and contains no table input -- a green there would say
+// nothing about the cell path. Forced here instead of assumed.
+console.log('\na table cell is escaped like any other inline context');
+const hostileCell = render('| <img src=x onerror=alert(1)> | b |\n|---|---|\n| <script>alert(1)</script> | 2 |');
+ok('markup in a header cell renders as visible text',
+   /<th>&lt;img src=x onerror=alert\(1\)&gt;<\/th>/.test(hostileCell), hostileCell.slice(0, 170));
+ok('markup in a body cell renders as visible text',
+   /<td>&lt;script&gt;alert\(1\)&lt;\/script&gt;<\/td>/.test(hostileCell), hostileCell.slice(0, 170));
+ok('no event-handler attribute survives anywhere in a rendered table',
+   !/\son\w+\s*=\s*["']/i.test(hostileCell), hostileCell.slice(0, 170));
+
+// FORCED FAILURE. CLAUDE.md: "a guard seen only in its passing state has not been shown
+// to work." The three assertions above are all of the form "the output does NOT contain
+// live markup", and a predicate that is simply wrong passes those trivially. So run the
+// same predicate against a deliberately-unescaped cell and require it to REJECT.
+const fakeUnescapedCell = '<div class="table-wrap"><table><thead><tr>'
+  + '<th><img src=x onerror="alert(1)"></th></tr></thead><tbody></tbody></table></div>';
+ok('FORCED FAILURE: the same predicate REJECTS an unescaped cell (so the PASSes mean something)',
+   /\son\w+\s*=\s*["']/i.test(fakeUnescapedCell));
+
+console.log('\nthe CSS exists for every tag the renderer emits');
+for (const sel of ['h4', 'table', 'th', 'td', 'pre', 'blockquote', 'hr', 'ul', 'code', 'img']) {
+  ok('article ' + sel + ' is styled',
+     new RegExp('article\\s+[^{;]*\\b' + sel + '\\b[^{;]*\\{').test(html));
+}
+ok('.table-wrap scrolls horizontally (a wide table must not scroll the page body)',
+   /\.table-wrap\s*\{[^}]*overflow-x:\s*auto/.test(html));
+
+console.log('\nevery .md on disk still renders without throwing');
+let renderedOk = 0;
+for (const p of onDisk) {
+  try { render(fs.readFileSync(path.join(BLOG, p), 'utf8')); renderedOk++; }
+  catch (e) { ok('renders: ' + p, false, e.message); }
+}
+ok(`${renderedOk}/${onDisk.length} .md files render without throwing`, renderedOk === onDisk.length);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## The brief was based on a stale note

The task was "the blog renderer supports no headings, PR #222's drafts would ship visibly broken — add headings." **That is not the state of `main`.**

`CLAUDE.md` has said this since the file was written:

> renders client-side with a **very** limited markdown parser: links, images, inline code, bold, italic. **No tables, no fenced code blocks, no headings.**

It has been wrong since **`cf38e315`** ("Render dev-blog posts as HTML"), which replaced the parser. Headings (`#` through `######`), fenced code, `-`/`1.` lists, blockquotes and `hr` all already worked. Rendering PR #222's `2026-07-30-issue-1-turns-one.md` against `main` gives:

```
<h1>Issue #1 turns one
<h2>The sentence
<h2>Issue #1, one abstraction layer down
<h2>What this post is not
<h2>Year two
```

...and its blockquotes render too. Zero literal `##` in the output. **PR #222 is not blocked by the renderer.** If it is being held, it is being held for the copy revision its own title names.

**Tables were the one true gap** — a table shipped its literal pipe characters at the reader. That is what this PR adds.

I also found the security work was already done. My first pass found two live holes (a `"` in an image `alt` closing the attribute and injecting a runnable `onerror=`; `javascript:`/`data:` URLs surviving escaping) — then discovered **PR #236's sweep had already landed on `main`** and fixed both, correctly, via the shared `public/assets/js/escape.js`. I discarded that work rather than ship a second escaper. CLAUDE.md's "check sibling branches before writing a fix" earned its place again.

## What this adds

**1. GitHub-style pipe tables.** `public/blog/post.html`.

**The delimiter row is mandatory, and that is the whole safety of the rule.** The detector fires only when the *next* line is nothing but pipes, dashes, colons and spaces. Existing posts contain pipes in prose and in shell pipelines; a looser rule would silently restructure published pages — a content regression dressed as a feature. Four assertions pin it:

- `a | b` renders as a paragraph, not a table
- `run cat x | grep y` stays a paragraph
- a pipe line followed by a bare `---` is an `<hr>`, not a table
- a delimiter-shaped line with no pipe row above it is not a table

Alignment colons are parsed and **ignored**. Honouring them means building a `style=""` attribute out of post text, and this page has no business generating one.

**2. `h4`-`h6` CSS.** The renderer already emitted them; there was no rule, so a `####` heading was visually indistinguishable from body text — a structural promise the page did not keep.

**3. A test that asserts what the parser supports, construct by construct.**

## What I deliberately did NOT add, and why

| Not added | Why |
|---|---|
| A second escaper / my own `safeUrl` | `main` already routes this page through the site's ONE escaper. CLAUDE.md is explicit that a second is how partial coverage happens. Deleted my version. |
| Nested lists | Needs indentation state in the block loop, materially more complexity, and no post wants one. Documented as unsupported. |
| Reference links, footnotes | Same — no content demand, real parser complexity. |
| Escaped pipes in a cell | Would need an escape pass interleaved with cell splitting. Documented as unsupported rather than half-implemented. |
| Alignment honoured | Would mean a `style` attribute derived from post text. Parsed and discarded instead. |
| Raw HTML passthrough | Escaped on purpose. Not a gap. |
| Adding the test to `content-honesty.yml` | It is **already fully wired** — see below. A second workflow running the same file is duplication, not coverage. |

## CI wiring

The brief asked me to wire the test to `content-honesty.yml`. I did not, because `generate-feeds.yml` on `main` already triggers on all the relevant paths:

```
- 'public/blog/index.json'
- 'public/blog/*.md'
- 'public/blog/post.html'          <- the renderer
- 'public/assets/js/escape.js'     <- what it depends on
- 'scripts/test-blog-render.js'    <- the test itself
```

That is complete. (Worth noting: it was *not* complete a few commits ago — `post.html` was absent, so editing the renderer never ran its own test. Someone already closed that.)

What **was** missing: `test-blog-render.js` appears nowhere in CLAUDE.md's documented suite list. Added, with the `[generate-feeds]` bracket.

## Before/after rendering diff across existing posts

Rendered all 24 `public/blog/*.md` through the extracted renderer, before and after:

```
b2 files: 24  a2 files: 24
b2 bytes: 127039  a2 bytes: 127039
>>> BYTE-IDENTICAL across all 24 posts
```

No existing post contains a table, and the delimiter-row requirement means none was reinterpreted. Zero justification needed because there is zero diff.

## Forced-failure evidence

Three kinds, all actually observed rather than asserted.

**1. The pre-existing tripwire fired, on purpose.** The old test carried a deliberate negative assertion:

```js
ok('tables are still unsupported -- do not use them in a post',
   tableOut.includes('| a | b |'), 'if this fails, tables now work: update the docs');
```

Adding tables made it fail, exactly as its author intended:

```
constructs the renderer cannot handle (would ship as raw text)
  FAIL tables are still unsupported -- do not use them in a post
        if this fails, tables now work: update the docs

6 passed, 1 failed
```

I replaced it with positive assertions and updated the docs, which is what the message instructed.

**2. Escaping in the new block context, forced.** Table cells are a new context, and `test-escaping.js`'s hostile corpus predates tables — it contains no table input, so its green said nothing about the cell path. The new assertions are of the form "the output does NOT contain live markup", which a broken predicate passes trivially, so the same predicate is run against a deliberately-unescaped cell and required to reject it:

```
a table cell is escaped like any other inline context
  PASS markup in a header cell renders as visible text
  PASS markup in a body cell renders as visible text
  PASS no event-handler attribute survives anywhere in a rendered table
  PASS FORCED FAILURE: the same predicate REJECTS an unescaped cell (so the PASSes mean something)
```

**3. Evidence from the discarded pass.** Before finding PR #236, I reverted `escapeHtml` in the working tree to its three-character form and ran the harness. That output is the clearest statement of why five characters matter, and is recorded here because the class is easy to reintroduce:

```
  FAIL inert: "![\" onerror=\"alert(1)](y.png)"
        <p><img src="y.png" alt="" onerror="alert(1)" loading="lazy" decoding="async"></p>
  FAIL inert: "![a](x\"onerror=alert)"
        <p><img src="x"onerror=alert" alt="a" loading="lazy" decoding="async"></p>
  FAIL no event-handler attribute appears anywhere in the rendered output
  FAIL escapeHtml handles & < > " ' -- the two quotes are the attribute-slot fix
        &amp;&lt;&gt;"'
```

No angle bracket is involved in either payload, which is why probing with `<script>` came back clean. **This is already fixed on `main`** — reproduced against a locally-reverted file, not against shipped code.

## Test results

`node scripts/test-blog-render.js` gives **53 passed, 0 failed** (was 7).

Also green locally: `test-escaping.js`, `test-changelog-render.js`, `build-blog-index.py --check`, `generate-feeds.py --check`, `check-encoding-safety.py`, `check-stale-facts.py --min-severity HIGH`, `check-deploy-excludes.py`.

## What I could not verify

- **No browser.** Table CSS (`.table-wrap` scroll, `th` background, the `h4`-`h6` uppercase treatment) is verified only as CSS rules present and correct against the dark palette. **Needs an eye on the Netlify preview**, ideally at phone width — the wrapper is supposed to scroll instead of the page body, and I cannot see that happen.
- **Real-world table content.** No committed post has a table, so the feature is exercised only by test fixtures. First real use is the true test.
- **A latent fragility I did not fix (pre-existing).** `test-blog-render.js` strips the page bootstrap with a regex that does not actually remove the async IIFE. It throws `ReferenceError: URLSearchParams is not defined` into a rejected promise, and `process.exit()` fires before Node reports it. Harmless today, but it means an unhandled rejection in that file would be invisible. Out of scope here; worth a follow-up.
- **CLAUDE.md drift is probably not limited to this bullet.** One paragraph describing a parser was wrong for months because nothing tested the *positive* direction. The same shape likely exists elsewhere in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
