### PR TITLE
fix(site): unhide first-run guidance; stop claiming open source on /press/

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -894,29 +894,73 @@ t	.hero {
 				</a>
 			</div>
 
-			<!-- Shown by resolveDownloads() only when a macOS build actually resolved.
-			     An unsigned/un-notarised Godot .app is refused by Gatekeeper on first
-			     open with "the developer cannot be verified", which reads as a broken
-			     download; most testers bounce silently rather than report it.
+			<!-- FIRST-RUN GUIDANCE. Wording is taken verbatim from the pdoom1 release
+			     body (v0.14.1, "Before you download: your OS will warn you"), which is
+			     the reviewed source for this text. Do not paraphrase it here; if it
+			     needs to change, change it in the release notes and copy it back.
 
-			     CORRECTED 2026-07-29. This note used to say "right-click and choose
-			     Open". Apple REMOVED that bypass in macOS Sequoia (15.x): on current
-			     macOS the context menu offers only Cancel / Move to Trash, so the old
-			     instruction failed in exactly the way it was written to prevent. It
-			     cost us a real playtest -- the first backer of the Manifund round
-			     followed it on 15.5, hit the dead end, and gave up. Verify against
-			     Apple's developer note before editing again; do not restore the
-			     Control-click wording as the primary path.
-			     The real fix is notarisation (Apple Developer Program), which is a
-			     budget line, not a copy change. -->
-			<p id="macos-gatekeeper-note" style="display: none; text-align: center; margin: 0 auto 0.6rem; max-width: 46rem; font-size: 0.8rem; color: var(--text-secondary); line-height: 1.5;">
-				<strong>On macOS:</strong> the first launch is blocked because the build isn't
-				Apple-notarised yet. On macOS&nbsp;15 (Sequoia) and later, open
-				<strong>System&nbsp;Settings → Privacy&nbsp;&amp;&nbsp;Security</strong>, scroll to
-				<strong>Security</strong>, and choose <strong>Open&nbsp;Anyway</strong> — you may need your
-				admin password. On macOS&nbsp;14 and earlier, right-click (or Control-click) the app
-				and choose <strong>Open</strong>. Either way you only need to do it once.
-			</p>
+			     WHY IT IS ALWAYS VISIBLE (2026-08-10). This used to be a macOS-only
+			     paragraph shipping with `display: none`, unhidden by resolveDownloads()
+			     only after the GitHub API confirmed a macOS asset. Two failures came out
+			     of that: (a) resolveDownloads() rewrites every button's href to the
+			     direct .zip, so clicking downloads ~100 MB and NEVER lands on the release
+			     page where this guidance lives -- pdoom1.com was the only place a visitor
+			     could have read it, and it was hidden; (b) on a GitHub rate-limit the
+			     buttons keep working and the site's ONLY warning vanished. A safety note
+			     must not be conditional on an API call succeeding. It is static markup
+			     now and no script touches it.
+
+			     CORRECTED 2026-07-29, STILL LOAD-BEARING. This note used to say
+			     "right-click and choose Open" as the primary macOS path. Apple REMOVED
+			     that bypass in macOS Sequoia (15.x): on current macOS the context menu
+			     offers only Cancel / Move to Trash, so the old instruction failed in
+			     exactly the way it was written to prevent. It cost us a real playtest --
+			     the first backer of the Manifund round followed it on 15.5, hit the dead
+			     end, and gave up. Verify against Apple's developer note before editing
+			     again; do not restore the Control-click wording as the primary path.
+
+			     CORRECTED 2026-08-10. The Sequoia path was missing its FIRST step. "Open
+			     Anyway" does not exist in Privacy & Security until the app has been
+			     double-clicked once and refused -- macOS writes the entry in response to
+			     the refusal. A reader following the old text found an empty Security
+			     section and concluded the instructions were wrong.
+
+			     The real fix for macOS is notarisation (Apple Developer Program), which
+			     is a budget line, not a copy change. -->
+			<div id="first-run-note" style="text-align: left; margin: 0 auto 0.8rem; max-width: 46rem; font-size: 0.8rem; color: var(--text-secondary); line-height: 1.55; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: var(--radius-md); padding: 0.8rem 1rem;">
+				<p style="margin: 0 0 0.5rem;">
+					<strong>Before you download: your OS will warn you, and that is expected.</strong>
+					These builds are <strong>unsigned</strong>. Signing means buying a code-signing
+					certificate (Windows) or an Apple Developer identity plus notarization (macOS).
+					p(Doom)1 is an alpha made by one person and has not bought either yet, so every
+					operating system reports that it cannot verify who made the program. The warnings
+					mean &ldquo;we cannot check the publisher&rdquo;, not &ldquo;this is malware&rdquo;.
+				</p>
+				<p style="margin: 0 0 0.5rem;">
+					<strong>Extract the whole zip to a folder before running the game.</strong>
+					Running it from inside the zip viewer hides <code>PDoom.pck</code>, and the game
+					will not start. That is the single most common problem people hit.
+				</p>
+				<p style="margin: 0 0 0.5rem;">
+					<strong>Windows &mdash; SmartScreen.</strong> You will see a blue
+					&ldquo;Windows protected your PC&rdquo; box, often naming an unknown / untrusted
+					publisher. Click <strong>More info</strong> (the small link under the message),
+					then <strong>Run anyway</strong>.
+				</p>
+				<p style="margin: 0 0 0.5rem;">
+					<strong>macOS &mdash; Gatekeeper.</strong> First launch is blocked. On
+					macOS&nbsp;15 (Sequoia) and later, <strong>double-click the app once and dismiss
+					the warning</strong> &mdash; that refusal is what puts the option there &mdash;
+					then go to <strong>System&nbsp;Settings → Privacy&nbsp;&amp;&nbsp;Security</strong>
+					and click <strong>Open&nbsp;Anyway</strong>. On macOS&nbsp;14 and earlier you can
+					right-click (or Control-click) the app and choose <strong>Open</strong>. Full steps
+					are in <code>HOW-TO-RUN.txt</code> inside the zip.
+				</p>
+				<p style="margin: 0;">
+					<strong>Linux.</strong> You may need to set the executable bit:
+					<code>chmod +x PDoom.x86_64</code>.
+				</p>
+			</div>
 
 			<div style="text-align: center; margin-bottom: 0.8rem;">
 				<a href="https://github.com/PipFoweraker/pdoom1" style="color: var(--accent-secondary); text-decoration: none; font-size: 0.9rem;">
@@ -1660,12 +1704,10 @@ t	.hero {
 					if (asset) markAvailable(el, asset.browser_download_url);
 					else markUnavailable(el);
 				}
-				// Show the macOS first-run note only when a macOS build actually resolved.
-				const macNote = document.getElementById('macos-gatekeeper-note');
-				if (macNote) {
-					const macEl = document.getElementById('download-macos');
-					macNote.style.display = (macEl && macEl.hasAttribute('href')) ? 'block' : 'none';
-				}
+				// DELIBERATELY does not touch #first-run-note. That note used to be
+				// unhidden here, which made the site's only unsigned-binary warning
+				// conditional on this fetch succeeding -- on a rate-limit the buttons
+				// still worked and the warning disappeared. It is static markup now.
 			} catch (_) { /* keep baseline */ }
 		}
 

