### PR TITLE
fix(parsers): harden the two real findings from the delimiter sweep

### DIFF
--- a/scripts/check-blessing-consistency.py
+++ b/scripts/check-blessing-consistency.py
@@ -112,13 +112,29 @@ def parse_ledger(path):
         epoch, rest = m.group(1), m.group(2)
         cells = [c.strip() for c in rest.split("|")]
         unfilled = bool(UNBLESSED_RE.search(rest))
-        ticked = BACKTICKED.findall(rest)
-        seed = None
-        for t in ticked:
-            # the seed cell is the first backticked value that is not a filename
-            if not t.endswith(".json"):
-                seed = t
-                break
+
+        # THE SEED COMES FROM ITS OWN CELL, and from nowhere else.
+        #
+        # This used to take "the first backticked value in the row that is not a
+        # filename", which reads sensibly and is wrong: a row whose seed cell is
+        # EMPTY adopts the first backtick anywhere in the row, including a
+        # documentation path in the notes column --
+        #
+        #   | L9 |  | L9 |  | - | - | see `docs/THING.md` for the seed |
+        #        -> seed == 'docs/THING.md'
+        #
+        # which would present a doc path as a blessed league seed. Found by
+        # attacking the parser (the 2026-08-11 sweep), not by reading it. It was
+        # harmless only because the live unfilled row is flagged separately and
+        # nulls the seed before this runs -- an accident, not a guard.
+        #
+        # Cell 0 is the seed column: ROW_RE has already consumed the epoch cell,
+        # so `rest` begins at the seed. Refuse rather than guess when it is empty.
+        seed_cell = cells[0] if cells else ""
+        ticked = BACKTICKED.findall(seed_cell)
+        seed = ticked[0] if ticked else (seed_cell or None)
+        if seed and (seed.endswith(".json") or UNBLESSED_RE.search(seed)):
+            seed = None
         date = None
         for c in cells:
             d = ISO_DATE.search(c)
@@ -188,6 +204,16 @@ def main():
         led_seed, led_blessed = row["seed"], row["blessed"]
         if row["unfilled"]:
             findings.append("LEDGER row for %s reads NOT YET BLESSED." % epoch)
+        elif not led_seed:
+            # Surfaced by the 2026-08-11 sweep's own regression test: a row that
+            # claims a blessing while naming no seed used to pass silently,
+            # because the old parser filled the gap from elsewhere in the row.
+            # With the seed read from its own cell the gap is now visible, and a
+            # blessing of nothing is exactly what this check exists to catch.
+            findings.append(
+                "LEDGER row for %s records a blessing but NAMES NO SEED. A blessing "
+                "is a sign-off on a specific string; without one there is nothing "
+                "for the other artefacts to agree with." % epoch)
         print("  ledger row                 seed=%s blessed=%s by=%s on=%s"
               % (led_seed, led_blessed, row["by"], row["blessed_utc"]))
 

--- a/scripts/generate-metabolism.py
+++ b/scripts/generate-metabolism.py
@@ -1477,6 +1477,20 @@ def build():
     })
 
 
+
+def _diff_is_only_anchors(current, fresh):
+    """True when the ONLY differences are file:line anchors in citation links.
+
+    Citations render as ...blob/main/<path>#L<n>. When something is inserted above
+    a cited line every anchor below it shifts, and the page is 'stale' without a
+    single fact having changed. Normalising the anchors away tells the two
+    incidents apart; it is deliberately conservative -- anything else differing
+    means CONTENT, and the caller says so.
+    """
+    anchor = re.compile(r"#L\d+")
+    return anchor.sub("#L0", current) == anchor.sub("#L0", fresh)
+
+
 def main():
     ap = argparse.ArgumentParser(
         description=__doc__,
@@ -1497,11 +1511,29 @@ def main():
                   "scripts/generate-metabolism.py"
                   % OUT.relative_to(REPO_ROOT).as_posix())
             return 1
