### PR TITLE
feat(blog): mark the human-written posts; absence renders as unattributed (#267)

### DIFF
--- a/.github/workflows/escaping.yml
+++ b/.github/workflows/escaping.yml
@@ -41,6 +41,9 @@ on:
     paths:
       - 'public/**/*.html'
       - 'public/assets/js/escape.js'
+      # authorship.js hands plain strings to the blog pages, which escape them at the
+      # sink. A change there changes what reaches those sinks.
+      - 'public/assets/js/authorship.js'
       - 'public/docs/roadmap.md'
       - 'scripts/test-escaping.js'
       - 'scripts/test-roadmap-render.js'
@@ -50,6 +53,9 @@ on:
     paths:
       - 'public/**/*.html'
       - 'public/assets/js/escape.js'
+      # authorship.js hands plain strings to the blog pages, which escape them at the
+      # sink. A change there changes what reaches those sinks.
+      - 'public/assets/js/authorship.js'
       - 'public/docs/roadmap.md'
       - 'scripts/test-escaping.js'
       - 'scripts/test-roadmap-render.js'

--- a/.github/workflows/generate-feeds.yml
+++ b/.github/workflows/generate-feeds.yml
@@ -14,6 +14,13 @@ on:
       - 'public/blog/index.json'
       - 'public/blog/*.md'
       - 'public/blog/post.html'
+      # The listing page and the authorship surfaces. test-blog-render.js asserts the
+      # colophon on BOTH blog pages and resolves every post against the registry, so a
+      # change to any of these three can break it on its own.
+      - 'public/blog/index.html'
+      - 'public/assets/js/authorship.js'
+      - 'public/data/authors.json'
+      - 'scripts/build-blog-index.py'
       # test-blog-render.js runs the PAGE's renderer, which since 2026-08-01 depends
       # on the shared escaper. A change to either must re-run it.
       - 'public/assets/js/escape.js'
@@ -24,6 +31,13 @@ on:
       - 'public/blog/index.json'
       - 'public/blog/*.md'
       - 'public/blog/post.html'
+      # The listing page and the authorship surfaces. test-blog-render.js asserts the
+      # colophon on BOTH blog pages and resolves every post against the registry, so a
+      # change to any of these three can break it on its own.
+      - 'public/blog/index.html'
+      - 'public/assets/js/authorship.js'
+      - 'public/data/authors.json'
+      - 'scripts/build-blog-index.py'
       # test-blog-render.js runs the PAGE's renderer, which since 2026-08-01 depends
       # on the shared escaper. A change to either must re-run it.
       - 'public/assets/js/escape.js'

--- a/public/assets/js/authorship.js
+++ b/public/assets/js/authorship.js
@@ -1,0 +1,159 @@
+/*
+ * authorship.js -- who held the pen, resolved honestly.
+ *
+ * WHAT THIS IS FOR
+ * ----------------
+ * Most of pdoom1.com is drafted by an assistant. Marking THAT would put a badge on
+ * nearly every page, and a mark that appears everywhere is furniture. So the site marks
+ * the HUMAN-written pieces instead: scarce by construction, and a claim about the ratio
+ * that anyone can check against the volume of everything else.
+ *
+ * THE ONE RULE THIS FILE EXISTS TO ENFORCE
+ * ----------------------------------------
+ * ABSENCE IS UNATTRIBUTED. A post with no recorded author is not "probably drafted" and
+ * not "probably Pip". Nobody has checked, and the page says exactly that. There is no
+ * default identity anywhere in this file -- a fallback ships precisely when the real
+ * value is missing, which is when it is most likely to be a lie.
+ *
+ * It returns PLAIN STRINGS, never markup. Every caller runs them through the site's one
+ * escaper (public/assets/js/escape.js) at its own sink. This file deliberately defines no
+ * escaping of its own; there is exactly one escaper on this site and it is that file.
+ *
+ * Identity is open-ended on purpose -- a string key into public/data/authors.json, not a
+ * boolean. `pdoom1-website` can become an author by adding a key to that file. A
+ * human/not-human flag would have needed a migration to say the same thing.
+ *
+ * Accountability is NOT here. It never varies -- it is always Pip, including for work
+ * done under his direction -- so it is one standing colophon sentence (registry.colophon)
+ * rather than a field repeated on every item that would always hold the same value.
+ */
+(function () {
+  'use strict';
+
+  // An id long enough to be a payload is not an id. Truncated before it can be quoted
+  // back at a reader in the unresolved message.
+  var MAX_ID = 64;
+
+  /**
+   * Read `author:` out of a post's YAML front matter.
+   *
+   * Only the fenced block at the very top is inspected: a line reading "author: someone"
+   * in the BODY of a post is prose about a person, not a claim about who wrote it, and
+   * treating it as one would let the page's own text change its attribution.
+   * Returns '' when there is no front matter or no author key -- which the resolver
+   * below renders as unattributed, never as anybody.
+   */
+  function authorFromFrontMatter(md) {
+    if (md === null || md === undefined) { return ''; }
+    var text = String(md).replace(/^﻿/, '').replace(/\r\n/g, '\n');
+    var lines = text.split('\n');
+    if (!/^\s*---\s*$/.test(lines[0] || '')) { return ''; }
+    for (var i = 1; i < lines.length; i++) {
+      if (/^\s*---\s*$/.test(lines[i])) { break; }
+      var m = lines[i].match(/^\s*author\s*:\s*(.*)$/);
+      if (m) {
+        var v = m[1].trim();
+        // Strip one layer of matching quotes; YAML writes author: "pip" and author: pip.
+        v = v.replace(/^"([\s\S]*)"$/, '$1').replace(/^'([\s\S]*)'$/, '$1');
+        return v.trim();
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Resolve an author id against the registry, in FIVE states, all of them honest.
+   *
+   *   unattributed  no id recorded            -> says so; claims neither human nor drafted
+   *   human         registry kind === human   -> the marked treatment
+   *   attributed    any other registry kind   -> a plain byline (the unmarked default)
+   *   unknown-id    id not in the registry    -> quotes the id back, invents no name
+   *   no-registry   registry failed to load   -> says the registry is unavailable
+   *
+   * The last two are separate because the causes are separate, and a message naming the
+   * wrong cause is its own small lie: "not in the registry" is false when the registry
+   * simply did not load.
+   *
+   * @param {string} id        the recorded identity, or '' / null when none
+   * @param {object|null} reg  parsed public/data/authors.json, or null if unavailable
+   * @returns {{state:string, cls:string, text:string, note:string, id:string}}
+   *          all plain text -- the CALLER escapes.
+   */
+  function resolveAuthorship(id, reg) {
+    var raw = (id === null || id === undefined) ? '' : String(id).trim();
+
+    if (!raw) {
+      return {
+        state: 'unattributed',
+        cls: 'authorship-unattributed',
+        id: '',
+        text: 'Authorship not recorded',
+        note: 'No author was recorded for this one, so it is claimed as neither hand-written nor drafted.'
+      };
+    }
+
+    var shown = raw.length > MAX_ID ? raw.slice(0, MAX_ID) + '…' : raw;
+
+    if (!reg || typeof reg !== 'object' || !reg.authors || typeof reg.authors !== 'object') {
+      return {
+        state: 'no-registry',
+        cls: 'authorship-unresolved',
+        id: shown,
+        text: 'Authorship recorded as “' + shown + '” (author registry unavailable)',
+        note: ''
+      };
+    }
+
+    var entry = Object.prototype.hasOwnProperty.call(reg.authors, raw) ? reg.authors[raw] : null;
+    if (!entry || typeof entry !== 'object') {
+      return {
+        state: 'unknown-id',
+        cls: 'authorship-unresolved',
+        id: shown,
+        text: 'Authorship recorded as “' + shown + '”, which is not in the author registry',
+        note: ''
+      };
+    }
+
+    // A registry entry with no byline still resolves -- to its name, or failing that to
+    // the id itself. Never to a manufactured one.
+    var byline = typeof entry.byline === 'string' && entry.byline.trim()
+      ? entry.byline.trim()
+      : (typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : shown);
+    var note = typeof entry.note === 'string' ? entry.note.trim() : '';
+
+    if (entry.kind === 'human') {
+      return { state: 'human', cls: 'authorship-human', id: shown, text: byline, note: note };
+    }
+    return { state: 'attributed', cls: 'authorship-attributed', id: shown, text: byline, note: note };
+  }
+
+  /**
+   * The standing accountability sentence, read from the registry rather than typed twice.
+   * Returns '' if the registry is unavailable -- the pages carry the same sentence in
+   * static HTML, and scripts/test-blog-render.js asserts the two are character-identical,
+   * so a drift between them fails CI rather than shipping two versions of a promise.
+   */
+  function colophonText(reg) {
+    if (!reg || typeof reg !== 'object' || typeof reg.colophon !== 'string') { return ''; }
+    return reg.colophon.trim();
+  }
+
+  var API = {
+    authorFromFrontMatter: authorFromFrontMatter,
+    resolveAuthorship: resolveAuthorship,
+    colophonText: colophonText
+  };
+
+  if (typeof window !== 'undefined') {
+    window.authorFromFrontMatter = authorFromFrontMatter;
+    window.resolveAuthorship = resolveAuthorship;
+    window.colophonText = colophonText;
+  }
+  if (typeof module !== 'undefined' && module.exports) { module.exports = API; }
+  if (typeof globalThis !== 'undefined' && typeof window === 'undefined') {
+    globalThis.authorFromFrontMatter = authorFromFrontMatter;
+    globalThis.resolveAuthorship = resolveAuthorship;
+    globalThis.colophonText = colophonText;
+  }
+})();

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -280,7 +280,39 @@
             margin-bottom: 1rem;
             color: var(--text-secondary);
         }
-        
+
+        /* AUTHORSHIP -- see public/assets/js/authorship.js for why the HUMAN pieces are
+           the marked ones. Subtle by design: a left rule and a warmer text colour, not a
+           badge. An unattributed post is not silent about it; silence would read as a
+           default, and there is no default. */
+        .authorship {
+            font-size: 0.82rem;
+            color: var(--text-muted);
+            line-height: 1.4;
+        }
+
+        .authorship-human {
+            color: var(--text-secondary);
+            border-left: 2px solid var(--accent-secondary);
+            padding-left: 0.6rem;
+            letter-spacing: 0.015em;
+        }
+
+        .authorship-unattributed,
+        .authorship-unresolved {
+            font-style: italic;
+        }
+
+        .colophon {
+            max-width: 1000px;
+            margin: 2.5rem auto 0;
+            padding: 1.2rem 2rem 0;
+            border-top: 1px solid var(--border-color);
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            line-height: 1.55;
+        }
+
         @media (max-width: 768px) {
             .container {
                 padding: 1rem;
@@ -310,6 +342,9 @@
 	     PLAIN blocking script: the inline renderers below call it, so it has to be
 	     defined before they run. Not defer, not async. -->
 	<script src="/assets/js/escape.js"></script>
+	<!-- Author identity resolution (returns plain strings; this page escapes them).
+	     Same blocking rule, same reason. -->
+	<script src="/assets/js/authorship.js"></script>
 </head>
 <body>
     <header>
@@ -357,11 +392,23 @@
             <div class="loading-skeleton" style="height: 200px; background: var(--bg-secondary); border-radius: var(--radius-lg);"></div>
         </main>
     </div>
-    
+
+    <!-- THE COLOPHON. One standing sentence, not per-post metadata: accountability here
+         never varies, so a field repeating it on every post would always hold the same
+         value. The identical sentence is the "colophon" key of /data/authors.json, and
+         scripts/test-blog-render.js fails if the two ever differ by a character. -->
+    <footer class="colophon">
+        Everything published here ships with Pip Foweraker's approval, and the mistakes are his — including the mistakes of things working under his direction.
+    </footer>
+
+
     <script>
         class DeveloperBlog {
             constructor() {
                 this.posts = [];
+                // null means "the author registry is unavailable", which
+                // resolveAuthorship() renders in those words. It never means "nobody".
+                this.authors = null;
                 this.currentFilter = 'all';
                 this.init();
             }
@@ -382,6 +429,15 @@
                 } catch (error) {
                     console.error('Failed to load blog posts:', error);
                     this.showError();
+                }
+                // Separate try: a missing author registry must not take the post list
+                // down with it. It degrades to an honest "registry unavailable" line.
+                try {
+                    const r = await fetch('/data/authors.json');
+                    const j = r.ok ? await r.json() : null;
+                    this.authors = (j && typeof j === 'object') ? j : null;
+                } catch (error) {
+                    this.authors = null;
                 }
             }
             
@@ -435,6 +491,12 @@
                 const commit = post.commit ?
                     `<span class="post-commit">commit: ${escapeHTML(post.commit)}</span>` : '';
 
+                // `author` is OPTIONAL and absent on every post written before
+                // 2026-08-06. Absent does NOT mean drafted and does not mean Pip --
+                // resolveAuthorship() renders it as "Authorship not recorded", which is
+                // the only true thing anyone can say about those posts today.
+                const authorship = resolveAuthorship(post.author, this.authors);
+
                 return `
                     <article class="blog-post" data-tags="${escapeHTML((post.tags || []).join(' '))}">
                         <div class="post-header">
@@ -444,6 +506,7 @@
                                 </h2>
                                 <div class="post-meta">
                                     <span class="post-date">${escapeHTML(this.formatDate(post.date))}</span>
+                                    <span class="authorship ${escapeHTML(authorship.cls)}">${escapeHTML(authorship.text)}</span>
                                     <div class="post-tags">${tags}</div>
                                 </div>
                             </div>

--- a/public/blog/post.html
+++ b/public/blog/post.html
@@ -65,17 +65,44 @@
             padding: 0.45rem 0.7rem; text-align: left; color: var(--text-secondary); }
         article th { color: var(--text-primary); background: var(--bg-tertiary); }
         .post-error { color: var(--accent-secondary); text-align: center; padding: 3rem 1rem; }
+
+        /* AUTHORSHIP.
+           Most of this site is drafted by an assistant, so the mark goes on the HUMAN
+           pieces -- scarce by construction. A left rule and a slightly warmer text
+           colour, not a badge and not a warning: the claim is "a person wrote this",
+           not "handle with care". Everything else, including an unattributed post,
+           renders in the muted metadata voice the rest of the page already uses. */
+        .authorship { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 1.6rem;
+            line-height: 1.5; }
+        .authorship-note { display: block; color: var(--text-muted); opacity: 0.85;
+            font-size: 0.95em; margin-top: 0.15rem; }
+        .authorship-human { color: var(--text-secondary);
+            border-left: 2px solid var(--accent-secondary); padding: 0.15rem 0 0.15rem 0.85rem;
+            letter-spacing: 0.015em; }
+        .authorship-unattributed, .authorship-unresolved { font-style: italic; }
+        .colophon { max-width: 820px; margin: 1.6rem auto 0; padding: 0 1.5rem;
+            font-size: 0.85rem; color: var(--text-muted); line-height: 1.55; }
     </style>
 	<!-- The site's ONE HTML escaper (escapeHTML / safeUrl / toNumber). Deliberately a
 	     PLAIN blocking script: the inline renderers below call it, so it has to be
 	     defined before they run. Not defer, not async. -->
 	<script src="/assets/js/escape.js"></script>
+	<!-- Author identity resolution (returns plain strings; this page escapes them).
+	     Same blocking rule, same reason. -->
+	<script src="/assets/js/authorship.js"></script>
 </head>
 <body>
     <div class="container">
         <div class="post-nav"><a href="/blog/">&larr; All dev-blog posts</a></div>
         <article id="post"><p class="post-error">Loading post&hellip;</p></article>
     </div>
+    <!-- THE COLOPHON. One standing sentence, not per-post metadata: accountability here
+         never varies, so a field repeating it on every item would always hold the same
+         value. The identical sentence is the "colophon" key of /data/authors.json, and
+         scripts/test-blog-render.js fails if the two ever differ by a character. -->
+    <footer class="colophon">
+        Everything published here ships with Pip Foweraker's approval, and the mistakes are his — including the mistakes of things working under his direction.
+    </footer>
     <script>
         // Minimal, dependency-free Markdown renderer. Covers the subset used by
         // p(Doom)1 dev-blog posts: headings, bold/italic, links, images, inline
@@ -191,8 +218,44 @@
             flushPara(); closeList();
             return out.join('\n');
         }
+        // The authorship line, built from plain strings by /assets/js/authorship.js and
+        // escaped HERE, at the sink. resolveAuthorship() never invents an identity: no
+        // author key renders as "Authorship not recorded", an id the registry does not
+        // carry is quoted back as-is, and a registry that failed to load says so. None
+        // of those five states defaults to a person.
+        function authorshipBlockHTML(a) {
+            const note = a.note
+                ? '<span class="authorship-note">' + escapeHTML(a.note) + '</span>' : '';
+            return '<p class="authorship ' + escapeHTML(a.cls) + '">'
+                 + escapeHTML(a.text) + note + '</p>';
+        }
+
+        // Put the byline under the title, where a byline belongs -- not above it. Both
+        // arguments are strings this page generated, so the split lands on our own
+        // markup and never inside post text. ADDITIVE by contract: the rendered body
+        // comes out whole, which is what keeps this change invisible to the sixteen
+        // posts that record no author. scripts/test-blog-render.js asserts that.
+        function assemblePost(body, block) {
+            const at = body.indexOf('</h1>');
+            return at === -1
+                ? block + body
+                : body.slice(0, at + 5) + block + body.slice(at + 5);
+        }
+
+        // Never rejects: a failed or malformed registry resolves to null, which
+        // resolveAuthorship() renders as "registry unavailable" rather than as nobody.
+        async function loadAuthorRegistry() {
+            try {
+                const r = await fetch('/data/authors.json', { cache: 'no-store' });
+                if (!r.ok) { return null; }
+                const j = await r.json();
+                return (j && typeof j === 'object') ? j : null;
+            } catch (e) { return null; }
+        }
+
         (async function () {
             const el = document.getElementById('post');
+            const registryPromise = loadAuthorRegistry();
             const params = new URLSearchParams(location.search);
             let file = params.get('p') || '';
             // allow only a safe .md filename in the /blog/ folder (no path traversal)
@@ -204,7 +267,14 @@
                 const res = await fetch('/blog/' + file, { cache: 'no-store' });
                 if (!res.ok) throw new Error(res.status);
                 const md = await res.text();
-                el.innerHTML = renderMarkdown(md);
+                // The identity is read from the post's OWN front matter, not from
+                // index.json, so the two can never disagree about who wrote a piece --
+                // index.json is derived from that same front matter by
+                // scripts/build-blog-index.py.
+                const authorship = resolveAuthorship(
+                    authorFromFrontMatter(md), await registryPromise);
+                el.innerHTML = assemblePost(
+                    renderMarkdown(md), authorshipBlockHTML(authorship));
                 const h1 = el.querySelector('h1');
                 if (h1) document.title = h1.textContent + ' - p(Doom)1 Dev Blog';
             } catch (e) {

--- a/public/data/authors.json
+++ b/public/data/authors.json
@@ -1,0 +1,25 @@
+{
+  "_what": "The author identities pdoom1.com can attribute a piece of writing to.",
+  "_why_not_a_boolean": "A human/not-human flag has nowhere to put a third party. Pip expects the game, the website and the repos to develop their own voice and contributions over time, and to be endorsed as authors when they do. An identity is a data addition here; a boolean would have been a migration.",
+  "_rendering": "Only kind == \"human\" receives the marked treatment. Every other kind renders as a plain byline, and an absent author renders as unattributed. That inversion is the point: most of this site is drafted by an assistant, so marking the drafted text would mark nearly everything and the mark would become furniture. Marking the human text keeps it scarce by construction, and makes it a claim about the ratio that is checkable against volume.",
+  "_absence": "A post with no author key is NOT drafted-by-default and NOT hand-written-by-default. It is unattributed, and the pages say so in those words. Nothing here supplies a fallback identity.",
+  "_not_a_shield": "The mark says who held the pen. It never lowers the accuracy bar for anything published under it.",
+  "_adding_one": "Add a key under \"authors\" and set author: <that key> in a post's front matter. scripts/build-blog-index.py refuses to publish a post naming an identity that is not in this file.",
+
+  "colophon": "Everything published here ships with Pip Foweraker's approval, and the mistakes are his — including the mistakes of things working under his direction.",
+
+  "authors": {
+    "pip": {
+      "name": "Pip Foweraker",
+      "kind": "human",
+      "byline": "Written by hand, by Pip Foweraker",
+      "note": "Most of this site is drafted by an assistant. This piece was not."
+    },
+    "assistant": {
+      "name": "Claude",
+      "kind": "assistant",
+      "byline": "Drafted by Claude, published with Pip's approval",
+      "note": ""
+    }
+  }
+}

--- a/scripts/build-blog-index.py
+++ b/scripts/build-blog-index.py
@@ -28,6 +28,20 @@ DRAFTS
 of the feed). That is how a post exists in the repo without being published:
 publishing is a deliberate act, not a side effect of adding a file.
 
+AUTHORSHIP
+----------
+`author: <id>` in front matter is OPTIONAL and is carried through to index.json
+only when it is present. The key is OMITTED, never written as "", when a post
+records no author -- because "" and "absent" would then be the same thing on the
+page, and they are not: absent means nobody has said who wrote it, and the site
+renders that as unattributed rather than defaulting it to anyone.
+
+An id that is present must resolve: it has to be a plain slug AND be a key in
+public/data/authors.json, or the build refuses. The pages degrade honestly on an
+unresolvable id (they quote it back rather than inventing a name), but that is a
+backstop for a fetch that failed at read time -- it is not a licence to publish
+an id that points at nobody.
+
 Usage:
     python scripts/build-blog-index.py            # write index.json
     python scripts/build-blog-index.py --check    # exit 1 if stale or invalid
@@ -57,9 +71,16 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BLOG_DIR = REPO_ROOT / "public" / "blog"
 INDEX = BLOG_DIR / "index.json"
+AUTHORS = REPO_ROOT / "public" / "data" / "authors.json"
 
 REQUIRED = ("title", "date", "summary")
 FM_FENCE = re.compile(r"^\s*---\s*$")
+
+# An author id is a lookup key, not prose: lowercase slug, so it can never carry
+# whitespace, punctuation or markup into a page. The pages escape it anyway --
+# this is the earlier of the two gates, and it fails the BUILD rather than
+# leaving a reader to notice.
+AUTHOR_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
 
 # Constructs public/blog/post.html mishandles. Keep in step with that file --
 # scripts/test-blog-render.js pins the table case against the real renderer.
@@ -105,8 +126,27 @@ def split_front_matter(text):
     return None, text, "front matter opened with --- but never closed"
 
 
+def known_author_ids():
+    """Return the set of identities in the registry, or None if it cannot be read.
+
+    None is NOT an empty set. An empty set would mean "no identity exists", which
+    would silently pass every post that records no author and reject every post
+    that does -- the same answer for two different worlds. None makes the caller
+    say which one it is looking at.
+    """
+    try:
+        data = json.loads(AUTHORS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    authors = data.get("authors") if isinstance(data, dict) else None
+    if not isinstance(authors, dict):
+        return None
+    return set(authors)
+
+
 def collect():
     posts, problems, drafts, warnings = [], [], [], []
+    author_ids = known_author_ids()
 
     for path in sorted(BLOG_DIR.glob("*.md")):
         name = path.name
@@ -152,10 +192,28 @@ def collect():
                                  % (label, why, body[:m.start()].count("\n") + 1)))
                 break
 
+        # Authorship. Optional, and absent by default -- see the AUTHORSHIP note in
+        # the module docstring for why the key is omitted rather than emptied.
+        author = str(fm.get("author") or "").strip()
+        if author:
+            if not AUTHOR_ID_RE.match(author):
+                problems.append((name, "author %r is not a plain id "
+                                       "(lowercase letters, digits, - and _)" % author))
+                continue
+            if author_ids is None:
+                problems.append((name, "declares author %r but %s could not be read"
+                                 % (author, AUTHORS.relative_to(REPO_ROOT))))
+                continue
+            if author not in author_ids:
+                problems.append((name, "author %r is not in %s -- add the identity there "
+                                       "first, or the page can only quote the id back"
+                                 % (author, AUTHORS.relative_to(REPO_ROOT))))
+                continue
+
         tags = fm.get("tags") or []
         if isinstance(tags, str):
             tags = [t.strip() for t in tags.split(",") if t.strip()]
-        posts.append({
+        entry = {
             "filename": name,
             "title": str(fm["title"]).strip(),
             "date": date,
@@ -163,7 +221,10 @@ def collect():
             "summary": str(fm["summary"]).strip(),
             "commit": str(fm.get("commit", "")).strip(),
             "featured": bool(fm.get("featured", False)),
-        })
+        }
+        if author:
+            entry["author"] = author
+        posts.append(entry)
 
     posts.sort(key=lambda p: (p["date"], p["filename"]), reverse=True)
     return posts, problems, drafts, warnings

--- a/scripts/test-blog-render.js
+++ b/scripts/test-blog-render.js
@@ -15,6 +15,9 @@ const vm = require('vm');
 const ROOT = path.join(__dirname, '..');
 const BLOG = path.join(ROOT, 'public', 'blog');
 const POST_HTML = path.join(BLOG, 'post.html');
+const LIST_HTML = path.join(BLOG, 'index.html');
+const AUTHORSHIP_JS = path.join(ROOT, 'public', 'assets', 'js', 'authorship.js');
+const AUTHORS_JSON = path.join(ROOT, 'public', 'data', 'authors.json');
 
 let pass = 0, fail = 0;
 function ok(name, cond, detail) {
@@ -42,9 +45,17 @@ vm.createContext(sandbox);
 vm.runInContext(
   fs.readFileSync(path.join(ROOT, 'public', 'assets', 'js', 'escape.js'), 'utf8'), sandbox);
 // Only evaluate the function declarations; skip page bootstrapping that needs a DOM.
+// The authorship module, loaded the same way the page loads it: AFTER the escaper,
+// because it hands plain strings to callers that escape them and the page's own
+// block builder calls escapeHTML directly.
+vm.runInContext(fs.readFileSync(AUTHORSHIP_JS, 'utf8'), sandbox);
 vm.runInContext(source.replace(/^\s*(document|window)\.[\s\S]*$/m, ''), sandbox);
 const render = sandbox.renderMarkdown;
 const strip = sandbox.stripFrontMatter;
+const authorOf = sandbox.authorFromFrontMatter;
+const resolve = sandbox.resolveAuthorship;
+const blockHTML = sandbox.authorshipBlockHTML;
+const assemble = sandbox.assemblePost;
 
 console.log('front matter stripping');
 ok('strips a normal block',
@@ -191,6 +202,229 @@ for (const p of onDisk) {
   catch (e) { ok('renders: ' + p, false, e.message); }
 }
 ok(`${renderedOk}/${onDisk.length} .md files render without throwing`, renderedOk === onDisk.length);
+
+// ===========================================================================
+// AUTHORSHIP (added 2026-08-06, #267)
+// ===========================================================================
+// The site marks the HUMAN-written pieces, not the drafted ones, because most of it is
+// drafted and a mark that appears everywhere is furniture. The whole design therefore
+// rests on one property that is easy to get wrong and impossible to see in a passing
+// render: ABSENCE MUST STAY ABSENT. Sixteen published posts record no author and nobody
+// knows who wrote them; stamping them either way would be fabrication.
+//
+// So the assertions below are mostly of the form "this output claims NOTHING", and a
+// predicate that is simply broken passes those trivially. Each such group therefore ends
+// with a FORCED FAILURE: the same predicate, run against a deliberately-wrong output,
+// required to reject it.
+console.log('\nauthorship: the module, and the registry it reads');
+
+ok('public/assets/js/authorship.js exists', fs.existsSync(AUTHORSHIP_JS));
+const authorshipSrc = fs.readFileSync(AUTHORSHIP_JS, 'utf8');
+// There is exactly ONE escaper on this site and it is public/assets/js/escape.js.
+// A new shared module is exactly where a second one would appear.
+ok('authorship.js defines no escaper of its own',
+   !/(?:function|const|let|var)\s+(?:esc|escape[A-Za-z]*|sanitize[A-Za-z]*|htmlEscape[A-Za-z]*)\s*[=(]/
+     .test(authorshipSrc));
+ok('authorship.js contains no default identity (no fallback author id)',
+   !/\|\|\s*['"](?:pip|assistant|human)['"]/i.test(authorshipSrc));
+
+for (const [label, file] of [['post.html', POST_HTML], ['index.html', LIST_HTML]]) {
+  const src = fs.readFileSync(file, 'utf8');
+  ok(label + ' loads authorship.js',
+     src.includes('<script src="/assets/js/authorship.js"></script>'));
+  ok(label + ' loads it BLOCKING (not defer/async)',
+     !/<script[^>]*authorship\.js[^>]*(?:defer|async)/.test(src));
+}
+
+ok('public/data/authors.json exists', fs.existsSync(AUTHORS_JSON));
+const reg = JSON.parse(fs.readFileSync(AUTHORS_JSON, 'utf8'));
+ok('the registry has an authors map',
+   reg && typeof reg.authors === 'object' && Object.keys(reg.authors).length > 0);
+ok('the registry carries a colophon sentence',
+   typeof reg.colophon === 'string' && reg.colophon.trim().length > 20);
+
+// The id rule is READ OUT of the builder rather than retyped, so the two cannot drift.
+// (CLAUDE.md: never assert a literal against a value that moves.)
+const builderSrc = fs.readFileSync(path.join(ROOT, 'scripts', 'build-blog-index.py'), 'utf8');
+const idRuleSrc = (builderSrc.match(/AUTHOR_ID_RE\s*=\s*re\.compile\(r"([^"]+)"\)/) || [])[1];
+ok('the builder still declares AUTHOR_ID_RE (the id rule is readable from one place)',
+   !!idRuleSrc, 'AUTHOR_ID_RE not found in scripts/build-blog-index.py');
+if (idRuleSrc) {
+  const idRule = new RegExp(idRuleSrc);
+  for (const id of Object.keys(reg.authors)) {
+    ok('registry id "' + id + '" satisfies the builder\'s own id rule', idRule.test(id));
+  }
+}
+for (const [id, a] of Object.entries(reg.authors)) {
+  ok('registry entry "' + id + '" has a name and a kind',
+     a && typeof a.name === 'string' && a.name.trim() && typeof a.kind === 'string' && a.kind.trim());
+}
+// If nothing is kind:"human" the marked treatment is unreachable and the whole feature
+// is decoration. Asserted as a rule, not as a count, so adding identities cannot break it.
+ok('at least one identity is kind:"human" (or the human treatment is dead code)',
+   Object.values(reg.authors).some((a) => a.kind === 'human'));
+
+// Everything the registry could put on a page. Used below to prove that the states which
+// must claim NOTHING claim nothing.
+const IDENTITY_STRINGS = Object.values(reg.authors)
+  .flatMap((a) => [a.name, a.byline]).filter((s) => typeof s === 'string' && s.trim());
+const claimsAnIdentity = (a) =>
+  a.cls === 'authorship-human' ||
+  IDENTITY_STRINGS.some((n) => (a.text + ' ' + a.note).includes(n));
+
+console.log('\nauthorship: the identity is read from the post itself');
+ok('author: pip in front matter is read', authorOf('---\nauthor: pip\n---\n# x') === 'pip');
+ok('quoted form is read', authorOf('---\nauthor: "pip"\n---\n# x') === 'pip');
+ok('single-quoted form is read', authorOf("---\nauthor: 'pip'\n---\n# x") === 'pip');
+ok('front matter with no author yields no author',
+   authorOf('---\ntitle: "x"\ndate: "2026-01-01"\n---\n# x') === '');
+ok('a post with no front matter yields no author', authorOf('# x\n\ntext') === '');
+ok('an "author:" line in the BODY is prose, not an attribution claim',
+   authorOf('---\ntitle: "x"\n---\n# x\n\nauthor: someone-else') === '',
+   authorOf('---\ntitle: "x"\n---\n# x\n\nauthor: someone-else'));
+ok('null/empty input yields no author', authorOf(null) === '' && authorOf('') === '');
+
+console.log('\nauthorship: five states, none of which defaults to a person');
+const unattributed = resolve('', reg);
+ok('no author -> state "unattributed"', unattributed.state === 'unattributed', unattributed.state);
+ok('no author -> the reader is TOLD it is unrecorded, not shown silence',
+   /not recorded/i.test(unattributed.text), unattributed.text);
+ok('no author -> NOT the human treatment', unattributed.cls !== 'authorship-human');
+ok('no author -> claims no identity at all: not human, not drafted, not anybody',
+   !claimsAnIdentity(unattributed), unattributed.text + ' / ' + unattributed.note);
+ok('no author -> says BOTH negatives explicitly (the AI-drafted reading is closed too)',
+   /hand-written/i.test(unattributed.note) && /drafted/i.test(unattributed.note),
+   unattributed.note);
+
+const human = resolve('pip', reg);
+ok('a human id -> state "human"', human.state === 'human', human.state);
+ok('a human id -> the marked class', human.cls === 'authorship-human', human.cls);
+ok('a human id -> the registry byline verbatim, not a manufactured one',
+   human.text === reg.authors.pip.byline, human.text);
+
+const drafted = resolve('assistant', reg);
+ok('a non-human id -> state "attributed"', drafted.state === 'attributed', drafted.state);
+ok('a non-human id does NOT get the human treatment',
+   drafted.cls !== 'authorship-human', drafted.cls);
+
+const unknown = resolve('nobody-in-the-registry', reg);
+ok('an unknown id -> state "unknown-id"', unknown.state === 'unknown-id', unknown.state);
+ok('an unknown id is quoted back rather than resolved to a name',
+   unknown.text.includes('nobody-in-the-registry'), unknown.text);
+ok('an unknown id invents no identity', !claimsAnIdentity(unknown), unknown.text);
+ok('an unknown id names the real cause (not in the registry)',
+   /not in the author registry/i.test(unknown.text), unknown.text);
+
+for (const badReg of [null, undefined, {}, { authors: 'x' }, 'nope', 42]) {
+  const r = resolve('pip', badReg);
+  ok('registry ' + JSON.stringify(badReg) + ' -> state "no-registry"',
+     r.state === 'no-registry', r.state);
+  ok('...and invents no identity from it', !claimsAnIdentity(r), r.text);
+}
+ok('a missing registry names ITS cause, not the wrong one',
+   /registry unavailable/i.test(resolve('pip', null).text), resolve('pip', null).text);
+
+// A 500-character "id" is a payload, not an id. It must not be quoted back whole.
+const longId = 'a'.repeat(500);
+ok('an absurdly long id is truncated before it is quoted back',
+   resolve(longId, reg).text.length < 200, String(resolve(longId, reg).text.length));
+
+// FORCED FAILURE. Every assertion above of the form "claims no identity" is satisfied by
+// a predicate that is simply broken. Run the same predicate against the two mistakes this
+// whole design exists to prevent, and require it to REJECT both.
+ok('FORCED FAILURE: claimsAnIdentity() REJECTS a resolver that defaults an unknown post to the human',
+   claimsAnIdentity({ cls: 'authorship-human', text: reg.authors.pip.byline, note: '' }));
+ok('FORCED FAILURE: ...and REJECTS one that defaults it to the assistant',
+   claimsAnIdentity({ cls: 'authorship-attributed', text: reg.authors.assistant.byline, note: '' }));
+
+console.log('\nauthorship: hostile strings are inert text, from either side');
+const liveMarkup = (h) => /<(?:img|script|svg|iframe)\b/i.test(h) || /\son\w+\s*=\s*["']/i.test(h);
+const HOSTILE_ID = '"><img src=x onerror=alert(1)>';
+const hostileIdOut = blockHTML(resolve(HOSTILE_ID, reg));
+ok('a hostile author id renders as visible text, not markup',
+   !liveMarkup(hostileIdOut), hostileIdOut.slice(0, 160));
+ok('...and the payload is still SHOWN, escaped, rather than silently dropped',
+   hostileIdOut.includes('&lt;img'), hostileIdOut.slice(0, 160));
+
+// The other side of the same sink: the registry is a data file, and a data file is edited.
+const hostileReg = { authors: { x: {
+  name: 'n', kind: 'human',
+  byline: '<script>alert(1)</script>',
+  note: '" onmouseover="alert(1)' } } };
+const hostileRegOut = blockHTML(resolve('x', hostileReg));
+ok('a hostile registry byline renders as visible text', !liveMarkup(hostileRegOut), hostileRegOut);
+ok('a hostile registry note cannot break out of the class attribute',
+   !/class="[^"]*"[^>]*\son\w+=/i.test(hostileRegOut), hostileRegOut);
+ok('FORCED FAILURE: liveMarkup() REJECTS an unescaped block (so the PASSes mean something)',
+   liveMarkup('<p class="authorship"><img src=x onerror="alert(1)"></p>'));
+
+console.log('\nauthorship: the byline is ADDITIVE -- it cannot alter the post body');
+const bodyFixture = '<h1>T</h1>\n<p>one</p>\n<p>two</p>';
+const blockFixture = '<p class="authorship authorship-unattributed">A</p>';
+const withH1 = assemble(bodyFixture, blockFixture);
+// The exact property, not a substring smell: delete the byline again and you must be
+// holding the original body, byte for byte.
+ok('removing the byline yields the original body, byte for byte',
+   withH1.replace(blockFixture, '') === bodyFixture, withH1);
+ok('the byline lands immediately after the title', /<\/h1>\s*<p class="authorship/.test(withH1), withH1);
+const noH1 = assemble('<p>one</p>', blockFixture);
+ok('with no <h1> the byline goes first and the body is untouched',
+   noH1 === blockFixture + '<p>one</p>', noH1);
+
+console.log('\nauthorship: the sixteen existing posts are unchanged and unattributed');
+let unattributedPosts = 0, bodyPreserved = 0, oneBylineEach = 0;
+for (const p of posts) {
+  const f = path.join(BLOG, p.filename);
+  if (!fs.existsSync(f)) { continue; }
+  const md = fs.readFileSync(f, 'utf8');
+  const id = authorOf(md);
+  const a = resolve(id, reg);
+  if (!id && a.state === 'unattributed' && !claimsAnIdentity(a)) { unattributedPosts++; }
+  const body = render(md);
+  const block = blockHTML(a);
+  const final = assemble(body, block);
+  // Delete the byline and you must be holding exactly what the renderer produced
+  // before this change existed. That is the "do not break the existing posts" contract.
+  if (final.replace(block, '') === body) { bodyPreserved++; }
+  if ((final.match(/class="authorship /g) || []).length === 1) { oneBylineEach++; }
+}
+ok(`all ${checked} existing posts resolve to unattributed and claim nobody`,
+   unattributedPosts === checked, `${unattributedPosts}/${checked}`);
+ok(`all ${checked} existing post bodies survive the byline insertion verbatim`,
+   bodyPreserved === checked, `${bodyPreserved}/${checked}`);
+ok(`each of the ${checked} posts gets exactly one byline`,
+   oneBylineEach === checked, `${oneBylineEach}/${checked}`);
+
+// The RULE, not the count: today no post carries an author, but the first one lands
+// within days. Asserting "zero authors" would go red on exactly the commit it should
+// go green on. Assert instead that whatever is recorded actually resolves.
+console.log('\nauthorship: index.json records nothing it cannot resolve');
+const withAuthor = posts.filter((p) => Object.prototype.hasOwnProperty.call(p, 'author'));
+ok('no post carries an EMPTY author key (absence is absence, not "")',
+   withAuthor.every((p) => typeof p.author === 'string' && p.author.trim() !== ''),
+   JSON.stringify(withAuthor.filter((p) => !String(p.author || '').trim()).map((p) => p.filename)));
+ok(`every recorded author (${withAuthor.length} of ${posts.length} posts) is in the registry`,
+   withAuthor.every((p) => Object.prototype.hasOwnProperty.call(reg.authors, p.author)),
+   JSON.stringify(withAuthor.filter((p) => !reg.authors[p.author]).map((p) => p.author)));
+
+console.log('\nthe colophon is ONE sentence, from one source');
+// Accountability never varies here -- it is always Pip, including for work done under his
+// direction -- so it is a standing sentence rather than a field repeated on every post.
+// It is served as static HTML (so a failed fetch cannot remove an accountability
+// statement) and mirrored in the registry (so an agent reading the site can find it).
+// Two copies of a promise is one copy too many unless something enforces they are equal.
+const colophon = reg.colophon.trim();
+for (const [label, file] of [['post.html', POST_HTML], ['index.html', LIST_HTML]]) {
+  const src = fs.readFileSync(file, 'utf8');
+  const hits = src.split(colophon).length - 1;
+  ok(label + ' carries the registry colophon, character-identical', hits >= 1,
+     'not found; page says: ' + ((src.match(/<footer class="colophon">([\s\S]{0,220})/) || [])[1] || '(no colophon footer)').trim());
+  ok(label + ' carries it exactly once', hits === 1, 'found ' + hits + ' times');
+}
+ok('the colophon names who is accountable and for what',
+   /mistakes/i.test(colophon) && /approval/i.test(colophon), colophon);
+ok('FORCED FAILURE: the same check REJECTS a page that does not carry it',
+   ('<footer class="colophon">something else entirely</footer>').split(colophon).length - 1 === 0);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/scripts/test-escaping.js
+++ b/scripts/test-escaping.js
@@ -137,9 +137,14 @@ const GUARDED = [
   },
   {
     page: 'public/blog/index.html',
-    roots: ['post', 'tag'],
+    // `authorship` is the resolved author identity for a card: plain strings out of
+    // /data/authors.json via resolveAuthorship(). Registry text is repo-controlled
+    // today, but the rule here is about the SINK, not about who we trust -- and one of
+    // its two interpolations lands in a class="" attribute, where an unescaped quote
+    // starts a new attribute.
+    roots: ['post', 'tag', 'authorship'],
     safeHelpers: [],
-    fetches: ['/blog/index.json'],
+    fetches: ['/blog/index.json', '/data/authors.json'],
   },
   {
     page: 'public/game-changelog/index.html',


### PR DESCRIPTION
Closes part of #267. Ships today because Pip is hand-writing a post today and another tomorrow; without this they render identically to the drafted ones.

## The data shape, and why it is not a boolean

An **open-ended string identity**, in three places that cannot disagree:

| where | what | shape |
|---|---|---|
| a post's YAML front matter | `author: pip` | optional, **absent by default** |
| `public/blog/index.json` | `"author": "pip"` | carried through by `build-blog-index.py`; the key is **omitted**, never `""`, when absent |
| `public/data/authors.json` | the registry | `{ "authors": { "<id>": { name, kind, byline, note } }, "colophon": "..." }` |

`kind` drives the rendering, and only `kind: "human"` gets the marked treatment; every other kind renders as a plain byline. A boolean would have had nowhere to put `pdoom1-website` as an author when the repos start contributing in their own voice. Adding one now is four lines of JSON and zero lines of code — retrofitting a third party into a boolean is the `max(..., 5)` floor #267 warns about.

`public/blog/post.html` reads the identity from the post's **own front matter**, not from `index.json`. `index.json` is derived from that same front matter, so the two structurally cannot disagree about who wrote a piece.

**Accountability is not in the schema.** It never varies, so a field repeating it on every item would always hold the same value. It is one standing colophon sentence, stored once in `authors.json` and served as static HTML on both blog pages, with a test that fails if the two ever differ by a character.

## Exactly how an unattributed post renders

All 16 currently-published posts (the brief said 14; `build-blog-index.py` counts 16) record no author. **None has been stamped.** They render:

```html
<p class="authorship authorship-unattributed">Authorship not recorded<span
class="authorship-note">No author was recorded for this one, so it is claimed as
neither hand-written nor drafted.</span></p>
```

Not silence — silence reads as a default, and there is no default. Not "AI-drafted", not "Pip". Retroactive attribution stays the open question #267 filed it as.

There are **five** states, all honest, and the last two are separate because the causes are separate (a message naming the wrong cause is its own small lie):

| state | when | renders |
|---|---|---|
| `unattributed` | no `author` key | *Authorship not recorded* |
| `human` | registry `kind: human` | *Written by hand, by Pip Foweraker* + left rule |
| `attributed` | any other kind | *Drafted by Claude, published with Pip's approval* |
| `unknown-id` | id absent from a registry that loaded | *Authorship recorded as "x", which is not in the author registry* |
| `no-registry` | the registry fetch failed | *Authorship recorded as "x" (author registry unavailable)* |

## Human-written vs drafted, side by side

Real output from the shipped renderer:

```
[human]        <p class="authorship authorship-human">Written by hand, by Pip Foweraker
               <span class="authorship-note">Most of this site is drafted by an
               assistant. This piece was not.</span></p>

[drafted]      <p class="authorship authorship-attributed">Drafted by Claude,
               published with Pip&#39;s approval</p>

[unattributed] <p class="authorship authorship-unattributed">Authorship not recorded
               <span class="authorship-note">No author was recorded for this one...</span></p>
```

Visually the human one gets a 2px left rule in `--accent-secondary` and the warmer `--text-secondary`; everything else stays in the muted metadata voice the page already uses. A rule and a colour, not a badge and not a warning — the claim is "a person wrote this", not "handle with care". It sits directly under the `<h1>`, where a byline belongs, and in the meta row on a listing card.

## Forced-failure evidence

`scripts/test-blog-render.js` goes 53 -> **125 assertions**. Every group whose assertions are of the form "this output claims NOTHING" ends with a forced failure, because a broken predicate passes those trivially. Real output from deliberately breaking each guard:

```
BREAK 1. no-author post is DEFAULTED to the human  -> exit 1
  FAIL no author -> state "unattributed"
  FAIL no author -> the reader is TOLD it is unrecorded, not shown silence
  FAIL no author -> NOT the human treatment
  FAIL no author -> claims no identity at all: not human, not drafted, not anybody
  FAIL all 16 existing posts resolve to unattributed and claim nobody
120 passed, 5 failed

BREAK 2. unknown author id INVENTS a name from the registry  -> exit 1
  FAIL an unknown id -> state "unknown-id"
  FAIL an unknown id is quoted back rather than resolved to a name
  FAIL an unknown id invents no identity
  FAIL an unknown id names the real cause (not in the registry)
120 passed, 5 failed

BREAK 3. the byline sink stops escaping  -> exit 1
  FAIL a hostile author id renders as visible text, not markup
  FAIL ...and the payload is still SHOWN, escaped, rather than silently dropped
  FAIL a hostile registry byline renders as visible text
122 passed, 3 failed

BREAK 4. the byline insertion MUTATES the existing post body  -> exit 1
  FAIL removing the byline yields the original body, byte for byte
  FAIL all 16 existing post bodies survive the byline insertion verbatim
123 passed, 2 failed

BREAK 5. the colophon drifts on one page  -> exit 1
  FAIL post.html carries the registry colophon, character-identical
  FAIL post.html carries it exactly once
123 passed, 2 failed

restored; 125 passed, 0 failed
```

The existing-posts guarantee is asserted as the exact property, not a substring smell: **delete the byline again and you are holding the renderer's original output byte for byte**, for all 16 posts.

The escaping guard fired on its own during development, before any test was written for it:

```
FAIL public/blog/index.html: UNDECLARED fetch -> /data/authors.json
     (add it and its result variable to GUARDED in this file)
```

That is `test-escaping.js` rule 4 doing exactly what it exists for. `/data/authors.json` and the `authorship` root are now declared, and both of that root's interpolations go through `escapeHTML` — one of them lands in a `class=""` attribute, where an unescaped quote starts a new attribute.

`build-blog-index.py` gained an author gate, forced with a temp post that was deleted again:

```
CASE an id that IS in the registry      -> exit 0   index.json now carries: "author": "pip"
CASE an id that is NOT in the registry  -> exit 1
  author 'somebody-else' is not in public\data\authors.json -- add the identity there
  first, or the page can only quote the id back
CASE an id that is not a plain slug     -> exit 1
  author 'Pip Foweraker <x>' is not a plain id (lowercase letters, digits, - and _)
```

So the two unresolvable render states are a genuine backstop for a read-time fetch failure, not a licence to publish an id pointing at nobody.

## Wired to CI in the same commit

- `generate-feeds.yml` already ran `test-blog-render.js`; its path filter now also covers `public/blog/index.html`, `public/assets/js/authorship.js`, `public/data/authors.json` and `scripts/build-blog-index.py`. Three of those could previously break that test without re-running it — `index.html` included, which the test now reads for the colophon.
- `escaping.yml` gains `public/assets/js/authorship.js`.

Green locally: `test-blog-render.js` (125), `test-escaping.js`, `build-blog-index.py --check`, `generate-feeds.py --check`, `check-deploy-excludes.py`, `check-encoding-safety.py`. `validate_data.py` output is identical before and after (checked against a stashed tree).

`public/blog/index.json` is **unchanged** by this PR — no post was given an author.

## What I did NOT build

- **The inline "-- Ed." mechanism** (#267 item 2). Whole-piece authorship only. That marks an interjection at the point it happened and is a separate, later mechanism; #267 records both are wanted.
- **Retroactive attribution of the existing 16 posts.** Still open in #267. I do not know who wrote them and would not guess. One easy first call for Pip if he wants it: commit `75760e83` is `content(blog): DRAFT anniversary + patch-week posts, for Pip's review (#222)`, which is direct evidence that `2026-07-30-issue-1-turns-one.md` and `2026-07-28-this-post-has-a-shelf-life.md` were assistant-drafted. That is Pip's call to make, not mine.
- **Authorship anywhere but the blog.** The registry is site-wide by shape; only `/blog/` reads it today.
- **The feeds.** `feed.xml` / `atom.xml` carry no author element yet. RSS `<author>` wants an email address, which is exactly the thing the feeds exist to avoid collecting or publishing; Atom `<author><name>` would work and is a small follow-up.

## Needs sequencing by Pip (not touched here)

`CLAUDE.md`'s **Blog & feeds** section should gain a line about the authorship surfaces and the absence rule. Another agent is editing that file right now, so I have left it alone rather than race it.

Not touched: `public/press/`, `public/frontier-labs/`, `public/metrics/`, anything Steam-related.

Generated with [Claude Code](https://claude.com/claude-code)
