### PR TITLE
fix(deploy): one concurrency group across all FOUR production deploys (#286)

### DIFF
--- a/.github/workflows/auto-deploy-on-push.yml
+++ b/.github/workflows/auto-deploy-on-push.yml
@@ -1,5 +1,23 @@
 name: Auto-Deploy to DreamHost on Push
 
+# ALL FOUR PRODUCTION DEPLOYS SHARE THIS GROUP. Do not rename it in one file.
+# There are four workflows in this repo that run `rsync --delete` from public/ to
+# the DreamHost document root, and until 2026-08-10 none of them coordinated with
+# any other. On 2026-08-07 at 07:35Z two Auto-Deploy runs on different SHAs
+# overlapped by 13 seconds; their rsync STEPS missed each other by 10. Nothing
+# collided -- that was runner scheduling, not design.
+#
+# cancel-in-progress is FALSE on purpose and it is the important half: cancelling a
+# half-finished `rsync --delete` against a live document root is strictly worse than
+# queueing behind it. Same shape snapshot-analytics.yml and syndicate-content.yml
+# already use ("never interrupt a run that may be mid-post").
+#
+# A guard on three of four is not a guard: weekly-deployment.yml is dispatch-only
+# and reads as parked, but a dispatch still performs a real destructive deploy.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy-dreamhost.yml
+++ b/.github/workflows/deploy-dreamhost.yml
@@ -1,5 +1,23 @@
 name: Deploy to DreamHost (manual)
 
+# ALL FOUR PRODUCTION DEPLOYS SHARE THIS GROUP. Do not rename it in one file.
+# There are four workflows in this repo that run `rsync --delete` from public/ to
+# the DreamHost document root, and until 2026-08-10 none of them coordinated with
+# any other. On 2026-08-07 at 07:35Z two Auto-Deploy runs on different SHAs
+# overlapped by 13 seconds; their rsync STEPS missed each other by 10. Nothing
+# collided -- that was runner scheduling, not design.
+#
+# cancel-in-progress is FALSE on purpose and it is the important half: cancelling a
+# half-finished `rsync --delete` against a live document root is strictly worse than
+# queueing behind it. Same shape snapshot-analytics.yml and syndicate-content.yml
+# already use ("never interrupt a run that may be mid-post").
+#
+# A guard on three of four is not a guard: weekly-deployment.yml is dispatch-only
+# and reads as parked, but a dispatch still performs a real destructive deploy.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/version-aware-deploy.yml
+++ b/.github/workflows/version-aware-deploy.yml
@@ -1,5 +1,23 @@
 name: Version-Aware Deployment to DreamHost
 
+# ALL FOUR PRODUCTION DEPLOYS SHARE THIS GROUP. Do not rename it in one file.
+# There are four workflows in this repo that run `rsync --delete` from public/ to
+# the DreamHost document root, and until 2026-08-10 none of them coordinated with
+# any other. On 2026-08-07 at 07:35Z two Auto-Deploy runs on different SHAs
+# overlapped by 13 seconds; their rsync STEPS missed each other by 10. Nothing
+# collided -- that was runner scheduling, not design.
+#
+# cancel-in-progress is FALSE on purpose and it is the important half: cancelling a
+# half-finished `rsync --delete` against a live document root is strictly worse than
+# queueing behind it. Same shape snapshot-analytics.yml and syndicate-content.yml
+# already use ("never interrupt a run that may be mid-post").
+#
+# A guard on three of four is not a guard: weekly-deployment.yml is dispatch-only
+# and reads as parked, but a dispatch still performs a real destructive deploy.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/weekly-deployment.yml
+++ b/.github/workflows/weekly-deployment.yml
@@ -1,5 +1,23 @@
 name: Weekly Scheduled Deployment
 
+# ALL FOUR PRODUCTION DEPLOYS SHARE THIS GROUP. Do not rename it in one file.
+# There are four workflows in this repo that run `rsync --delete` from public/ to
+# the DreamHost document root, and until 2026-08-10 none of them coordinated with
+# any other. On 2026-08-07 at 07:35Z two Auto-Deploy runs on different SHAs
+# overlapped by 13 seconds; their rsync STEPS missed each other by 10. Nothing
+# collided -- that was runner scheduling, not design.
+#
+# cancel-in-progress is FALSE on purpose and it is the important half: cancelling a
+# half-finished `rsync --delete` against a live document root is strictly worse than
+# queueing behind it. Same shape snapshot-analytics.yml and syndicate-content.yml
+# already use ("never interrupt a run that may be mid-post").
+#
+# A guard on three of four is not a guard: weekly-deployment.yml is dispatch-only
+# and reads as parked, but a dispatch still performs a real destructive deploy.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 on:
   # Scheduled deployment: Every Friday at 06:00 UTC (16:00 AEST/17:00 AEDT)
   # SCHEDULE REMOVED 2026-07-22 -- manual dispatch only. Two reasons:


### PR DESCRIPTION
Closes #286 — and **corrects its count from three to four.**

## What changed

All four workflows that `rsync --delete` from `public/` to the DreamHost document root now declare an identical group:

```yaml
concurrency:
  group: production-deploy
  cancel-in-progress: false
```

`auto-deploy-on-push.yml` · `deploy-dreamhost.yml` · `version-aware-deploy.yml` · **`weekly-deployment.yml`**

## The correction, and it matters

**#286 names three workflows, and its own closing verification greps three.** Run as written, that check goes green while `weekly-deployment.yml` sits ungrouped holding a live `rsync --delete`. The issue would have closed having verified three quarters of itself.

That file reads as safe — its header says *"SCHEDULE REMOVED 2026-07-22 — manual dispatch only"* — but **a dispatch still performs a real destructive deploy.** Dormant, not dead. `scripts/check-deploy-excludes.py` already had the right number and says so in its own comment.

## Why this is not theoretical

On **2026-08-07 at 07:35Z**, two `Auto-Deploy` runs on different SHAs overlapped by **13 seconds**:

- run `31158243575`, sha `4ee71ee6` — `07:35:17Z → 07:35:33Z`
- run `31158247120`, sha `f47b6625` — `07:35:20Z → 07:35:45Z`

Their rsync **steps** missed each other by **10 seconds** (`07:35:28→30` vs `07:35:40→42`). A third deploy followed at `07:39:35`. **Three production deploys inside five minutes, and the only thing preventing two concurrent `rsync --delete` runs against one document root was runner scheduling.**

## Why `cancel-in-progress: false`

Cancelling a half-finished `rsync --delete` against a live document root is strictly worse than queueing behind it. `snapshot-analytics.yml` and `syndicate-content.yml` already use this exact shape — `syndicate-content.yml` even carries the rationale as a comment (*"never interrupt a run that may be mid-post"*). **The convention existed; it had simply never been applied to the workflows with the most destructive verb.**

## Order of landing

This should go in **before** #289 and before my #298 epoch-drift check. Both of those add automatic paths that can end in a production deploy, and adding traffic to an unguarded intersection is the wrong order.

## Verified

All four parse under `yaml.safe_load`; all four carry `group: production-deploy` with `cancel-in-progress: false`. The corrected closing check:

```bash
grep -A2 '^concurrency:' .github/workflows/{deploy-dreamhost,auto-deploy-on-push,version-aware-deploy,weekly-deployment}.yml | grep -c "group: production-deploy"
# 4
```

Comment block is duplicated in each file rather than referenced, so anyone editing one workflow sees why the group exists without going to look for it.
