### PR TITLE
fix(honesty): the site contradicted itself about baseline doom, on the same page

### DIFF
--- a/public/game-stats/index.html
+++ b/public/game-stats/index.html
@@ -212,7 +212,7 @@
             <p>These statistics are calculated using various automated methods and data sources:</p>
             
             <div class="calculation-note">
-                <strong>Baseline Doom:</strong> Currently stubbed at 23%. Future implementation will aggregate AI safety sentiment from research papers, news sentiment analysis, and expert forecasting platforms.
+                <strong>Baseline Doom:</strong> Not yet measured, and deliberately not estimated here. Baseline doom is a property of the simulation, so only the game can report it. The intended method &mdash; aggregating research, news sentiment and forecasting-platform signals &mdash; is a plan, not a running pipeline, and until it runs this stays blank rather than carrying a placeholder.
             </div>
             
             <div class="calculation-note">

--- a/public/stats/index.html
+++ b/public/stats/index.html
@@ -208,7 +208,7 @@
             <p>These statistics are calculated using various automated methods and data sources:</p>
             
             <div class="calculation-note">
-                <strong>Baseline Doom:</strong> Currently stubbed at 23%. Future implementation will aggregate AI safety sentiment from research papers, news sentiment analysis, and expert forecasting platforms.
+                <strong>Baseline Doom:</strong> Not yet measured, and deliberately not estimated here. Baseline doom is a property of the simulation, so only the game can report it. The intended method &mdash; aggregating research, news sentiment and forecasting-platform signals &mdash; is a plan, not a running pipeline, and until it runs this stays blank rather than carrying a placeholder.
             </div>
             
             <div class="calculation-note">


### PR DESCRIPTION
Found by a portfolio sweep, 2026-08-04. **Two lines, two pages, and the shape of the failure is more interesting than the fix.**

## What a visitor sees today

`public/game-stats/index.html` and `public/stats/index.html`, thirty-nine lines apart:

> **:176** — *"Not yet measured. Baseline doom is a property of the simulation, so only the game can measure it — until it emits that number, this stays blank rather than showing a made-up one. **It read "23%" for months; nobody had measured it.**"*

> **:215** — *"**Baseline Doom: Currently stubbed at 23%.** Future implementation will aggregate AI safety sentiment from research papers, news sentiment analysis, and expert forecasting platforms."*

PR #206 removed the invented `23%` from the stat tiles and **missed the methodology paragraph beneath them**. The word *"Currently"* is what makes the second line a live claim rather than a note about history.

## Why this shape matters

**The honesty note is what made the violation invisible.** A page that visibly cares about not inventing numbers — that explains, at length, why it leaves a figure blank — does not get read as a page that invents numbers. Nobody scrolls down looking. A page with no such note would have been checked.

That is worth recording as its own failure mode, distinct from ordinary staleness: *a conspicuous correction elsewhere on the surface suppresses scrutiny of the rest of it.* It joins the roster contributed to pdoom1#984.

## The fix

The paragraph now says what the tile forty lines above already says: not measured, only the game can report it, and the described method is **a plan, not a running pipeline**. The intended approach is kept — it is real future work — but stated as intent rather than as a system that exists.

## Guards

- `check-stale-facts.py --min-severity HIGH` — **passes**.
- `snapshot-copy.py --check` — reports both pages as drift. **Correct, and expected.** That check is advisory precisely so a diff like this can land; per CLAUDE.md the only acceptable justification is *"this was false, now it is true"*, which is exactly what this is.
- No `Currently stubbed` or `stubbed at 23` string remains anywhere under `public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)