### PR TITLE
Revert the mailto mitigation - the form authenticates now, and the banners are telling visitors otherwise

### DIFF
--- a/public/assets/js/navigation.js
+++ b/public/assets/js/navigation.js
@@ -34,32 +34,14 @@
 				<li role="none" class="dropdown">
 					<a href="#" role="menuitem" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle">Community ▾</a>
 					<ul class="dropdown-menu" role="menu">
-						<!-- TEMPORARY, 2026-08-15. This pointed at /bug-report/, and the
-						     comment here said that was "the ONLY zero-account path on the
-						     site that actually delivers". That became false and nobody
-						     noticed, which is why it is being written down rather than
-						     quietly edited.
-
-						     /bug-report/ POSTs to bug-submit.php, which calls PHP mail()
-						     on DreamHost. pdoom1.com has NEVER published an SPF record and
-						     its MX is Google, so Google sees its own hosted domain arriving
-						     unauthorised from a DreamHost IP and does not deliver. mail()
-						     returns true regardless, and the 200 the visitor sees is
-						     generated before delivery is even attempted -- so the form
-						     shows "Report Submitted!" and the message is gone. Measured
-						     2026-08-14: a probe returned {"ok":true} and had not arrived
-						     34 minutes later. pdoom1-website#321.
-
-						     mailto: is UNAFFECTED. A visitor's own mail client sends from
-						     their provider to Google's MX and never touches DreamHost. So
-						     the nav points at the address, which works, instead of the
-						     form, which does not.
-
-						     REVERT THIS once the SPF record is live AND a probe has been
-						     confirmed arriving in the inbox -- not merely once the DNS has
-						     been edited. Handover:
-						     coordination/HANDOVER_2026-08-15_pdoom1-mail-transmission.md -->
-						<li role="none"><a href="mailto:team@pdoom1.com?subject=p(Doom)1%20feedback" role="menuitem">Contact / Feedback</a></li>
+						<!-- /bug-report/ is the ONLY zero-account path on the site that
+						     actually delivers: it POSTs to bug-submit.php, which emails
+						     team@pdoom1.com. It was linked from nowhere in the nav until
+						     2026-08-11, so the one working contact route was unreachable
+						     unless you already knew the URL. Labelled for a general
+						     visitor, not "Report a Bug" -- most first-stranger contact is
+						     not a bug report, and a bug-only label turns them away. -->
+						<li role="none"><a href="/bug-report/" role="menuitem">Contact / Feedback</a></li>
 						<li role="none"><a href="/issues/" role="menuitem">Issues & Feedback</a></li>
 						<li role="none"><a href="/blog/" role="menuitem">Dev Blog</a></li>
 						<li role="none"><a href="/game-changelog/" role="menuitem">Updates</a></li>

--- a/public/bug-report/index.html
+++ b/public/bug-report/index.html
@@ -295,26 +295,6 @@
 
 	<main id="main-content" role="main">
 		<h1>Report a Bug</h1>
-		<!-- TEMPORARY 2026-08-15, pdoom1-website#321. The form below POSTs to
-		     bug-submit.php, which uses PHP mail() on DreamHost. pdoom1.com has
-		     never published an SPF record and its MX is Google, so Google will
-		     not deliver mail claiming to be from its own hosted domain arriving
-		     from a DreamHost IP. mail() returns true anyway and the success
-		     message is shown before delivery is attempted. Email is unaffected
-		     -- a visitor's own client never touches DreamHost.
-		     REMOVE once SPF is live AND a probe has been confirmed IN THE INBOX. -->
-		<div style="border-left: 4px solid #c98a00; background: rgba(201,138,0,0.09);
-		            padding: 0.9rem 1.1rem; margin: 0 0 1.4rem 0; border-radius: 4px;">
-			<strong>Email us directly &mdash; it is the reliable route right now.</strong>
-			<p style="margin: 0.5rem 0 0 0;">
-				We are fixing a mail-delivery fault that can stop this form reaching us.
-				Until it is confirmed fixed, please write to
-				<a href="mailto:team@pdoom1.com?subject=p(Doom)1%20feedback"><strong>team@pdoom1.com</strong></a>
-				instead. Your own email will arrive normally &mdash; the fault is on our
-				sending side, not yours. Sorry, and thank you for bothering to tell us
-				anything at all.
-			</p>
-		</div>
 		<p class="intro">
 			There are two ways to report: from inside the game, or from the form on this page.
 			No GitHub account is needed for either. The in-game reporter is worth the extra step

--- a/public/cats/index.html
+++ b/public/cats/index.html
@@ -224,7 +224,7 @@
 		<section class="info-section">
 			<h2>Submit your cat</h2>
 			<p style="margin-bottom: 1rem;">We can now turn a photo of a real cat into a pixel office companion &mdash; so we're actually asking: send us your cat. If it makes the cut, it joins the custodians above.</p>
-			<p style="margin-bottom: 1rem;">There's no upload widget here yet, and our web form is currently not delivering reliably (we are fixing it). So the honest path today is email: send the photo to <a href="mailto:team@pdoom1.com?subject=Cat%20submission" style="color: var(--accent-primary);"><strong>team@pdoom1.com</strong></a> with the subject &ldquo;Cat submission&rdquo;. Your own email reaches us normally &mdash; the fault is on our sending side, not yours.</p>
+			<p style="margin-bottom: 1rem;">There's no upload widget here yet. The honest path is our <a href="/bug-report/" style="color: var(--accent-primary);">reporting form</a>: choose <strong>Feature</strong>, title it &ldquo;Cat submission&rdquo;, attach the photo (up to 500&nbsp;KB), and it comes straight through to the team.</p>
 			<p style="color: var(--text-muted); font-size: 0.9rem;">The consent bit, plainly: a photo of your cat is something you're choosing to send us, and the cat may appear publicly in the game. The form's &ldquo;name for credit&rdquo; is opt-in &mdash; fill it in to be credited (you or the cat!), leave it blank to stay anonymous. Your email is used only to reply.</p>
 		</section>
 