--- a/public/press/index.html
+++ b/public/press/index.html
@@ -408,7 +408,7 @@
 				</div>
 				<div class="factsheet-item">
 					<strong>Price:</strong>
-					Free, open source, non-commercial
+					Free, source-available, non-commercial
 				</div>
 				<div class="factsheet-item">
 					<!-- DERIVED. Version and date are read at runtime from
@@ -459,7 +459,7 @@
 				<li>Institutional strategy: headcount, budget, compute and reputation as the actual verbs</li>
 				<li>A published, moving p(doom) estimate you can argue with rather than a score you can only accept</li>
 				<li>Deterministic seeds &mdash; everyone playing a given week's seed gets the same world, so two players' decisions are directly comparable</li>
-				<li>Open source, in public, with the design decisions written down as they are made</li>
+				<li>Source-available, in public, with the design decisions written down as they are made</li>
 				<li>Rough edges, honestly labelled &mdash; this is an early alpha and the site says so everywhere</li>
 			</ul>
 		</section>
@@ -522,7 +522,7 @@
 			<p style="text-align: center; color: var(--text-muted); font-size: 0.9rem; margin: 0 auto 1.5rem;">
 				<!-- DERIVED: platform names come from version.json, never from prose here. -->
 				Builds attached to the latest release: <span class="derived" id="download-platforms">&mdash;</span>.
