### PR TITLE
chore(park): give the sync-leaderboards park a return date (§5c)

### DIFF
--- a/.github/workflows/auto-deploy-on-push.yml
+++ b/.github/workflows/auto-deploy-on-push.yml
@@ -10,7 +10,11 @@ on:
       - '.github/workflows/auto-deploy-on-push.yml'
 
   # A push made by a workflow using the default GITHUB_TOKEN does NOT trigger another
-  # workflow (CLAUDE.md, "Bot commits do not trigger deploys"). Board Liveness commits the
+  # workflow -- the reason this `push` trigger alone is insufficient. (That used to cite
+  # CLAUDE.md's "Bot commits do not trigger deploys". PR #260 REWROTE that section,
+  # because this very `workflow_run` block is what made it false: bot commits now DO
+  # reach production, ~4x/day. The quote was dangling; the reasoning below still holds.)
+  # Board Liveness commits the
   # live leaderboard under public/, so without this trigger the board would reach the repo
   # and never reach pdoom1.com -- during a league, that means a board frozen at whatever a
   # human last pushed while players watch it not update. This closes that gap for the one

--- a/.github/workflows/sync-leaderboards.yml
+++ b/.github/workflows/sync-leaderboards.yml
@@ -23,6 +23,15 @@ name: Sync Leaderboards
 # square every day, and CLAUDE.md's severity model is explicit that a permanently
 # red job trains everyone to ignore the Actions tab.
 #
+# RETURN DATE: 2026-09-02. Required by coordination PRINT_AND_PROCESS_REFERENCE
+# section 5c (RULED 2026-08-05): a park without a return date renders as ABANDONED --
+# "parking without a date is abandonment with better manners". This park originally
+# carried a revival CONDITION and no date, which under that rule is not a park at all.
+#
+# On 2026-09-02 one of three things must happen, and drifting past it is not one of
+# them: revive it, re-park it with a NEW date and a reason the old one lapsed, or
+# delete it and say so. The date exists to force a re-decision, not to express a hope.
+#
 # TO REVIVE: resolve #254 finding 3 (make validate_game_repo recognise a Godot
 # layout, or drop the local-checkout requirement entirely), then restore:
 #     schedule:


### PR DESCRIPTION
Applying coordination's `PRINT_AND_PROCESS_REFERENCE` **§5c**, ruled binding 2026-08-05:

> **`parked` requires a return date. No date renders as `abandoned`.**
> *"Parking without a date is abandonment with better manners."*

I parked this workflow yesterday with a revival **condition** — *"resolve #254 finding 3"* — and no date. Under the ruling that is not a park. It is an abandonment that reads as a park, which is precisely the ambiguity the two-axis scheme exists to remove.

**The ruling caught my own work the day it landed**, which is the best available evidence that it is doing something rather than describing something.

## Return date: 2026-09-02

On that date one of three things must happen, and drifting past it is not one of them:

1. revive it,
2. re-park it with a **new** date *and* a reason the old one lapsed,
3. delete it and say so.

The date exists to force a re-decision, not to express a hope.

## Context unchanged

0 of 6 runs succeeded since 2026-07-30, every failure `ERROR: No game repository configured` — `game-integration.py:126-132` validates a game checkout by requiring `main.py` / `src` / `ui.py`, and pdoom1 is a **Godot** project. It was green for weeks while doing nothing; it only went red when PR #190 made board-key loss loud.

## Verified

YAML parses, triggers remain `['workflow_dispatch']`; `generate-metabolism.py --check` → `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)