--- a/public/issues/index.html
+++ b/public/issues/index.html
@@ -763,7 +763,14 @@
 			}
 
 			if (res && res.ok) {
-				formStatus.textContent = 'Sent — it went straight to the team inbox. Nothing else for you to do.';
+				// SOFTENED 2026-08-17. This said "it went straight to the team inbox.
+				// Nothing else for you to do." Both halves claimed more than a 200 can
+				// support: res.ok means bug-submit.php's mail() returned true, which is
+				// the LOCAL MTA accepting a handoff, not delivery -- and bug-submit.php
+				// writes no submission log, so if it never arrives there is no record
+				// anywhere that the sender existed. /bug-report/ already says this in
+				// its own prose; this page was promising the opposite two screens away.
+				formStatus.textContent = 'Sent to the team inbox. We cannot confirm delivery from our side, so if you do not hear back, the GitHub route below leaves a record we can both see.';
 				formStatus.style.color = 'var(--success-color)';
 				e.target.reset();
 				submitButton.textContent = originalButtonText;

--- a/public/issues/index.html
+++ b/public/issues/index.html
@@ -331,25 +331,6 @@
 				Help us improve p(Doom)1 by reporting bugs, requesting features, or providing feedback
 			</p>
 		</section>
-		<!-- TEMPORARY 2026-08-15, pdoom1-website#321. The form on this page POSTs
-		     to bug-submit.php, which uses PHP mail() on DreamHost. pdoom1.com
-		     publishes no SPF record and its MX is Google, so Google will not
-		     deliver mail claiming to be from its own hosted domain arriving from
-		     a DreamHost IP. mail() returns true anyway and the success message is
-		     shown before delivery is attempted. Email is unaffected: a visitor's
-		     own client never touches DreamHost.
-		     REMOVE once SPF is live AND a probe is confirmed IN THE INBOX. -->
-		<div style="border-left: 4px solid #c98a00; background: rgba(201,138,0,0.09);
-		            padding: 0.9rem 1.1rem; margin: 0 0 1.4rem 0; border-radius: 4px;">
-			<strong>Email us directly &mdash; it is the reliable route right now.</strong>
-			<p style="margin: 0.5rem 0 0 0;">
-				We are fixing a mail-delivery fault that can stop this form reaching us.
-				Until it is confirmed fixed, please write to
-				<a href="mailto:team@pdoom1.com?subject=p(Doom)1%20feedback"><strong>team@pdoom1.com</strong></a>
-				instead. Your own email will arrive normally &mdash; the fault is on our
-				sending side, not yours.
-			</p>
-		</div>
 
 		<!-- Quick Actions -->
 		<div style="text-align: center; margin-bottom: 2rem;">


### PR DESCRIPTION
**Not auto-merged. Needs Pip's decision** — this changes reader-facing prose on four production surfaces.

Reverts `50227fc0` on the condition that commit set for itself:

> "REVERT ALL FOUR once SPF is live AND a probe is confirmed IN THE INBOX."

Both met, measured rather than assumed.

## The evidence

SPF and DMARC published 2026-08-17, confirmed on all three DreamHost nameservers plus 8.8.8.8, 1.1.1.1 and 9.9.9.9. `06416bf2` gave `bug-submit.php` an aligned envelope sender. A message through the **live** form at 09:13 AEST returned:

```
Return-Path: <team@pdoom1.com>
spf=pass    (designates 208.113.156.243 as permitted sender)
dmarc=pass  (p=NONE sp=NONE dis=NONE) header.from=pdoom1.com
```

Confirmed in the `team@pdoom1.com` inbox with no warning banner. That is the probe `50227fc0` asked for.

## Why this is urgent rather than tidy-up

The mitigation was honest when written. It is now the prime directive inverted — four production surfaces tell a visitor *"we are fixing a mail-delivery fault that can stop this form reaching us"* about a form that delivers and authenticates. Telling someone the working thing is broken is still lying to a visitor, and it steers them off the only zero-account contact path on the site.

| surface | what it currently says |
|---|---|
| `public/bug-report/index.html:298` | "Email us directly — it is the reliable route right now" |
| `public/issues/index.html:334` | same banner |
| `public/cats/index.html:227` | "our web form is currently not delivering reliably" |
| `public/assets/js/navigation.js:37` | nav Contact repointed to `mailto:` — the layout spine, so all 21 delegating pages |

## What is deliberately NOT reverted

`bug-report/index.html`'s caveat that *"the mail step can fail on our side without telling us — we cannot confirm delivery from here."* That predates the mitigation and is **still true**: `bug-submit.php` writes no submission log, so email remains the sole record. Verified present after the revert. The two statements say different things and only one has become false.

## Merge hazard this also closes

`feedback/intake-contract` forked at `04004298`, *before* `50227fc0`. Merging that branch would leave all four banners in place while showing nothing about them in the diff. Landing this first removes the trap.

## Verification after merge

Auto-deploy ~20s, then:

```
curl -s https://pdoom1.com/bug-report/ | grep -c "mail-delivery fault"   # expect 0
curl -s https://pdoom1.com/assets/js/navigation.js | grep -c "mailto:team"  # expect 0
```

A clean `git revert` was possible because nothing has touched these four files since `50227fc0`.