-        if OUT.read_text(encoding="utf-8") != page:
-            print("STALE: %s no longer matches what its sources produce.\n"
-                  "A cadence, a cron, a park notice or a cited line has moved. "
-                  "Regenerate:\n    python scripts/generate-metabolism.py"
-                  % OUT.relative_to(REPO_ROOT).as_posix())
+        current = OUT.read_text(encoding="utf-8")
+        if current != page:
+            # WHICH CLASS OF STALE? These are different incidents that printed the
+            # same words, and twice in four days someone (me) spent twenty minutes
+            # hunting a cadence change that had never happened. A citation is a
+            # file:line ANCHOR, so it moves whenever anything above it moves --
+            # the fact is identical and only its coordinates changed. Say so.
+            only_anchors = _diff_is_only_anchors(current, page)
+            if only_anchors:
+                print("STALE (COORDINATES ONLY): %s cites its sources by file:line, "
+                      "and a cited line has MOVED.\n"
+                      "  NO cadence, cron or park notice changed -- something was "
+                      "inserted above a citation.\n"
+                      "  This is expected after editing any cited file. Regenerate:\n"
+                      "    python scripts/generate-metabolism.py"
+                      % OUT.relative_to(REPO_ROOT).as_posix())
+            else:
+                print("STALE (CONTENT): %s no longer matches what its sources "
+                      "produce.\n"
+                      "  A cadence, a cron or a park notice has genuinely CHANGED -- "
+                      "read the diff before regenerating.\n"
+                      "  Regenerate:\n    python scripts/generate-metabolism.py"
+                      % OUT.relative_to(REPO_ROOT).as_posix())
             return 1
         print("OK: /metabolism/ is in step with its sources.")
         return 0

--- a/scripts/sync/sync-keybinds.py
+++ b/scripts/sync/sync-keybinds.py
@@ -373,7 +373,20 @@ def check_no_hardcoded_keys(committed, problems, notes):
     actions = {b["action"] for b in committed.get("keybinds", [])}
     # A <kbd> may carry data-keybind="<known action>" and must be empty or hold
     # only the ellipsis placeholder that JS overwrites.
-    kbd_re = re.compile(r"<kbd\b(?P<attrs>[^>]*)>(?P<inner>.*?)</kbd>", re.DOTALL | re.IGNORECASE)
+    # The attribute run allows a quoted value to contain '>', because per the HTML
+    # spec a '>' inside a quoted attribute value does NOT close the tag. The naive
+    # [^>]* stops there and hands back a truncated action name --
+    #
+    #   <kbd data-keybind="move>right">X</kbd>
+    #      attrs -> ' data-keybind="move'   inner -> 'right">X'
+    #
+    # which would look up a key that does not exist and leave the placeholder
+    # standing, sending a player to a key that does nothing. That is the exact
+    # outcome this whole mirror exists to prevent, reached by a second route.
+    # Found by attacking the parser, 2026-08-11 sweep, probe 3.
+    kbd_re = re.compile(
+        r'<kbd\b(?P<attrs>(?:"[^"]*"|\'[^\']*\'|[^>"\'])*)>(?P<inner>.*?)</kbd>',
+        re.DOTALL | re.IGNORECASE)
     attr_re = re.compile(r'data-keybind\s*=\s*"(?P<action>[^"]+)"')
     # Only RENDERED markup counts. Style and script blocks legitimately mention
     # <kbd> in comments (this file's own convention is documented there), and

--- a/scripts/test-blessing-consistency.py
+++ b/scripts/test-blessing-consistency.py
@@ -187,6 +187,32 @@ code, out = run(r)
 check(code == 2, "exit 2 (got %s)" % code)
 check("no current epoch" in out, "explains there is nothing to compare about")
 
