### PR TITLE
content(blog): 1,313 tests passed and the game had no buttons

### DIFF
--- a/public/blog/2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md
+++ b/public/blog/2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md
@@ -39,10 +39,11 @@ gitignored, and belongs to one checkout. A refactor earlier in the week added
 a new class, `Capacity`. The agent that wrote it worked in a separate
 worktree, which built its own fresh cache and saw all 1,313 tests pass —
 honestly. The shared checkout only *pulled*, so its cache predated the new
-file, and every script that referenced `Capacity` failed to compile: 30 parse
-errors, 17 dependent-script failures, cascading through the autoloads that
-build the UI and start the game. The windowed run swallowed all of it; the
-errors only surfaced in a headless run.
+file, and every script that referenced `Capacity` failed to compile,
+cascading through the autoloads that build the UI and start the game.
+Reconstructing that exact cache afterwards on a scratch copy: 30 parse
+errors, 17 dependent-script failures. The windowed run swallowed all of it;
+the errors only surfaced in a headless run.
 
 The fix is one command and takes seconds. Diagnosis took the evening. The
 full symptom record is
@@ -95,9 +96,10 @@ minutes of play (a legible first screen, and rejections that actually reach
 the player instead of a hidden feed). Honest caveats: a lab name is typed,
 not an identity, so this is not established to be the same person, and it is
 not a controlled comparison. It is evidence of headroom, and I will take it.
-Monday's 44 has a distinction the number does not show: it was the first
-score submitted to the global board by someone who is not me, which is worth
-more than any check I can run against my own API.
+Monday's 44 has a distinction the number does not show: a run submitted by
+someone who is not me, accepted by the live board — the first external
+evidence the whole pipeline works end to end, which is worth more than any
+check I can run against my own API.
 
 **Every refusal in the game got audited.** 144 distinct player-facing refusal
 strings, each traced to the code behind it: 106 are real rules, correctly