-				Free and open source &mdash; no store account needed.
+				Free and source-available &mdash; no store account needed.
 			</p>
 
 			<!-- Steam badge - Valve compliant -->

--- a/scripts/test-download-resolution.js
+++ b/scripts/test-download-resolution.js
@@ -4,6 +4,12 @@
 //   - a platform WITHOUT one degrades to "coming soon" instead of a dead link
 //   - an unreachable / unrecognised API degrades NOTHING -- every button keeps the
 //     release-page baseline rather than being falsely disabled.
+//   - the first-run note (unsigned binaries / extract the zip / SmartScreen / chmod)
+//     is STATIC: visible in the shipped HTML and never touched by this function.
+//     It used to be `display: none` until resolveDownloads() unhid it, so a GitHub
+//     rate-limit left working download buttons and no warning at all. Since the
+//     buttons resolve to a direct .zip, the release page carrying this guidance is
+//     never visited -- pdoom1.com is the only place a visitor can read it.
 //
 // NOTE: all three buttons ship LIVE in the HTML (href = release page, "Download
 // for <OS>"). That is copy-pass's launch shape: v0.13.1 ships Windows, macOS AND
@@ -41,7 +47,12 @@ async function run(name, assets, { ok = true } = {}) {
     'download-windows': makeEl('download-windows', 'Windows'),
     'download-macos': makeEl('download-macos', 'macOS'),
     'download-linux': makeEl('download-linux', 'Linux'),
-    'macos-gatekeeper-note': { id: 'note', style: { display: 'none' } },
+    // Present in the DOM so a regression that re-adds display juggling is caught
+    // by the "untouched" assertions below rather than by a null-guard silently
+    // skipping. `style` starts empty, exactly as static markup with no inline
+    // display would behave.
+    'first-run-note': { id: 'first-run-note', style: {} },
+    'macos-gatekeeper-note': { id: 'macos-gatekeeper-note', style: {} },
   };
   const document = { getElementById: (id) => els[id] || null };
   const fetch = async () => ({ ok, json: async () => ({ assets }) });