+print("\n10. THE SWEEP BUG: an empty seed cell must not adopt a backtick from the notes")
+# 2026-08-11 sweep, probe 2. This row's seed cell is EMPTY and its NOTES carry a
+# backticked documentation path. The old parser took "the first backticked value in
+# the row that is not a filename" and would present docs/THING.md as a league seed.
+r = build(tmp / "j", "L9",
+          ["| L9 |  | L9 |  | - | - | see `docs/THING.md` for the seed |\n"],
+          ladder_of("L9", "weekly-2026-w99"),
+          weekly_of("L9", "weekly-2026-w99", True),
+          pub_of("L9", "weekly-2026-w99"))
+code, out = run(r)
+check("docs/THING.md" not in out,
+      "a documentation path from the NOTES column is never read as a seed")
+check(code == 1, "and the row still reports a disagreement rather than passing quietly")
+
+print("\n11. A pipe inside a later cell must not move the seed")
+# The row parser splits on '|', so a pipe in the notes shifts every later cell.
+# The seed must still come from its own cell rather than from a shifted position.
+r = build(tmp / "k", "L4",
+          ["| L4 | `weekly-2026-w32` | L4 | `b.json` | 2026-08-08 | Pip | uses `a|b` |\n"],
+          ladder_of("L4", "weekly-2026-w32"),
+          weekly_of("L4", "weekly-2026-w32", True),
+          pub_of("L4", "weekly-2026-w32"))
+code, out = run(r)
+check(code == 0,
+      "a pipe in a notes cell shifts later cells but must not move the seed (got %s)" % code)
+
 print("\n9. It never claims to be able to fix the ledger")
 r = build(tmp / "i", "L4", [unfilled_row("L4")],
           ladder_of("L4", "weekly-2026-w32"),


### PR DESCRIPTION
Follow-through on the 2026-08-11 sweep, which attacked four parsers with adversarial input. **Two were genuinely broken. One was fine and I was wrong about it.**

## 1. The seed comes from its own cell — real, mine, shipped in #301

It took *"the first backticked value in the row that is not a filename"*. Reads sensibly; wrong:

```
| L9 |  | L9 |  | - | - | see `docs/THING.md` for the seed |
       ->  seed extracted: 'docs/THING.md'
```

**A documentation path presented as a blessed league seed.** Harmless today only because the live unfilled row is flagged separately and nulls the seed first — an accident, not a guard. That is the defect class that once stranded 23 submissions.

Two regression tests, and **the second one found a further gap on its own**: a ledger row that claims a blessing while naming **no seed** used to pass silently. It now reports — a blessing is a sign-off on a specific string, and without one there is nothing for the other artefacts to agree with.

## 2. A `>` inside a quoted attribute does not close a tag

`sync-keybinds` used `[^>]*` for the attribute run, which stops at the first `>` regardless of quoting:

```
<kbd data-keybind="move>right">X</kbd>
   attrs -> ' data-keybind="move'    inner -> 'right">X'
```

It would look up a truncated action, fail to substitute, and leave the placeholder standing — **sending a player to a key that does nothing, which is the exact outcome this mirror exists to prevent.** Verified against both quote styles and normal input; the real check still passes.

## 3. Metabolism now says *which* class of stale

The page cites sources by `file:line`, so inserting anything above a citation moves the anchor **without any fact changing**. That printed the same words as a genuine cadence change, and it cost me twenty minutes twice in four days.

- **STALE (COORDINATES ONLY)** — a cited line moved, nothing changed, regenerate
- **STALE (CONTENT)** — a cadence genuinely changed, **read the diff first**

## Probe 4 is WITHDRAWN and deliberately not actioned

I claimed the `<script>` stripper ended early at a `</script>` inside a JS string and silently lost coverage. **Checked against a real HTML parser: it does not.** Per spec that sequence genuinely terminates the element — which is why you write `<\/script>` in JS. The regex matches browser behaviour and my "false negative" reasoning was backwards; ending early scans *more*.

Three probes were attacks. The fourth was an argument — and it was the one I called *"the most interesting"*. Correction is in `coordination`'s pack plus a printed addendum.

## Verified

`test-blessing-consistency` (11 states) · `generate-metabolism --check` · `sync-keybinds --ci` · `check-encoding-safety` · `test-epoch-drift` — all green.