### PR TITLE
fix(analytics): Linux download event no longer names an unpublished asset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1760,7 +1760,7 @@ t	.hero {
 			const TARGETS = [
 				{ id: 'download-windows', platform: 'Windows', file: 'PDoom-Windows.zip' },
 				{ id: 'download-macos',   platform: 'macOS',   file: 'PDoom.app.zip' },
-				{ id: 'download-linux',   platform: 'Linux',   file: 'PDoom.x86_64' }
+				{ id: 'download-linux',   platform: 'Linux',   file: 'PDoom-Linux.zip' }
 			];
 
 			TARGETS.forEach(function(target) {


### PR DESCRIPTION
## What this fixes, precisely

Related to PipFoweraker/pdoom1#1068 ("The site's Linux download button 404s (PDoom.x86_64 is not a release asset)").

`public/index.html`'s `setupDownloadTracking()` had a `TARGETS` array used to build the Plausible `Download` event's `file` prop:

```js
{ id: 'download-linux', platform: 'Linux', file: 'PDoom.x86_64' }
```

**Verified against the live v0.14.1 release assets** (`gh release view v0.14.1 --repo PipFoweraker/pdoom1 --json assets`): `PDoom-Windows.zip`, `PDoom.app.zip`, and `PDoom-Linux.zip` all exist as real, downloadable assets. `PDoom.x86_64` does not — it's the executable packed *inside* the Linux zip, not a published release asset, and `curl`-ing its would-be direct URL confirms a 404.

## Important scope correction from my investigation

Before editing, I traced how `TARGETS` is actually used, since #1068's cited line/behavior didn't match what's currently in `public/index.html`. Two things worth being explicit about:

1. **The Linux button's actual click-through `href` is not sourced from `TARGETS` at all.** It starts as the release-page baseline (`.../releases/latest`) and is upgraded at page load by `resolveDownloads()`, which fetches the live release's real asset list from the GitHub API and regex-matches each platform's actual filename. That mechanism (added in commit `493fac55`, well before #1068 was filed) already handles arbitrary/versioned asset names correctly — for v0.14.1 it resolves the Linux button to the real `PDoom-Linux-v0.14.1.zip` asset, a working link.
2. **`TARGETS` is consumed only by the Plausible analytics `file` prop** (see `setupDownloadTracking()`), fired on click. So the practical effect of the stale `PDoom.x86_64` value was silently wrong analytics data — every Linux download to date was logged under a filename that was never published — not a dead link for visitors clicking the button today.

I'm not certain whether #1068 was observing an older deploy or reasoning from a static grep of the file without accounting for `resolveDownloads()`'s dynamic override. Either way, this PR fixes the one real, currently-live defect I could confirm: the Linux entry now matches the stable unversioned asset name (`PDoom-Linux.zip`), the same pattern Windows and macOS already use, so the analytics `file` prop reflects a real, resolvable asset.

**Windows and macOS entries were already correct and are untouched by this change.**

## Diff

One line changed in `public/index.html`:
```diff
- { id: 'download-linux',   platform: 'Linux',   file: 'PDoom.x86_64' }
+ { id: 'download-linux',   platform: 'Linux',   file: 'PDoom-Linux.zip' }
```

## Test plan

- [x] `gh release view v0.14.1 --repo PipFoweraker/pdoom1 --json assets` confirms `PDoom-Windows.zip`, `PDoom.app.zip`, `PDoom-Linux.zip` all exist as real assets.
- [x] Confirmed `scripts/test-download-resolution.js` (the CI check covering download-button behavior, wired into `content-honesty.yml`) only exercises `resolveDownloads()`, not the `TARGETS` array touched here — this change is outside that test's surface, and I could not run it locally (no `node`/`npm` in this environment) but read it in full to confirm non-interference.
- [x] Grepped `scripts/check-stale-facts.py` and `scripts/check-platform-claims.py` for any reference to `TARGETS`/`x86_64`/`file:` — none found, so no other guard is affected.
- [ ] Pip to verify in the Netlify deploy preview and confirm intended scope (analytics-accuracy fix, not a click-through fix, since the click-through was already working).

**Do not merge — flagging for Pip's review per standing instruction on anything touching the public site.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>