### PR TITLE
feat(league): check that the four blessing artefacts agree (#297)

### DIFF
--- a/.github/workflows/content-honesty.yml
+++ b/.github/workflows/content-honesty.yml
@@ -327,6 +327,17 @@ jobs:
       #                                remainder is content emoji inside frozen prose --
       #                                real drift, but not a lie to a visitor, and
       #                                blocking on it would freeze content work.
+      # check-blessing-consistency     ADVISORY ON PURPOSE AND ONLY FOR NOW. It reports
+      #                                7 real findings today, and every one of them is
+      #                                true. It is not blocking because the fix is two
+      #                                ledger rows that ONLY PIP MAY WRITE -- they record
+      #                                who blessed a seed and when, and a seat inferring
+      #                                that is the defect (#297). Blocking on a condition
+      #                                no seat is permitted to clear would be a permanent
+      #                                red, which CLAUDE.md forbids with double force.
+      #                                PROMOTE THIS TO BLOCKING once #297's L3 and L4 rows
+      #                                are filled. If it is still advisory in a month,
+      #                                that is the thing to question, not the finding.
       #
       # Each runs with continue-on-error so the job stays green. Green here means
       # "reported", NOT "clean" -- read the summary.
@@ -379,6 +390,25 @@ jobs:
   #
   # Single rolling issue, reused not duplicated -- the shape data-contract-validation.yml
   # already uses here. Only trusted GitHub contexts reach the script (CLAUDE.md trap #5).
+
+      - name: ADVISORY -- do the four blessing artefacts agree?
+        continue-on-error: true
+        run: |
+          set +e
+          python scripts/check-blessing-consistency.py | tee blessing.log
+          set -e
+          {
+            echo '## ADVISORY: blessing record consistency'
+            echo ''
+            echo 'Exit 0 agree / 1 disagree / 2 cannot tell. NEVER blocks -- the fix is'
+            echo 'two ledger rows only Pip may write. See #297.'
+            echo ''
+            echo '```'
+            cat blessing.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
   alert:
     name: Alert on scheduled failure (de-duplicated)
     needs: [honesty]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,8 @@ python  scripts/test-publish-live-board.py # publisher refuses, never guesses [b
 python  scripts/test-board-liveness-verdicts.py # probe names an epoch disagreement, never composes a key [board-liveness]
 python  scripts/check-epoch-drift.py      # declared board key vs the published one [epoch-drift]
 python  scripts/test-epoch-drift.py       # ...and drift is red, absence is UNKNOWN  [epoch-drift]
+python  scripts/check-blessing-consistency.py # the four blessing artefacts agree [content-honesty ADVISORY]
+python  scripts/test-blessing-consistency.py  # ...and every disagreement shape is caught [content-honesty]
 
 node    scripts/test-escaping.js          # the SAME rule on the other 14 pages [escaping]
 node    scripts/test-roadmap-render.js    # roadmap markdown subset + escaping  [escaping]

--- a/scripts/check-blessing-consistency.py
+++ b/scripts/check-blessing-consistency.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+check-blessing-consistency.py -- do the four artefacts that record a league
+blessing actually agree with each other?
+
+WHY THIS EXISTS
+---------------
+A blessing is Pip's explicit sign-off that a seed is the real one for an epoch. It
+is one decision, and it is recorded by hand into FOUR places with nothing checking
+that they match. On 2026-08-09 they did not, and the failure was worse than a
+stale value:
+
+  * public/data/ladder-epochs.json -> regularised_from  said seed_status "blessed"
+  * docs/LEAGUE_SEED_LEDGER.md     -> the L3 table row   said "NOT YET BLESSED"
+  * weekly/current.json            said blessed: true, CITING the ledger as its
+                                   authority -- while contradicting it
+
+Five or six of the seven checklist steps had run. The one that did not was the
+HUMAN-READABLE one. So the machine knew and the document lied, which is the worse
+split: a seat reading for orientation reads the document, and this seat did, and
+told Pip his epoch had never been blessed. He was right and it was wrong.
+
+That is what this catches. See pdoom1-website#297 and the Workshop 2 R9 ruling.
+
+THE FOUR ARTEFACTS AND THEIR DIFFERENT ROLES
+--------------------------------------------
+They are NOT four copies of one fact. Treating them as interchangeable is how the
+last fix went wrong, so the roles are encoded here rather than left to memory:
+
+  1. docs/LEAGUE_SEED_LEDGER.md      THE HUMAN RECORD. Authoritative for WHO
+                                     blessed and WHEN. A row here is the blessing.
+  2. public/data/ladder-epochs.json  THE MACHINE-READ FIELD. The seed ledger's own
+                                     checklist calls regularised_from "the only
+                                     place a script reads it". Must match (1).
+  3. weekly/current.json             DERIVED by weekly-league-manager.py. Must
+                                     match (1) and (2); it must never lead.
+  4. published-board.json            AN OBSERVATION of what the client posts to.
+                                     Its seed_provenance.blessed is FALSE BY
+                                     DESIGN and that is correct -- it records what
+                                     IS, not what was blessed. So it is compared
+                                     on the KEY only, never on blessed-status.
+
+  ** Do not "fix" (4) to say blessed: true. It would be a lie, and the publisher
+     writes that field deliberately. **
+
+WHAT IT WILL NOT DO
+-------------------
+It does not decide anything. It cannot fill a ledger row -- that row records who
+blessed and when, and a seat inferring that is how #297 started. It reports
+disagreement and stops.
+
+ABSENCE IS NOT AGREEMENT. A file that cannot be read, or a row that cannot be
+parsed, is `unknown` and exit 2 -- never a quiet pass.
+
+EXIT CODES
+  0  the artefacts agree about the current epoch
+  1  they disagree -- a blessing is recorded in some places and not others
+  2  cannot tell -- an artefact is missing, unreadable, or declares nothing
+
+RUN
+    python scripts/check-blessing-consistency.py
+    python scripts/check-blessing-consistency.py --root path/to/fixture-tree
+"""
+
+import argparse
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        try:
+            if _s is sys.stdout:
+                sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+        except Exception:
+            pass
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A ledger row: | L3 | `seed` | L3 | `board file` | blessed date | by | notes |
+ROW_RE = re.compile(r"^\|\s*\**\s*(L\d+)\s*\**\s*\|(.+)$")
+BACKTICKED = re.compile(r"`([^`]+)`")
+# The unfilled-row marker the ledger uses. Matching the WORDS, not the emoji --
+# CLAUDE.md: the Windows console is cp1252 and an emoji literal is a crash.
+UNBLESSED_RE = re.compile(r"NOT\s+YET\s+BLESSED", re.I)
+ISO_DATE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+
+
+def load_json(path, default=None):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return default
+
+
+def parse_ledger(path):
+    """Return {epoch: {seed, blessed, blessed_utc, by, unfilled}} from the table."""
+    rows = {}
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        m = ROW_RE.match(line.strip())
+        if not m:
+            continue
+        epoch, rest = m.group(1), m.group(2)
+        cells = [c.strip() for c in rest.split("|")]
+        unfilled = bool(UNBLESSED_RE.search(rest))
+        ticked = BACKTICKED.findall(rest)
+        seed = None
+        for t in ticked:
+            # the seed cell is the first backticked value that is not a filename
+            if not t.endswith(".json"):
+                seed = t
+                break
+        date = None
+        for c in cells:
+            d = ISO_DATE.search(c)
+            if d:
+                date = d.group(1)
+                break
+        by = None
+        for c in cells:
+            if c and c not in ("-", "—") and len(c) < 24 and c.isalpha():
+                by = c
+                break
+        rows[epoch] = {"seed": None if unfilled else seed, "blessed": not unfilled,
+                       "blessed_utc": date, "by": by, "unfilled": unfilled}
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=str(REPO_ROOT))
+    args = ap.parse_args()
+    root = Path(args.root)
+
+    P_LADDER = root / "public" / "data" / "ladder-epochs.json"
+    P_WEEKLY = root / "public" / "leaderboard" / "data" / "weekly" / "current.json"
+    P_PUB = root / "public" / "leaderboard" / "data" / "published-board.json"
+    P_TARGETS = root / "public" / "leaderboard" / "data" / "board-probe-targets.json"
+    P_LEDGER = root / "docs" / "LEAGUE_SEED_LEDGER.md"
+
+    print("Blessing consistency -- do the four artefacts agree?")
+    print("=" * 74)
+
+    ladder = load_json(P_LADDER)
+    weekly = load_json(P_WEEKLY)
+    published = load_json(P_PUB)
+    targets = load_json(P_TARGETS) or {}
+    ledger = parse_ledger(P_LEDGER)
+
+    missing = [n for n, v in (("ladder-epochs.json", ladder),
+                              ("weekly/current.json", weekly),
+                              ("published-board.json", published),
+                              ("LEAGUE_SEED_LEDGER.md", ledger)) if v is None]
+    if missing:
+        print("  CANNOT TELL: could not read %s." % ", ".join(missing))
+        print("  A missing artefact is UNKNOWN, never agreement.")
+        return 2
+
+    # Which epoch is current? board-probe-targets.json is the site's declaration,
+    # and check-epoch-drift.py separately proves it against what the game ships --
+    # so this check does not need to re-derive it and must not guess it.
+    epoch = ((targets.get("current_ladder_epoch") or {}).get("value"))
+    if not epoch:
+        print("  CANNOT TELL: board-probe-targets.json declares no current epoch,")
+        print("  so there is no epoch to check agreement about.")
+        return 2
+    print("  current epoch (declared)   %s" % epoch)
+
+    findings = []
+
+    # ---- 1. the human record -------------------------------------------------
+    row = (ledger or {}).get(epoch)
+    if row is None:
+        findings.append("LEDGER has NO ROW for %s. The blessing is not recorded "
+                        "where a human would look for it." % epoch)
+        led_seed, led_blessed = None, False
+    else:
+        led_seed, led_blessed = row["seed"], row["blessed"]
+        if row["unfilled"]:
+            findings.append("LEDGER row for %s reads NOT YET BLESSED." % epoch)
+        print("  ledger row                 seed=%s blessed=%s by=%s on=%s"
+              % (led_seed, led_blessed, row["by"], row["blessed_utc"]))
+
+    # ---- 2. the machine-read field ------------------------------------------
+    reg = (ladder or {}).get("regularised_from") or {}
+    lad_seed = reg.get("seed")
+    lad_blessed = (reg.get("seed_status") == "blessed")
+    lad_epoch = reg.get("ladder_version")
+    print("  ladder-epochs.json         seed=%s status=%s epoch=%s"
+          % (lad_seed, reg.get("seed_status"), lad_epoch))
+
+    # The same file's epochs[] array is a SECOND record inside ONE artefact, and
+    # on 2026-08-10 it contradicted regularised_from. An artefact that disagrees
+    # with itself cannot be used to check the others.
+    for e in (ladder.get("epochs") or []):
+        if e.get("ladder_version") == lad_epoch:
+            if (e.get("seed") or None) != (lad_seed or None):
+                findings.append(
+                    "ladder-epochs.json CONTRADICTS ITSELF for %s: regularised_from "
+                    "says seed %r, epochs[] says %r."
+                    % (lad_epoch, lad_seed, e.get("seed")))
+            if lad_blessed and e.get("status") == "opening":
+                findings.append(
+                    "ladder-epochs.json CONTRADICTS ITSELF for %s: regularised_from "
+                    "says blessed, epochs[] still says status 'opening'." % lad_epoch)
+
+    # ---- 3. the derived file -------------------------------------------------
+    wk_seed = weekly.get("seed")
+    wk_blessed = bool((weekly.get("seed_provenance") or {}).get("blessed"))
+    wk_epoch = ((weekly.get("meta") or {}).get("ladder_version")
+                or (weekly.get("epoch") or {}).get("ladder_version"))
+    print("  weekly/current.json        seed=%s blessed=%s epoch=%s"
+          % (wk_seed, wk_blessed, wk_epoch))
+
+    # ---- 4. the observation (KEY ONLY -- never blessed-status) ---------------
+    pub_seed = published.get("seed")
+    pub_epoch = published.get("ladder_epoch")
+    print("  published-board.json       seed=%s epoch=%s   (observation; its "
+          "blessed:false is CORRECT)" % (pub_seed, pub_epoch))
+    print("-" * 74)
+
+    # ---- comparisons ---------------------------------------------------------
+    if lad_epoch and lad_epoch != epoch:
+        findings.append("ladder-epochs.json describes %s as the frontier, but the "
+                        "declared current epoch is %s." % (lad_epoch, epoch))
+    if wk_epoch and wk_epoch != epoch:
+        findings.append("weekly/current.json is stamped %s, but the declared "
+                        "current epoch is %s -- the league page derives from this."
+                        % (wk_epoch, epoch))
+    if pub_epoch and pub_epoch != epoch:
+        findings.append("published-board.json serves %s while %s is declared "
+                        "current." % (pub_epoch, epoch))
+
+    if led_blessed != lad_blessed:
+        findings.append(
+            "BLESSED-STATUS SPLIT for %s: the ledger says %s, ladder-epochs.json "
+            "says %s. This is the 2026-08-09 defect exactly -- the machine knew "
+            "and the document lied." % (epoch, led_blessed, lad_blessed))
+    if wk_blessed and not led_blessed:
+        findings.append(
+            "weekly/current.json claims blessed:true for a seed the ledger has not "
+            "blessed -- and it cites the ledger as its authority while "
+            "contradicting it.")
+
+    seeds = {"ledger": led_seed, "ladder-epochs": lad_seed, "weekly": wk_seed}
+    named = {k: v for k, v in seeds.items() if v}
+    if len(set(named.values())) > 1:
+        findings.append("SEED DISAGREEMENT: %s." % ", ".join(
+            "%s=%s" % (k, v) for k, v in sorted(named.items())))
+
+    if not findings:
+        print()
+        print("  OK: ledger, ladder-epochs.json and weekly/current.json agree about")
+        print("  %s, and published-board.json serves the same key." % epoch)
+        return 0
+
+    print()
+    print("  !! THE BLESSING RECORD DISAGREES WITH ITSELF -- %d finding(s)"
+          % len(findings))
+    for f in findings:
+        print("     - %s" % f)
+    print()
+    print("     A blessing is ONE decision written to FOUR places by hand. Nothing")
+    print("     until now checked they matched, and on 2026-08-09 they did not.")
+    print()
+    print("     THIS SCRIPT WILL NOT FILL A LEDGER ROW. That row records WHO")
+    print("     blessed and WHEN; a seat inferring it is how #297 started.")
+    print("     See docs/LEAGUE_SEED_LEDGER.md 'How to add a row' and #297.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-blessing-consistency.py
+++ b/scripts/test-blessing-consistency.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Forced-state tests for scripts/check-blessing-consistency.py.
+
+Every case builds a whole fixture tree in a temp dir and runs the real script
+against it with --root. Nothing reads or writes the repo's own artefacts, so the
+tests keep passing after Pip fills the ledger rows -- a test that only passes
+while the repo is broken is worse than no test.
+
+THE CASE THAT MATTERS MOST is test 2: the 2026-08-09 defect reproduced with its
+real values. ladder-epochs.json says blessed, the ledger row says NOT YET BLESSED,
+and weekly/current.json claims blessed:true while citing the ledger. That is the
+state that made this seat tell Pip his epoch was unblessed when it was not.
+
+Run:  python scripts/test-blessing-consistency.py     (exit 0 = pass)
+"""
+
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        try:
+            if _s is sys.stdout:
+                sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+        except Exception:
+            pass
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-blessing-consistency.py"
+failures = []
+
+
+def check(cond, msg):
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+LEDGER_HEAD = (
+    "# League seed ledger\n\n"
+    "| epoch | seed | ladder | board file | blessed (UTC) | by | notes |\n"
+    "|---|---|---|---|---|---|---|\n"
+)
+
+
+def build(tmp, epoch, ledger_rows, ladder, weekly, published):
+    r = Path(tmp)
+    (r / "public" / "data").mkdir(parents=True, exist_ok=True)
+    (r / "public" / "leaderboard" / "data" / "weekly").mkdir(parents=True, exist_ok=True)
+    (r / "docs").mkdir(parents=True, exist_ok=True)
+    (r / "public" / "data" / "ladder-epochs.json").write_text(
+        json.dumps(ladder), encoding="utf-8")
+    (r / "public" / "leaderboard" / "data" / "weekly" / "current.json").write_text(
+        json.dumps(weekly), encoding="utf-8")
+    (r / "public" / "leaderboard" / "data" / "published-board.json").write_text(
+        json.dumps(published), encoding="utf-8")
+    (r / "public" / "leaderboard" / "data" / "board-probe-targets.json").write_text(
+        json.dumps({"current_ladder_epoch": {"value": epoch, "source": "fixture"}}),
+        encoding="utf-8")
+    (r / "docs" / "LEAGUE_SEED_LEDGER.md").write_text(
+        LEDGER_HEAD + "".join(ledger_rows), encoding="utf-8")
+    return r
+
+
+def run(root):
+    p = subprocess.run([sys.executable, str(SCRIPT), "--root", str(root)],
+                       capture_output=True, text=True, encoding="utf-8")
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+def blessed_row(epoch, seed, date="2026-08-08", by="Pip"):
+    return ("| %s | `%s` | %s | `board_%s__%s.json` | %s | %s | notes |\n"
+            % (epoch, seed, epoch, seed, epoch, date, by))
+
+
+def unfilled_row(epoch):
+    return ("| **%s** | NOT YET BLESSED | %s | `board_<seed>__%s.json` | "
+            "- | - | PENDING -- a human must fill this row. |\n" % (epoch, epoch, epoch))
+
+
+def ladder_of(epoch, seed, status="blessed", epochs=None):
+    return {"regularised_from": {"seed": seed, "seed_status": status,
+                                 "ladder_version": epoch},
+            "epochs": epochs if epochs is not None
+                      else [{"ladder_version": epoch, "status": "current", "seed": seed}]}
+
+
+def weekly_of(epoch, seed, blessed):
+    return {"seed": seed, "seed_provenance": {"blessed": blessed},
+            "meta": {"ladder_version": epoch}}
+
+
+def pub_of(epoch, seed):
+    # blessed:false is CORRECT here and every fixture keeps it that way.
+    return {"seed": seed, "ladder_epoch": epoch,
+            "seed_provenance": {"blessed": False}}
+
+
+tmp = Path(tempfile.mkdtemp())
+
+print("\n1. All four agree -> exit 0")
+r = build(tmp / "a", "L4", [blessed_row("L4", "weekly-2026-w32")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 0, "exit 0 when they agree (got %s)" % code)
+check("OK:" in out, "says so plainly")
+check("blessed:false is CORRECT" in out,
+      "states that the observation's blessed:false is correct, so nobody 'fixes' it")
+
+print("\n2. THE 2026-08-09 DEFECT, real values: machine says blessed, document does not")
+r = build(tmp / "b", "L3", [unfilled_row("L3")],
+          ladder_of("L3", "weekly-2026-w31"),
+          weekly_of("L3", "weekly-2026-w31", True),
+          pub_of("L3", "weekly-2026-w31"))
+code, out = run(r)
+check(code == 1, "exit 1 (got %s)" % code)
+check("BLESSED-STATUS SPLIT" in out, "names the split explicitly")
+check("the machine knew and the document lied" in out,
+      "uses the words that make the failure recognisable next time")
+check("cites the ledger as its authority while" in out,
+      "catches weekly/current.json citing a document it contradicts")
+
+print("\n3. A file that disagrees WITH ITSELF is caught")
+r = build(tmp / "c", "L3", [blessed_row("L3", "weekly-2026-w31")],
+          ladder_of("L3", "weekly-2026-w31",
+                    epochs=[{"ladder_version": "L3", "status": "opening", "seed": None}]),
+          weekly_of("L3", "weekly-2026-w31", True),
+          pub_of("L3", "weekly-2026-w31"))
+code, out = run(r)
+check(code == 1, "exit 1 (got %s)" % code)
+check(out.count("CONTRADICTS ITSELF") >= 2,
+      "catches BOTH internal contradictions -- the seed and the status")
+
+print("\n4. No ledger row at all for the current epoch")
+r = build(tmp / "d", "L4", [blessed_row("L3", "weekly-2026-w31")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 1, "exit 1 (got %s)" % code)
+check("NO ROW for L4" in out, "says which epoch is unrecorded")
+
+print("\n5. Seed disagreement between the human record and the machine field")
+r = build(tmp / "e", "L4", [blessed_row("L4", "weekly-2026-w32")],
+          ladder_of("L4", "weekly-2026-w99"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 1, "exit 1 (got %s)" % code)
+check("SEED DISAGREEMENT" in out, "names it and lists each source's value")
+
+print("\n6. published-board.json's blessed:false is NEVER counted as disagreement")
+r = build(tmp / "f", "L4", [blessed_row("L4", "weekly-2026-w32")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 0,
+      "an observation that correctly records blessed:false does not fail the check")
+
+print("\n7. A missing artefact is UNKNOWN, never agreement")
+r = build(tmp / "g", "L4", [blessed_row("L4", "weekly-2026-w32")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+(r / "public" / "data" / "ladder-epochs.json").unlink()
+code, out = run(r)
+check(code == 2, "exit 2, not 0 and not 1 (got %s)" % code)
+check("never agreement" in out, "says absence is not agreement")
+
+print("\n8. No declared epoch -> cannot tell, and it is not a disagreement")
+r = build(tmp / "h", None, [blessed_row("L4", "weekly-2026-w32")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 2, "exit 2 (got %s)" % code)
+check("no current epoch" in out, "explains there is nothing to compare about")
+
+print("\n9. It never claims to be able to fix the ledger")
+r = build(tmp / "i", "L4", [unfilled_row("L4")],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check("WILL NOT FILL A LEDGER ROW" in out,
+      "says out loud that filling the row is a human's act, not a seat's")
+
+shutil.rmtree(tmp, ignore_errors=True)
+
+print()
+if failures:
+    print("%d FAILURE(S)" % len(failures))
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("OK: agreement passes, every disagreement shape is caught, an observation's "
+      "blessed:false is not a defect, and absence is unknown.")


### PR DESCRIPTION
Implements the `--check` that #297 says is needed under **either** blessing model.

## What it catches

A blessing is **one decision written to four places by hand**, and nothing checked they matched. On 2026-08-09 they didn't:

- `ladder-epochs.json` → `seed_status: blessed`
- `LEAGUE_SEED_LEDGER.md` L3 row → **NOT YET BLESSED**
- `weekly/current.json` → `blessed: true`, **citing the ledger as its authority while contradicting it**

Five or six of seven checklist steps had run. The one that hadn't was the human-readable one — so **the machine knew and the document lied**, and I told Pip his epoch was unblessed when he was right.

## Roles, encoded rather than remembered

These are **not four copies of one fact**, and treating them as interchangeable is how the last fix went wrong:

| artefact | role |
|---|---|
| `LEAGUE_SEED_LEDGER.md` | the human record — authoritative for **who** and **when** |
| `ladder-epochs.json` | the machine-read field; must match the ledger |
| `weekly/current.json` | derived by the manager; must never lead |
| `published-board.json` | **an observation** — compared on the key only |

**`published-board.json`'s `blessed: false` is correct and is never counted as disagreement.** The publisher writes it deliberately; "fixing" it would be a lie. Test 6 pins that.

## Seven real findings today — including one nobody had noticed

```
LEDGER has NO ROW for L4
ladder-epochs.json CONTRADICTS ITSELF for L3: regularised_from says seed
  'weekly-2026-w31', epochs[] says None
ladder-epochs.json CONTRADICTS ITSELF for L3: regularised_from says blessed,
  epochs[] still says status 'opening'
ladder-epochs.json describes L3 as the frontier, declared current is L4
weekly/current.json is stamped L3 -- the league page derives from this
BLESSED-STATUS SPLIT for L4
weekly/current.json claims blessed:true for a seed the ledger has not blessed
```

**The self-contradiction inside `ladder-epochs.json` was not in #297** and I hadn't spotted it before writing this.

## Why ADVISORY, and when to promote it

Every finding is true, so blocking would be defensible — except **the fix is two ledger rows only Pip may write.** They record who blessed a seed and when, and a seat inferring that *is* the defect. Blocking on a condition no seat is permitted to clear is a permanent red, which CLAUDE.md forbids with double force.

**The promotion condition is written into the workflow beside the step:** promote to blocking once #297's L3 and L4 rows are filled. If it's still advisory in a month, question that rather than the finding.

## Tests

Nine forced states against **fixture trees**, so they keep passing after the ledger is fixed — a test that only passes while the repo is broken is worse than no test. Includes the 2026-08-09 defect reproduced with its **real values**, both self-contradiction shapes, a missing artefact (`unknown`, exit 2, never agreement), and an assertion that the script says out loud it will not fill a ledger row.