--- a/public/blog/2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md
+++ b/public/blog/2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md
@@ -1,0 +1,130 @@
+---
+title: "1,313 tests passed and the game had no buttons"
+date: "2026-08-15"
+tags: ["playtest", "testing", "process", "dev-notes"]
+summary: "On Thursday a first-time player sat down, the game drew its art and a doom percentage, and offered nothing to click. 1,313 tests were green. The cause is a per-checkout cache that CI can never see go stale, because CI always starts clean. The guard shipped Friday afternoon; the identical failure shape was back within hours - and this time it was caught."
+commit: ""
+---
+# 1,313 tests passed and the game had no buttons
+
+**2026-08-15**
+
+On Thursday evening a friend sat down in front of p(Doom)1 for a playtest —
+a first-time player, at the machine, with me narrating over their shoulder.
+
+The game launched. It drew the background art, including the cat. The doom
+readout said 58.5%. The research-quality selector worked — rushed, standard,
+thorough, all clickable. And that was the whole game. No action icons. No
+upgrades. No music. No way to commit a month. The phase label said *starting
+up* and never said anything else.
+
+No crash. No dialog. No red text anywhere. From my own narration on the
+capture, as it happened:
+
+> "all my icons have disappeared. And all my upgrades have disappeared, and I
+> can't commit the month, and the music track seems not to be working, and
+> also, there's no active game, so I don't think the game's actually
+> initialized"
+
+It looked exactly like a game that had not finished loading. Anyone would
+wait. We waited. That is the trap: enough of the screen survives that the
+screen stays plausible.
+
+Meanwhile, 1,313 tests were passing.
+
+## What broke
+
+Godot resolves every `class_name` through a cache file that is generated,
+gitignored, and belongs to one checkout. A refactor earlier in the week added
+a new class, `Capacity`. The agent that wrote it worked in a separate
+worktree, which built its own fresh cache and saw all 1,313 tests pass —
+honestly. The shared checkout only *pulled*, so its cache predated the new
+file, and every script that referenced `Capacity` failed to compile: 30 parse
+errors, 17 dependent-script failures, cascading through the autoloads that
+build the UI and start the game. The windowed run swallowed all of it; the
+errors only surfaced in a headless run.
+
+The fix is one command and takes seconds. Diagnosis took the evening. The
+full symptom record is
+[pdoom1#1215](https://github.com/PipFoweraker/pdoom1/issues/1215).
+
+## The interesting part is not the bug
+
+The interesting part is that CI structurally cannot catch it. CI clones fresh
+every run, so it always generates a correct cache. Only a long-lived working
+copy can hold a stale one. This is a whole class of failure that is invisible
+to every check that starts clean — and most checks start clean. Green CI here
+was not lying; it was answering a question nobody was asking.
+
+So the guard that came out of this
+([pdoom1#1216](https://github.com/PipFoweraker/pdoom1/pull/1216)) does not
+live in CI. It lives on the launch path: a ~30ms check, before the game
+starts, that every declared class actually resolves in *this* checkout's
+cache, with the repair built in. The only job CI has is proving the detector
+itself still detects — there is a test that reconstructs Thursday's exact
+cache and asserts the check goes red on it.
+
+## The sting in the tail
+
+The guard merged on Friday at 16:53.
+
+At 18:22 the same day — about ninety minutes later — a different piece of
+work merged
+([pdoom1#1222](https://github.com/PipFoweraker/pdoom1/pull/1222)), written in
+its own worktree, tests green. It adds a new class: `class_name Refusal`. The
+identical shape.
+
+Dated observation, per house rules: on Saturday morning I ran the guard on
+the shared checkout and it said
+
+```
+STALE CLASS CACHE -- this checkout will run the WRONG code, silently.
+    MISSING   Refusal    res://scripts/core/refusal.gd
+```
+
+exit code 1. The failure that cost Thursday's playtest came back within
+hours of the guard shipping, and this time it costs one command before the
+next launch instead of an evening. I do not think I have ever had a guard
+pay for itself faster.
+
+## The rest of the week, briefly
+
+**The board moved.** The public leaderboard shows the same lab name at 44 on
+Monday and 87 on Wednesday — and in between, fixes landed on the first five
+minutes of play (a legible first screen, and rejections that actually reach
+the player instead of a hidden feed). Honest caveats: a lab name is typed,
+not an identity, so this is not established to be the same person, and it is
+not a controlled comparison. It is evidence of headroom, and I will take it.
+Monday's 44 has a distinction the number does not show: it was the first
+score submitted to the global board by someone who is not me, which is worth
+more than any check I can run against my own API.
+
+**Every refusal in the game got audited.** 144 distinct player-facing refusal
+strings, each traced to the code behind it: 106 are real rules, correctly
+stated. 29 refuse because the feature is unbuilt, 8 give a reason that is not
+the actual reason, and 1 could not be determined from the code at all. The
+game is mostly honest, and now the dishonest ones are being marked: a stub
+must say it is a stub, because a stub that refuses in the voice of a rule
+teaches the player a rule that does not exist.
+
+**Playing the game found an exploit.** Nine leftover doom literals in the
+runtime event options, measured at −6 doom per turn at the shipped event cap
+— enough to drive doom from 50 to the 0.0 floor in about eight turns and pin
+it there. In a game whose whole premise is that there is no victory
+condition, only buying time, that is not a balance issue, it is a thesis
+issue. Measured and written up in
+[pdoom1#1232](https://github.com/PipFoweraker/pdoom1/issues/1232); the fix is
+in review.
+
+**Nine PRs merged on Friday** across the game and this site, including
+everything above that says "merged".
+
+None of this is me telling you the game is good. It is me telling you the
+alpha is honest about being one — including about the evening it shipped
+1,313 passing tests and no buttons.
+
+---
+
+*p(Doom)1 is free, source-available and non-commercial. If something in the
+game confuses you, that is the most useful thing you can tell us — the bug
+tracker is the front door.*

--- a/public/blog/atom.xml
+++ b/public/blog/atom.xml
@@ -4,8 +4,19 @@
   <link href="https://pdoom1.com/blog/" />
   <link href="https://pdoom1.com/blog/atom.xml" rel="self" />
   <id>urn:pdoom1:blog</id>
-  <updated>2026-08-07T12:00:00Z</updated>
+  <updated>2026-08-15T12:00:00Z</updated>
   <subtitle>Development notes from p(Doom)1 - a satirical strategy game about managing an AI safety lab.</subtitle>
+  <entry>
+    <title>1,313 tests passed and the game had no buttons</title>
+    <link href="https://pdoom1.com/blog/post.html?p=2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md" />
+    <id>urn:pdoom1:blog:2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md</id>
+    <updated>2026-08-15T12:00:00Z</updated>
+    <summary>On Thursday a first-time player sat down, the game drew its art and a doom percentage, and offered nothing to click. 1,313 tests were green. The cause is a per-checkout cache that CI can never see go stale, because CI always starts clean. The guard shipped Friday afternoon; the identical failure shape was back within hours - and this time it was caught.</summary>
+    <category term="playtest" />
+    <category term="testing" />
+    <category term="process" />
+    <category term="dev-notes" />
+  </entry>
   <entry>
     <title>v0.14.0: the ladder forks, and your old scores stay where they are</title>
     <link href="https://pdoom1.com/blog/post.html?p=2026-08-07-v0-14-0-the-ladder-forks.md" />

--- a/public/blog/feed.xml
+++ b/public/blog/feed.xml
@@ -5,8 +5,19 @@
     <link>https://pdoom1.com/blog/</link>
     <description>Development notes from p(Doom)1 - a satirical strategy game about managing an AI safety lab.</description>
     <language>en-AU</language>
-    <lastBuildDate>Fri, 07 Aug 2026 12:00:00 +0000</lastBuildDate>
+    <lastBuildDate>Sat, 15 Aug 2026 12:00:00 +0000</lastBuildDate>
     <atom:link href="https://pdoom1.com/blog/feed.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>1,313 tests passed and the game had no buttons</title>
+      <link>https://pdoom1.com/blog/post.html?p=2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md</link>
+      <guid isPermaLink="false">pdoom1-blog-2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md</guid>
+      <pubDate>Sat, 15 Aug 2026 12:00:00 +0000</pubDate>
+      <description>On Thursday a first-time player sat down, the game drew its art and a doom percentage, and offered nothing to click. 1,313 tests were green. The cause is a per-checkout cache that CI can never see go stale, because CI always starts clean. The guard shipped Friday afternoon; the identical failure shape was back within hours - and this time it was caught.</description>
+      <category>playtest</category>
+      <category>testing</category>
+      <category>process</category>
+      <category>dev-notes</category>
+    </item>
     <item>
       <title>v0.14.0: the ladder forks, and your old scores stay where they are</title>
       <link>https://pdoom1.com/blog/post.html?p=2026-08-07-v0-14-0-the-ladder-forks.md</link>

--- a/public/blog/index.json
+++ b/public/blog/index.json
@@ -1,6 +1,20 @@
 {
   "posts": [
     {
+      "filename": "2026-08-15-1313-tests-passed-and-the-game-had-no-buttons.md",
+      "title": "1,313 tests passed and the game had no buttons",
+      "date": "2026-08-15",
+      "tags": [
+        "playtest",
+        "testing",
+        "process",
+        "dev-notes"
+      ],
+      "summary": "On Thursday a first-time player sat down, the game drew its art and a doom percentage, and offered nothing to click. 1,313 tests were green. The cause is a per-checkout cache that CI can never see go stale, because CI always starts clean. The guard shipped Friday afternoon; the identical failure shape was back within hours - and this time it was caught.",
+      "commit": "",
+      "featured": false
+    },
+    {
       "filename": "2026-08-07-v0-14-0-the-ladder-forks.md",
       "title": "v0.14.0: the ladder forks, and your old scores stay where they are",
       "date": "2026-08-07",


### PR DESCRIPTION
## What this is

The dev-blog post for the week of 10-15 August. One story carries it: the stale
class-name cache that cost Thursday's first-time playtest
([pdoom1#1215](https://github.com/PipFoweraker/pdoom1/issues/1215)), why CI
structurally cannot catch that class of failure, and the guard
([pdoom1#1216](https://github.com/PipFoweraker/pdoom1/pull/1216)) whose target
failure shape recurred within ninety minutes of it merging.

## Every claim is sourced

- **The incident, symptoms, quotes, 1,313 tests, 58.5% doom readout** -- pdoom1#1215 and the guard's own docstring (`tools/check_class_cache.py`). Quotes are verbatim from the capture transcript quoted in #1215.
- **"Guard caught the identical shape"** -- written as a **dated Saturday-morning observation**: I ran `python3 tools/check_class_cache.py` on the shared checkout at `/home/pip/Repos/pdoom1` and it reported `MISSING Refusal`, exit 1 (the cache there predates #1222's merge). If someone runs `--repair` before you read this, the post is still true -- it reports the observation with its date.
- **44 -> 87** -- hedged exactly as `coordination/LEDGER_EVIDENCE_2026-08-14_L3-and-L4.md` hedges it: same lab name two days apart, NOT established as the same player, not a controlled comparison. "First external score" framing is from `PLAYTEST_2026-08-10`.
- **Refusal audit** -- pdoom1#1222's real split: 106 RULE / 29 STUB / 8 WRONG / 1 UNCLEAR of 144. (The figure "38 stubs" circulating in memos is the non-RULE remainder, not the stub count -- corrected here.)
- **Doom-sink exploit** -- pdoom1#1232, measured numbers only; fix (#1233) described as **in review**, not fixed.
- **Nine PRs merged Friday** -- counted via `gh pr list` over the local-Hobart Friday window: pdoom1 5 (#1207, #1216, #1217, #1220, #1222) + pdoom1-website 4 (#315, #284, #319, #320). The "eleven open PRs to zero" line from the week's chatter did NOT survive verification (new PRs opened Friday evening) and is not in the post.
- Licence wording: **source-available**, per this week's four-place correction.
- Playtester referred to only as "a friend". No names other than Pip's.

## Deviations from the brief I was handed

- The playtest was **Thursday 2026-08-13**, not Wednesday (capture `2026-08-13_214820`, #1215, #1216). The post says Thursday.
- Audit split corrected as above.

## Generated files

`index.json`, `feed.xml`, `atom.xml` regenerated by `build-blog-index.py` and `generate-feeds.py`; both `--check` modes green locally, `check-stale-facts.py --min-severity HIGH` green. `test-blog-render.js` runs in CI (no node on this box); `build-blog-index.py` already validated the post against the renderer's markdown subset.

**Do not merge -- for Pip's review of the copy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)