@@ -50,6 +61,13 @@ async function run(name, assets, { ok = true } = {}) {
   const fn = new Function('document', 'fetch', 'return ' + m[0])(document, fetch);
   await fn();
   return els;
+}
+
+// resolveDownloads() must not set `display` on either note id -- the current one or
+// the retired one, so re-adding the old id does not quietly restore the old bug.
+function noteUntouched(els) {
+  return ['first-run-note', 'macos-gatekeeper-note']
+    .every((id) => els[id].style.display === undefined);
 }
 
 (async () => {
@@ -69,7 +87,7 @@ async function run(name, assets, { ok = true } = {}) {
   check(els['download-macos'].href === 'https://gh/PDoom-macOS-v0.13.1.zip', 'macOS -> direct asset');
   check(els['download-linux'].href === 'https://gh/PDoom-Linux-v0.13.1.zip', 'Linux -> direct asset');
   check(els['download-macos'].textContent === 'Download for macOS', 'macOS -> live label kept');
-  check(els['macos-gatekeeper-note'].style.display === 'block', 'Gatekeeper note shown (mac resolved)');
+  check(noteUntouched(els), 'First-run note untouched (mac resolved)');
 
   // Scenario 2: a future release that dropped macOS + Linux, Windows only.
   els = await run('win only', [A('PDoom-Windows-v0.13.1.zip')]);
@@ -79,7 +97,9 @@ async function run(name, assets, { ok = true } = {}) {
   check(/coming soon/i.test(els['download-macos'].textContent), 'macOS -> says "coming soon"');
   check(!els['download-linux'].hasAttribute('href'), 'Linux -> no href (not a dead link)');
   check(/coming soon/i.test(els['download-linux'].textContent), 'Linux -> says "coming soon"');
-  check(els['macos-gatekeeper-note'].style.display === 'none', 'Gatekeeper note hidden (no mac build)');
+  // The note must survive a DROPPED macOS build too: it is a three-OS note now,
+  // and hiding it would take the Windows and Linux guidance down with it.
+  check(noteUntouched(els), 'First-run note untouched (no mac build)');
 
   // Scenario 3: API unreachable -- change nothing. Every button keeps its live
   // release-page baseline (we cannot know what shipped, so never degrade).
@@ -95,6 +115,33 @@ async function run(name, assets, { ok = true } = {}) {
   check(els['download-windows'].href === BASE, 'Windows keeps baseline');
   check(els['download-macos'].href === BASE, 'macOS keeps baseline');
   check(els['download-linux'].href === BASE, 'Linux keeps baseline');
+
+  // Scenario 5: the SHIPPED markup, not the shim. The note has to be readable with
+  // JS off and on a rate-limited API, so it is asserted against index.html directly.
+  console.log('Scenario 5: first-run note is static, visible, and covers all three OSes');
+  const noteTag = src.match(/<div id="first-run-note"[^>]*>/);
+  check(!!noteTag, 'note element exists in index.html');
+  if (noteTag) {
+    check(!/display\s*:\s*none/i.test(noteTag[0]), 'note does not ship hidden');
+  }
+  const noteBody = src.match(/<div id="first-run-note"[\s\S]*?\n\t\t\t<\/div>/);
+  check(!!noteBody, 'note block is parseable');
+  if (noteBody) {
+    const body = noteBody[0];
+    // One assertion per fact the release notes say a first-run visitor needs. The
+    // buttons download a .zip directly, so if a fact is not here it is nowhere.
+    for (const [label, rx] of [
+      ['says the builds are unsigned', /unsigned/i],
+      ['tells you to extract the zip first', /extract the whole zip/i],
+      ['names the Windows SmartScreen dialog', /Windows protected your PC/i],
+      ['gives the SmartScreen escape', /More info[\s\S]{0,120}Run anyway/i],
+      ['tells Sequoia users to double-click FIRST', /double-click the app once[\s\S]{0,200}Privacy/i],
+      ['names Open Anyway', /Open&nbsp;Anyway/],
+      ['gives the Linux chmod', /chmod \+x/],
+    ]) check(rx.test(body), 'note ' + label);
+  }
+  check(!/getElementById\(['"]macos-gatekeeper-note['"]\)/.test(src),
+    'no JS still reaches for the retired macos-gatekeeper-note id');
 
   console.log(failures ? `\n${failures} FAILURE(S)` : '\nAll checks passed.');
   process.exit(failures ? 1 : 0);


### PR DESCRIPTION
**Do not merge — Pip reviews anything touching the public site.**

Two honesty fixes on the pages a first-time visitor reads. Both are grounded in copy that already existed and had already been reviewed; no new marketing prose was invented.

## 1. The site contradicted itself about being open source

`public/index.html:1226` already rules on this, deliberately:

> Free: yes, completely, and that is not going to change during alpha. Open source: **not yet, and it would be wrong to say otherwise**. The source is public on GitHub and you are welcome to read it, evaluate it and contribute to it — but the current interim licence does not grant redistribution, and the art and game content are expected to stay all-rights-reserved.

`public/press/index.html` said the opposite in **three** places:

| line | before | after |
|---|---|---|
| 411 | Factsheet → Price: "Free, open source, non-commercial" | "Free, source-available, non-commercial" |
| 462 | Key features bullet: "Open source, in public, …" | "Source-available, in public, …" |
| 525 | Download blurb: "Free and open source — no store account needed." | "Free and source-available — no store account needed." |

Line 462 was not in the original report; it turned up in the sweep. A press page is the copy most likely to be quoted verbatim by someone else, which makes it the worst place for that claim to survive.

`index.html:1226` is **untouched**. It is the correct statement and everything else now matches it.

### Everything else the sweep found, and why it was left alone

- `public/about/index.html:465, 510` — already honest ("Not open source yet"; "Source-available rather than open source for now").
- `public/about/index.html:534`, `public/privacy/index.html:373–396` — Godot and Plausible, third-party projects that genuinely are open source.
- `public/blog/2025-10-09-architecture-revolution-monolith-to-modular.md:204, 208, 245` — a dated dev post about the refactoring *tooling*, not the game licence. Historical, and out of scope for a copy change tonight. **Flagging it rather than editing it** — worth a call.
- `public/events/arxiv_*.html`, `public/data/events.json`, `public/data/version.json` — third-party abstracts and a mirrored release body ("opensource doom streams" is a game mechanic).

One more, **not fixable on this branch**: the unmerged branch `fix/linux-download-asset-name` carries `public/blog/2026-08-07-v0-14-0-the-ladder-forks.md`, whose footer reads *"p(Doom)1 is free, open source and non-commercial."* That file does not exist on `main`, so it cannot be fixed here. It needs the same one-word change before that branch merges.

## 2. The unsigned-binary guidance was unreachable

`resolveDownloads()` rewrites every download button's `href` to the direct `.zip` asset URL. A click therefore pulls 94–124 MB and **never loads the GitHub release page** — which is where all the correct first-run guidance lives. Net effect: nothing on pdoom1.com told a Windows user about SmartScreen, told anyone to extract the zip before running, or told a Linux user about `chmod +x`.

The one note we did have was macOS-only, shipped `style="display: none"`, and was unhidden only after the GitHub API confirmed a macOS asset:

```js
macNote.style.display = (macEl && macEl.hasAttribute('href')) ? 'block' : 'none';
```

So on a GitHub rate-limit the buttons kept working and the site's only warning disappeared. **A safety note must not be conditional on an API call succeeding.**

### What changed

- The note is now a **static three-OS block** directly under the download button row (`public/index.html:930`), visible by default, renamed `#first-run-note`.
- Wording is **verbatim from the v0.14.1 release body** (`gh release view v0.14.1 --repo PipFoweraker/pdoom1`, section "Before you download: your OS will warn you"): unsigned builds and what the warning means; extract the whole zip first (the release notes call this "the single most common problem people hit"); Windows SmartScreen → More info → Run anyway; macOS Gatekeeper; Linux `chmod +x PDoom.x86_64`.
- `resolveDownloads()` no longer touches it. The display-toggling block is replaced by a comment recording why.

### Accuracy bug fixed in the same note

The old macOS text sent readers straight to **System Settings → Privacy & Security**. On Sequoia, **"Open Anyway" is not there yet** — macOS writes that entry in response to a refused launch. A reader following the old text found an empty Security section and reasonably concluded the instructions were broken. The first step is now stated: double-click the app once and dismiss the warning, *then* go to Privacy & Security.

The 2026-07-29 ruling is preserved intact: Control-click remains the **macOS 14-and-earlier** path only and is never presented as the primary one. That comment block was not weakened — it was extended with the new correction alongside it.

### Test contract

`scripts/test-download-resolution.js` is updated to match, and now asserts the properties that were missing when the bug shipped:

- the note is **untouched** by `resolveDownloads()` in every scenario — including the dropped-macOS-build case, where hiding it would take the Windows and Linux guidance down with it;
- it does **not** ship hidden, asserted against `public/index.html` itself rather than the DOM shim, because it has to survive JS-off and a rate-limited API;
- it carries **each fact** the release notes say a first-run visitor needs, one assertion per fact — the buttons download a `.zip` directly, so a fact that is not here is nowhere;
- no JS still reaches for the retired `macos-gatekeeper-note` id, so re-adding that element cannot quietly restore the old behaviour.

## Checks run

All green:

```
check-platform-claims.py        test-platform-claims.py
check-stale-facts.py --min-severity HIGH   (250 findings, 0 HIGH)
check-encoding-safety.py        check-published-emails.py
check-deploy-excludes.py        check-control-characters.py (no findings in changed files)
test-design-notes.py            validate_data.py
test_ingest_scores.py           test-sync-events.py
test-sync-events-pii.py         test-update-version-info.py
test-health-check.py            test-snapshot-plausible.py
test-changelog-structure.py     test-blessing-consistency.py
generate-feeds.py --check       make-og-card.py --check
generate-metabolism.py --check
```

`snapshot-copy.py --check` shows exactly the intended prose diffs and nothing else.

Two advisories are red and both are **pre-existing and unrelated** to this branch: `check-blessing-consistency.py` (the league seed ledger disagrees with `weekly/current.json`) and `check-token-drift.py` (45 files with stale token values, mostly generated `public/events/*.html`).

**Caveat: there is no `node` binary on this machine**, so the `.js` half of the suite could not be run locally. Every regex in the new scenario 5 was verified against `public/index.html` with the equivalent Python patterns, and the `resolveDownloads()` extraction regex still matches after the edit — but CI is the first real run of `test-download-resolution.js`. Please confirm it green before merging.

Also worth a look on the Netlify preview: the note is a bordered box under the buttons, so it changes the visual weight of the hero above the fold.
