### PR TITLE
fix(ci): update-game-data has failed every run since 2026-08-03 — undefined name

### DIFF
--- a/.github/workflows/update-game-data.yml
+++ b/.github/workflows/update-game-data.yml
@@ -159,7 +159,16 @@ jobs:
               #
               # redact_pii() walks the WHOLE structure rather than a named field
               # list, so a field the GitHub API adds tomorrow cannot leak.
-              issues_cache = _sync.redact_pii(issues_cache)
+              # NOTE 2026-08-04: this read `_sync`, a name that was never bound --
+              # two parallel branches each added a redaction block and the union merge
+              # kept both bodies but only one importer. It raised
+              # `name '_sync' is not defined` and failed this workflow on every
+              # 6-hourly run from 2026-08-03. Corrected to the module actually
+              # imported above. Kept rather than deleted as redundant: the call above
+              # walks the API payload, this one walks the FINAL written object, so a
+              # future wrapper field is covered too. Belt and braces on the one file
+              # here that is a verbatim public dump of other people's prose.
+              issues_cache = _sync_events.redact_pii(issues_cache)
               print(f"✓ Redacted email addresses in issues cache")
 
               with open('public/data/issues-cache.json', 'w', encoding="utf-8") as f:


### PR DESCRIPTION
## The failure

```
Fetching GitHub issues...
Redacted 0 email address(es) from the issues mirror
Unexpected error: name '_sync' is not defined
##[error]Process completed with exit code 1
```

Every six-hourly run since 2026-08-03.

## Cause

Two parallel branches each added PII redaction to this workflow's inline Python. The union merge kept **both call sites** but only **one importer**, so the second call referenced a module alias that no longer existed.

This is a specific hazard of resolving conflicts by union — which was the right call for the *reasoning comments*, and the wrong one for the code, and nothing caught the difference because the workflow's Python is a heredoc that no linter reads.

## Why it matters more than a red square

This workflow writes `public/data/issues-cache.json` — a **verbatim public dump of GitHub issue objects, full bodies included**. It is the exact file that carried `noreply@anthropic.com` out of a `Co-Authored-By` trailer and turned `main` red on 2026-08-02.

While broken, the cache is not refreshing at all. And it runs straight into a **two-week unattended window**.

## The fix

Pointed at the module actually imported above, rather than deleting the call as redundant.

The first call walks the **API payload**; this one walks the **final written object**, so a wrapper field added later is covered too. On the one file in this repo that republishes other people's prose verbatim, belt and braces is the right trade.

## Verified by execution, not by reading

Ran the corrected sequence against the real `sync-events` module with a planted address:

```
count_emails found : 1
address survives?  : False
marker present?    : True
```

YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)